### PR TITLE
feat: streaks + lightweight gamification

### DIFF
--- a/__e2e__/tests/streaksAndRecap.test.ts
+++ b/__e2e__/tests/streaksAndRecap.test.ts
@@ -1,0 +1,141 @@
+/**
+ * E2E flow specifications for Streaks + Lightweight Gamification (S22).
+ *
+ * The Bluesky e2e harness uses Maestro YAML flows under `__e2e__/flows/`.
+ * The plan binds S22 to a single TypeScript spec file enumerating the six
+ * required user journeys so device-driven authoring (Maestro / Detox) can
+ * follow this contract verbatim. Each `test.todo` carries the precise
+ * navigation, assertions, and persistence expectations derived from the
+ * acceptance criteria.
+ *
+ * The suite is wrapped in `describe.skip` so it stays out of the active
+ * Jest runner (no real device + no XRPC). The tests are intentionally
+ * authored as `.todo` so the e2e team gets a structured to-do list and the
+ * file still compiles + lints inside the unit-test toolchain.
+ *
+ * Coverage: A6, A7, A8, B3, B5, X1, X3.
+ */
+
+import {describe, test} from '@jest/globals'
+
+describe.skip('Streaks + Recap — E2E flows (S22)', () => {
+  /*
+   * Flow 1 — streak-indicator-visibility
+   *
+   * Covers AC: A6 (streak visible in Home header), A7 (hidden when no
+   *            session, hidden when feature flag off).
+   *
+   * Steps (Maestro pseudocode):
+   *   1. Launch app with feature flag ON, no logged-in account.
+   *      → assertNotVisible: testID "streakIndicator".
+   *   2. Sign in as alice.test.
+   *      → assertVisible: testID "streakIndicator" inside the Home header.
+   *      → assertVisible: streak count >= 1 (formatted plural string).
+   *   3. Navigate to /notifications.
+   *      → assertNotVisible: testID "streakIndicator" (only Home tab).
+   *   4. Toggle feature flag OFF (Statsig override panel).
+   *   5. Restart app, sign in.
+   *      → assertNotVisible: testID "streakIndicator".
+   */
+  test.todo('A6/A7: streak indicator visible only with session + flag ON')
+
+  /*
+   * Flow 2 — streak-explainer-open-and-settings-link
+   *
+   * Covers AC: A8 (tapping streak opens explainer dialog with a link to
+   *            "Activity & recap" settings). This flow specifically
+   *            exercises the dialog-close callback footgun (CLAUDE.md):
+   *            the link must navigate AFTER the dialog finishes its close
+   *            animation.
+   *
+   * Steps:
+   *   1. Sign in. Tap testID "streakIndicator".
+   *      → assertVisible: text "Your streak" (dialog title).
+   *      → assertVisible: testID "streakExplainer-settingsLink".
+   *   2. Tap testID "streakExplainer-settingsLink".
+   *      → assertVisible: testID "activityAndRecapSettingsScreen"
+   *        within 1500ms (covers control.close(() => navigate()) delay).
+   *      → assertNotVisible: dialog backdrop.
+   */
+  test.todo('A8: streak explainer dialog → settings link uses close callback')
+
+  /*
+   * Flow 3 — recap-card-tap-opens-recap
+   *
+   * Covers AC: B3 (tapping the WeeklyRecapCard opens the Recap screen
+   *            for the previous ISO week).
+   *
+   * Steps:
+   *   1. Sign in. Stub the recap query to return a week with postsCount=5,
+   *      followerDelta=2, and a topPost candidate.
+   *   2. Navigate to /notifications.
+   *      → assertVisible: testID "weeklyRecapCard".
+   *      → assertVisible: testID "weeklyRecapCard-posts".
+   *   3. tapOn testID "weeklyRecapCard".
+   *      → assertVisible: testID "recapScreen".
+   *      → assertVisible: testID "recapScreen-posts".
+   *      → URL/route should match /recap/<priorWeekIso>.
+   */
+  test.todo(
+    'B3: tapping WeeklyRecapCard navigates to RecapScreen for that week',
+  )
+
+  /*
+   * Flow 4 — recap-card-dismiss-persists
+   *
+   * Covers AC: B5 (dismissing the WeeklyRecapCard hides it for that week
+   *            and the dismissal survives an app restart).
+   *
+   * Steps:
+   *   1. Sign in. Navigate to /notifications.
+   *      → assertVisible: testID "weeklyRecapCard".
+   *   2. tapOn label "Dismiss recap".
+   *      → assertNotVisible: testID "weeklyRecapCard".
+   *   3. Force-quit and relaunch the app. Sign in. Navigate to
+   *      /notifications.
+   *      → assertNotVisible: testID "weeklyRecapCard" (MMKV-backed
+   *        dismissal must persist for the same weekIso).
+   */
+  test.todo('B5: WeeklyRecapCard dismissal persists across app restart')
+
+  /*
+   * Flow 5 — activity-and-recap-settings-roundtrip
+   *
+   * Covers AC: X1 (toggling "Show streak" / "Show weekly recap" in
+   *            Settings → Activity & recap immediately hides the
+   *            indicator and the card respectively, with no app reload).
+   *
+   * Steps:
+   *   1. Sign in. Confirm streak indicator visible on Home.
+   *   2. Navigate to /settings/content-and-media → tap "Activity & recap".
+   *      → assertVisible: testID "activityAndRecapSettingsScreen".
+   *   3. Toggle off "Show streak".
+   *   4. Navigate back to Home.
+   *      → assertNotVisible: testID "streakIndicator".
+   *   5. Navigate to /notifications. Toggle off "Show weekly recap" via
+   *      the same settings screen route.
+   *      → assertNotVisible: testID "weeklyRecapCard".
+   *   6. Toggle both back on.
+   *      → assertVisible: streak indicator AND recap card.
+   */
+  test.todo('X1: Activity & recap settings toggles round-trip without restart')
+
+  /*
+   * Flow 6 — fresh-install-no-nux
+   *
+   * Covers AC: X3 (no first-run NUX, modal, or coachmark for streaks or
+   *            recap on a fresh install — the feature is discoverable but
+   *            not interruptive).
+   *
+   * Steps:
+   *   1. Wipe app data (`clearState`). Launch app fresh.
+   *   2. Complete sign-in.
+   *      → assertNotVisible: any modal/coachmark referencing "streak"
+   *        or "recap" or "Your week on Bluesky" (text + testID variants).
+   *   3. Navigate Home → Notifications → Settings.
+   *      → No interruptive overlay appears at any point.
+   *      → Streak indicator + recap card are passively visible per their
+   *        own visibility rules; no NUX/welcome dialog is presented.
+   */
+  test.todo('X3: fresh install presents no NUX/coachmark for streaks or recap')
+})

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -84,6 +84,7 @@ import {ModerationScreen} from '#/screens/Moderation'
 import {Screen as ModerationVerificationSettings} from '#/screens/Moderation/VerificationSettings'
 import {Screen as ModerationInteractionSettings} from '#/screens/ModerationInteractionSettings'
 import {NotificationsActivityListScreen} from '#/screens/Notifications/ActivityList'
+import {PastRecapsScreen} from '#/screens/PastRecaps'
 import {PostLikedByScreen} from '#/screens/Post/PostLikedBy'
 import {PostQuotesScreen} from '#/screens/Post/PostQuotes'
 import {PostRepostedByScreen} from '#/screens/Post/PostRepostedBy'
@@ -94,11 +95,13 @@ import {ProfileFollowsScreen} from '#/screens/Profile/ProfileFollows'
 import {ProfileLabelerLikedByScreen} from '#/screens/Profile/ProfileLabelerLikedBy'
 import {ProfileSearchScreen} from '#/screens/Profile/ProfileSearch'
 import {ProfileListScreen} from '#/screens/ProfileList'
+import {RecapScreen} from '#/screens/Recap'
 import {SavedFeeds} from '#/screens/SavedFeeds'
 import {SearchScreen} from '#/screens/Search'
 import {AboutSettingsScreen} from '#/screens/Settings/AboutSettings'
 import {AccessibilitySettingsScreen} from '#/screens/Settings/AccessibilitySettings'
 import {AccountSettingsScreen} from '#/screens/Settings/AccountSettings'
+import {ActivityAndRecapSettingsScreen} from '#/screens/Settings/ActivityAndRecap'
 import {ActivityPrivacySettingsScreen} from '#/screens/Settings/ActivityPrivacySettings'
 import {AppearanceSettingsScreen} from '#/screens/Settings/AppearanceSettings'
 import {AppIconSettingsScreen} from '#/screens/Settings/AppIconSettings'
@@ -526,6 +529,30 @@ function commonScreens(Stack: typeof Flat, unreadCountLabel?: string) {
         getComponent={() => ContentAndMediaSettingsScreen}
         options={{
           title: title(msg`Content and Media`),
+          requireAuth: true,
+        }}
+      />
+      <Stack.Screen
+        name="ActivityAndRecap"
+        getComponent={() => ActivityAndRecapSettingsScreen}
+        options={{
+          title: title(msg`Activity & Recap`),
+          requireAuth: true,
+        }}
+      />
+      <Stack.Screen
+        name="Recap"
+        getComponent={() => RecapScreen}
+        options={{
+          title: title(msg`Your week on Bluesky`),
+          requireAuth: true,
+        }}
+      />
+      <Stack.Screen
+        name="PastRecaps"
+        getComponent={() => PastRecapsScreen}
+        options={{
+          title: title(msg`Past recaps`),
           requireAuth: true,
         }}
       />

--- a/src/analytics/features/types.ts
+++ b/src/analytics/features/types.ts
@@ -15,4 +15,7 @@ export enum Features {
   DmsNewMessageComposerEnable = 'dms:new_message_composer:enable',
 
   AATest = 'aa-test',
+
+  // owner: @growth, remove by: 2026-10-01 (post-KPI readout) — ticket i9KLo7kw
+  StreaksAndRecapEnable = 'streaks_and_recap:enable',
 }

--- a/src/analytics/metrics/types.ts
+++ b/src/analytics/metrics/types.ts
@@ -1043,4 +1043,21 @@ export type Events = {
   'profile:associated:germ:click-self-info': {}
   'profile:associated:germ:self-disconnect': {}
   'profile:associated:germ:self-reconnect': {}
+
+  // Activity & Recap (ticket i9KLo7kw) — booleans only (AC-B12).
+  'streak:indicatorShown': {
+    has_streak: boolean
+  }
+  'streak:explainerOpened': {}
+  'streak:optIn': {}
+  'streak:optOut': {}
+  'recap:cardShown': {
+    has_posts: boolean
+    has_top_post: boolean
+    has_follower_delta: boolean
+  }
+  'recap:cardTapped': {}
+  'recap:cardDismissed': {}
+  'recap:optIn': {}
+  'recap:optOut': {}
 }

--- a/src/features/activityAndRecap/__tests__/StreakIndicator.test.tsx
+++ b/src/features/activityAndRecap/__tests__/StreakIndicator.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * StreakIndicator tests (S9).
+ *
+ * Renders the native variant via the testing-library/react-native renderer
+ * with mocked collaborators. Asserts visibility rules (AC-A4/A6/A7/G4)
+ * and zero-footprint behavior when the flag is off (AC-X6).
+ */
+
+import React from 'react'
+import {beforeEach, describe, expect, jest, test} from '@jest/globals'
+import {render} from '@testing-library/react-native'
+
+// Stop the Dialog → bottom-sheet → BottomSheetNativeComponent chain at a
+// stub so the test doesn't try to read Platform.Version from a real
+// native module.
+jest.mock('#/../modules/bottom-sheet', () => ({
+  __esModule: true,
+  BottomSheet: () => null,
+}))
+
+jest.mock('@bsky.app/react-native-mmkv', () => ({
+  MMKV: class MMKVMock {
+    _store = new Map<string, string>()
+    set(key: string, value: string) {
+      this._store.set(key, value)
+    }
+    getString(key: string) {
+      return this._store.get(key)
+    }
+    delete(key: string) {
+      this._store.delete(key)
+    }
+    addOnValueChangedListener(_cb: (key: string) => void) {
+      return {remove: () => {}}
+    }
+    clearAll() {
+      this._store.clear()
+    }
+  },
+}))
+
+const mockState = {
+  featureOn: true,
+  hasSession: true,
+  did: 'did:plc:me' as string | undefined,
+  showStreak: true,
+  storeReadCount: 0,
+  storeValue: undefined as
+    | undefined
+    | {currentStreak: number; longestStreak: number},
+  dialogOpenCount: 0,
+}
+
+jest.mock(
+  '#/features/activityAndRecap/hooks/useStreaksAndRecapEnabled',
+  () => ({
+    useStreaksAndRecapEnabled: () => mockState.featureOn,
+  }),
+)
+jest.mock('#/features/activityAndRecap/hooks/useShowStreakPreference', () => ({
+  useShowStreakPreference: () => [mockState.showStreak, () => {}],
+}))
+jest.mock('#/features/activityAndRecap/hooks/useStreakStore', () => ({
+  useStreakStore: () => {
+    mockState.storeReadCount += 1
+    return mockState.storeValue
+  },
+}))
+jest.mock('#/state/session', () => ({
+  useSession: () => ({
+    hasSession: mockState.hasSession,
+    currentAccount: mockState.hasSession ? {did: mockState.did} : undefined,
+  }),
+}))
+jest.mock(
+  '#/features/activityAndRecap/components/StreakExplainerDialog',
+  () => ({
+    StreakExplainerDialog: () => null,
+    useStreakExplainerControl: () => ({
+      open: () => {
+        mockState.dialogOpenCount += 1
+      },
+      close: () => {},
+    }),
+  }),
+)
+
+// Lingui needs an i18n context provider; stub the hook so we don't need to
+// mount one. Macros compile to a `{id, message, values}` descriptor.
+jest.mock('@lingui/react', () => {
+  function mockRenderDescriptor(d: any): string {
+    if (typeof d === 'string') return d
+    if (!d) return ''
+    let out: string = d.message ?? d.id ?? ''
+    const values = d.values ?? {}
+    out = out.replace(
+      /\{(\w+),\s*plural,\s*one\s*\{#\s*([^}]+)\}\s*other\s*\{#\s*([^}]+)\}\}/g,
+      (_m: string, key: string, _one: string, other: string) => {
+        const n = values[key]
+        return `${n} ${other}`
+      },
+    )
+    out = out.replace(/\{(\w+)\}/g, (_m: string, key: string) =>
+      values[key] !== undefined ? String(values[key]) : `{${key}}`,
+    )
+    return out
+  }
+  return {
+    useLingui: () => ({_: (d: any) => mockRenderDescriptor(d)}),
+  }
+})
+
+import {StreakIndicator} from '#/features/activityAndRecap/components/StreakIndicator'
+
+beforeEach(() => {
+  mockState.featureOn = true
+  mockState.hasSession = true
+  mockState.did = 'did:plc:me'
+  mockState.showStreak = true
+  mockState.storeReadCount = 0
+  mockState.storeValue = {currentStreak: 5, longestStreak: 10}
+  mockState.dialogOpenCount = 0
+})
+
+describe('StreakIndicator (S9)', () => {
+  test('renders when streak >= 2 and all gates pass', () => {
+    const {queryByTestId} = render(<StreakIndicator />)
+    expect(queryByTestId('streakIndicator')).not.toBeNull()
+  })
+
+  test('hidden when currentStreak < 2 (G4)', () => {
+    mockState.storeValue = {currentStreak: 1, longestStreak: 1}
+    const {queryByTestId} = render(<StreakIndicator />)
+    expect(queryByTestId('streakIndicator')).toBeNull()
+  })
+
+  test('hidden when streak store is undefined (no visits yet)', () => {
+    mockState.storeValue = undefined
+    const {queryByTestId} = render(<StreakIndicator />)
+    expect(queryByTestId('streakIndicator')).toBeNull()
+  })
+
+  test('hidden when hasSession is false (A7)', () => {
+    // useStreaksAndRecapEnabled() encapsulates the hasSession gate; when
+    // there is no session, it returns false regardless of the flag.
+    mockState.hasSession = false
+    mockState.featureOn = false
+    const {queryByTestId} = render(<StreakIndicator />)
+    expect(queryByTestId('streakIndicator')).toBeNull()
+  })
+
+  test('hidden when showStreak preference is off (X1)', () => {
+    mockState.showStreak = false
+    const {queryByTestId} = render(<StreakIndicator />)
+    expect(queryByTestId('streakIndicator')).toBeNull()
+  })
+
+  test('feature flag off → returns null before any storage read (X6)', () => {
+    mockState.featureOn = false
+    const {queryByTestId} = render(<StreakIndicator />)
+    expect(queryByTestId('streakIndicator')).toBeNull()
+    expect(mockState.storeReadCount).toBe(0)
+  })
+
+  test('contains accessibilityLabel mentioning the streak count', () => {
+    mockState.storeValue = {currentStreak: 3, longestStreak: 7}
+    const {getByTestId} = render(<StreakIndicator />)
+    const node = getByTestId('streakIndicator')
+    const label = (node.props.accessibilityLabel as string | undefined) ?? ''
+    expect(label).toMatch(/3/)
+    expect(label.toLowerCase()).toContain('streak')
+  })
+})

--- a/src/features/activityAndRecap/__tests__/WeeklyRecapCard.test.tsx
+++ b/src/features/activityAndRecap/__tests__/WeeklyRecapCard.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * WeeklyRecapCard tests (S13).
+ *
+ * Renders the card with mocked visibility, query, and analytics. Asserts:
+ *   - hidden when useRecapCardVisibility returns null (B11, B5, B6, G7, X6)
+ *   - zero-posts copy is the EXACT RECAP_ZERO_POSTS_COPY (B4)
+ *   - tap fires recap:cardTapped + navigates with weekId (B3)
+ *   - dismiss fires recap:cardDismissed + invokes useDismissRecapCard (B5)
+ *   - recap:cardShown emits booleans-only payload (B12)
+ *   - markRecapCardFirstShown stamped on first paint (B6)
+ */
+
+import React from 'react'
+import {beforeEach, describe, expect, jest, test} from '@jest/globals'
+import {fireEvent, render} from '@testing-library/react-native'
+
+// Stop the bottom-sheet chain so RN module access doesn't crash the tests.
+jest.mock('#/../modules/bottom-sheet', () => ({
+  __esModule: true,
+  BottomSheet: () => null,
+}))
+
+jest.mock('@bsky.app/react-native-mmkv', () => ({
+  MMKV: class MMKVMock {
+    _store = new Map<string, string>()
+    set(key: string, value: string) {
+      this._store.set(key, value)
+    }
+    getString(key: string) {
+      return this._store.get(key)
+    }
+    delete(key: string) {
+      this._store.delete(key)
+    }
+    addOnValueChangedListener(_cb: (key: string) => void) {
+      return {remove: () => {}}
+    }
+    clearAll() {
+      this._store.clear()
+    }
+  },
+}))
+
+// Reanimated only contributes useReducedMotion to the WeeklyRecapCard tree.
+// We don't need the full mock — a one-liner stub is enough.
+jest.mock('react-native-reanimated', () => ({
+  useReducedMotion: () => false,
+}))
+
+const mockState = {
+  weekIso: '2026-W14' as string | null,
+  did: 'did:plc:me' as string | undefined,
+  data: undefined as
+    | undefined
+    | {
+        postsCount: number
+        followerDelta: number
+        topPost: {uri: string; cid: string} | null
+      },
+  isLoading: false,
+  isError: false,
+  navigateCalls: [] as Array<{route: string; params: any}>,
+  metricCalls: [] as Array<[string, any]>,
+  dismissCalls: [] as string[],
+  firstShownStamps: [] as Array<{did: string; weekIso: string}>,
+}
+
+jest.mock('#/features/activityAndRecap/hooks/useRecapCardVisibility', () => ({
+  useRecapCardVisibility: () => mockState.weekIso,
+}))
+jest.mock('#/features/activityAndRecap/queries/weeklyRecap', () => ({
+  useWeeklyRecapQuery: () => ({
+    data: mockState.data,
+    isLoading: mockState.isLoading,
+    isError: mockState.isError,
+  }),
+}))
+jest.mock('#/features/activityAndRecap/hooks/useDismissRecapCard', () => ({
+  useDismissRecapCard: () => (weekIso: string) => {
+    mockState.dismissCalls.push(weekIso)
+  },
+}))
+jest.mock('#/features/activityAndRecap/storage', () => ({
+  markRecapCardFirstShown: (did: string, weekIso: string, _utcMs: number) => {
+    mockState.firstShownStamps.push({did, weekIso})
+  },
+}))
+jest.mock('#/state/session', () => ({
+  useSession: () => ({
+    currentAccount: mockState.did ? {did: mockState.did} : undefined,
+  }),
+}))
+jest.mock('#/analytics', () => ({
+  useAnalytics: () => ({
+    metric: (...args: any[]) => {
+      mockState.metricCalls.push(args as [string, any])
+    },
+  }),
+}))
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: (route: string, params: any) => {
+      mockState.navigateCalls.push({route, params})
+    },
+  }),
+}))
+
+// Lingui descriptor → string. Mirrors StreakIndicator.test.tsx pattern.
+// Babel-plugin-lingui-macro transforms `from '@lingui/react/macro'` →
+// `from '@lingui/react'`, so we mock the runtime entry only.
+jest.mock('@lingui/react', () => {
+  function mockRenderDescriptor(d: any): string {
+    if (typeof d === 'string') return d
+    if (!d) return ''
+    let out: string = d.message ?? d.id ?? ''
+    const values = d.values ?? {}
+    out = out.replace(
+      /\{(\w+),\s*plural,\s*one\s*\{#\s*([^}]+)\}\s*other\s*\{#\s*([^}]+)\}\}/g,
+      (_m: string, key: string, _one: string, other: string) => {
+        const n = values[key]
+        return `${n} ${other}`
+      },
+    )
+    out = out.replace(/\{(\w+)\}/g, (_m: string, key: string) =>
+      values[key] !== undefined ? String(values[key]) : `{${key}}`,
+    )
+    return out
+  }
+  // Trans children may be a string OR a React element (e.g. when the
+  // <Trans> body interpolates other components). Render the children as-is.
+  function MockTrans({children}: {children: any}) {
+    return children
+  }
+  return {
+    useLingui: () => ({_: (d: any) => mockRenderDescriptor(d)}),
+    Trans: MockTrans,
+  }
+})
+
+import {WeeklyRecapCard} from '#/features/activityAndRecap/components/WeeklyRecapCard'
+import {RECAP_ZERO_POSTS_COPY} from '#/features/activityAndRecap/constants'
+
+beforeEach(() => {
+  mockState.weekIso = '2026-W14'
+  mockState.did = 'did:plc:me'
+  mockState.data = {
+    postsCount: 5,
+    followerDelta: 2,
+    topPost: {uri: 'at://x', cid: 'cid1'},
+  }
+  mockState.isLoading = false
+  mockState.isError = false
+  mockState.navigateCalls = []
+  mockState.metricCalls = []
+  mockState.dismissCalls = []
+  mockState.firstShownStamps = []
+})
+
+describe('WeeklyRecapCard (S13)', () => {
+  test('hidden when visibility predicate returns null (B11/B5/B6/G7)', () => {
+    mockState.weekIso = null
+    const {queryByTestId} = render(<WeeklyRecapCard />)
+    expect(queryByTestId('weeklyRecapCard')).toBeNull()
+  })
+
+  test('renders metric tiles when data is present', () => {
+    const {queryByTestId} = render(<WeeklyRecapCard />)
+    expect(queryByTestId('weeklyRecapCard')).not.toBeNull()
+    expect(queryByTestId('weeklyRecapCard-posts')).not.toBeNull()
+    expect(queryByTestId('weeklyRecapCard-followers')).not.toBeNull()
+    expect(queryByTestId('weeklyRecapCard-topPost')).not.toBeNull()
+  })
+
+  test('zero-posts: shows the exact RECAP_ZERO_POSTS_COPY string (B4)', () => {
+    mockState.data = {postsCount: 0, followerDelta: 0, topPost: null}
+    const {getByText, queryByTestId} = render(<WeeklyRecapCard />)
+    expect(getByText(RECAP_ZERO_POSTS_COPY)).toBeTruthy()
+    // Tiles are not rendered in the zero state.
+    expect(queryByTestId('weeklyRecapCard-posts')).toBeNull()
+  })
+
+  test('tap fires recap:cardTapped and navigates to Recap with weekId (B3)', () => {
+    const {getByTestId} = render(<WeeklyRecapCard />)
+    fireEvent.press(getByTestId('weeklyRecapCard'))
+    const tapped = mockState.metricCalls.find(c => c[0] === 'recap:cardTapped')
+    expect(tapped).toBeDefined()
+    expect(mockState.navigateCalls).toEqual([
+      {route: 'Recap', params: {weekId: '2026-W14'}},
+    ])
+  })
+
+  test('dismiss fires recap:cardDismissed and writes via useDismissRecapCard (B5)', () => {
+    const {getByLabelText} = render(<WeeklyRecapCard />)
+    fireEvent.press(getByLabelText('Dismiss recap'))
+    const dismissed = mockState.metricCalls.find(
+      c => c[0] === 'recap:cardDismissed',
+    )
+    expect(dismissed).toBeDefined()
+    expect(mockState.dismissCalls).toEqual(['2026-W14'])
+  })
+
+  test('recap:cardShown payload contains booleans only (B12)', () => {
+    render(<WeeklyRecapCard />)
+    const shown = mockState.metricCalls.find(c => c[0] === 'recap:cardShown')
+    expect(shown).toBeDefined()
+    const payload = shown?.[1]
+    expect(payload).toEqual({
+      has_posts: true,
+      has_top_post: true,
+      has_follower_delta: true,
+    })
+    // Crucially: no numeric counts in the payload.
+    expect(JSON.stringify(payload)).not.toMatch(/\d/)
+  })
+
+  test('markRecapCardFirstShown is stamped on first paint (B6)', () => {
+    render(<WeeklyRecapCard />)
+    expect(mockState.firstShownStamps).toEqual([
+      {did: 'did:plc:me', weekIso: '2026-W14'},
+    ])
+  })
+})

--- a/src/features/activityAndRecap/__tests__/analytics.test.ts
+++ b/src/features/activityAndRecap/__tests__/analytics.test.ts
@@ -1,0 +1,66 @@
+import {describe, expect, test} from '@jest/globals'
+
+import {
+  recapCardDismissed,
+  recapCardShown,
+  recapCardTapped,
+  recapOptIn,
+  recapOptOut,
+  streakExplainerOpened,
+  streakIndicatorShown,
+  streakOptIn,
+  streakOptOut,
+} from '#/features/activityAndRecap/analytics/events'
+
+describe('analytics events (AC-B12)', () => {
+  test('streakIndicatorShown carries only has_streak boolean', () => {
+    const [name, payload] = streakIndicatorShown(true)
+    expect(name).toBe('streak:indicatorShown')
+    expect(payload).toEqual({has_streak: true})
+  })
+
+  test('streak:explainerOpened / optIn / optOut have empty payloads', () => {
+    expect(streakExplainerOpened()).toEqual(['streak:explainerOpened', {}])
+    expect(streakOptIn()).toEqual(['streak:optIn', {}])
+    expect(streakOptOut()).toEqual(['streak:optOut', {}])
+  })
+
+  test('recap:cardShown carries ONLY booleans, no metric values (B12)', () => {
+    const [name, payload] = recapCardShown({
+      postsCount: 3,
+      followerDelta: 10,
+      topPost: {uri: 'at://x', cid: 'bafy'},
+    })
+    expect(name).toBe('recap:cardShown')
+    expect(payload).toEqual({
+      has_posts: true,
+      has_top_post: true,
+      has_follower_delta: true,
+    })
+    // Booleans only — never leak the raw counts.
+    expect(Object.values(payload).every(v => typeof v === 'boolean')).toBe(true)
+    expect(payload).not.toHaveProperty('postsCount')
+    expect(payload).not.toHaveProperty('followerDelta')
+    expect(payload).not.toHaveProperty('topPost')
+  })
+
+  test('recap:cardShown flags false when zeros / null', () => {
+    const [, payload] = recapCardShown({
+      postsCount: 0,
+      followerDelta: 0,
+      topPost: null,
+    })
+    expect(payload).toEqual({
+      has_posts: false,
+      has_top_post: false,
+      has_follower_delta: false,
+    })
+  })
+
+  test('recap:cardTapped / cardDismissed / optIn / optOut have empty payloads', () => {
+    expect(recapCardTapped()).toEqual(['recap:cardTapped', {}])
+    expect(recapCardDismissed()).toEqual(['recap:cardDismissed', {}])
+    expect(recapOptIn()).toEqual(['recap:optIn', {}])
+    expect(recapOptOut()).toEqual(['recap:optOut', {}])
+  })
+})

--- a/src/features/activityAndRecap/__tests__/clearActivityAndRecapDataForDid.test.ts
+++ b/src/features/activityAndRecap/__tests__/clearActivityAndRecapDataForDid.test.ts
@@ -1,0 +1,79 @@
+import {beforeEach, describe, expect, jest, test} from '@jest/globals'
+
+jest.mock('@bsky.app/react-native-mmkv', () => ({
+  MMKV: class MMKVMock {
+    _store = new Map<string, string>()
+    set(key: string, value: string) {
+      this._store.set(key, value)
+    }
+    getString(key: string) {
+      return this._store.get(key)
+    }
+    delete(key: string) {
+      this._store.delete(key)
+    }
+    addOnValueChangedListener(_cb: (key: string) => void) {
+      return {remove: () => {}}
+    }
+    clearAll() {
+      this._store.clear()
+    }
+  },
+}))
+
+import {clearActivityAndRecapDataForDid} from '#/features/activityAndRecap/clearActivityAndRecapDataForDid'
+import {
+  readFollowerSnapshots,
+  readPrefs,
+  readStreak,
+  upsertFollowerSnapshot,
+  writePrefs,
+  writeStreak,
+} from '#/features/activityAndRecap/storage'
+import {STREAK_STORE_VERSION} from '#/features/activityAndRecap/types'
+
+const DID = 'did:plc:clean-me'
+const OTHER = 'did:plc:keep-me'
+
+beforeEach(() => {
+  clearActivityAndRecapDataForDid({did: DID})
+  clearActivityAndRecapDataForDid({did: OTHER})
+})
+
+describe('clearActivityAndRecapDataForDid (AC-A10)', () => {
+  test('clears streak, snapshots, and prefs for the given DID', () => {
+    writeStreak(DID, {
+      version: STREAK_STORE_VERSION,
+      currentStreak: 3,
+      longestStreak: 5,
+      lastVisitDay: '2026-04-14',
+      lastVisitZone: 'America/New_York',
+      lastVisitAtUtcMs: 1,
+      graceUsedForCurrentStreak: false,
+    })
+    upsertFollowerSnapshot(DID, {day: '2026-04-14', count: 100})
+    writePrefs(DID, {showStreak: false})
+
+    clearActivityAndRecapDataForDid({did: DID})
+
+    expect(readStreak(DID)).toBeUndefined()
+    expect(readFollowerSnapshots(DID)).toEqual([])
+    expect(readPrefs(DID)).toEqual({})
+  })
+
+  test('does NOT touch other DIDs', () => {
+    writeStreak(OTHER, {
+      version: STREAK_STORE_VERSION,
+      currentStreak: 99,
+      longestStreak: 99,
+      lastVisitDay: '2026-04-14',
+      lastVisitZone: 'UTC',
+      lastVisitAtUtcMs: 1,
+      graceUsedForCurrentStreak: false,
+    })
+
+    clearActivityAndRecapDataForDid({did: DID})
+
+    expect(readStreak(OTHER)?.currentStreak).toBe(99)
+  })
+})

--- a/src/features/activityAndRecap/__tests__/computeNextStreak.test.ts
+++ b/src/features/activityAndRecap/__tests__/computeNextStreak.test.ts
@@ -1,0 +1,197 @@
+import {describe, expect, test} from '@jest/globals'
+
+import {computeNextStreak} from '#/features/activityAndRecap/reducer/computeNextStreak'
+import {
+  STREAK_STORE_VERSION,
+  type StreakStore,
+} from '#/features/activityAndRecap/types'
+
+const MS_HOUR = 60 * 60 * 1000
+const MS_DAY = 24 * MS_HOUR
+
+function makeStore(overrides: Partial<StreakStore> = {}): StreakStore {
+  return {
+    version: STREAK_STORE_VERSION,
+    currentStreak: 1,
+    longestStreak: 1,
+    lastVisitDay: '2026-04-14',
+    lastVisitZone: 'America/New_York',
+    lastVisitAtUtcMs: Date.UTC(2026, 3, 14, 14, 0, 0),
+    graceUsedForCurrentStreak: false,
+    ...overrides,
+  }
+}
+
+describe('computeNextStreak', () => {
+  test('first visit → currentStreak=1, longestStreak=1 (A2)', () => {
+    const now = {
+      utcMs: Date.UTC(2026, 3, 15, 14, 0),
+      zone: 'America/New_York',
+      localDay: '2026-04-15',
+    }
+    const next = computeNextStreak(undefined, now)
+    expect(next.currentStreak).toBe(1)
+    expect(next.longestStreak).toBe(1)
+    expect(next.graceUsedForCurrentStreak).toBe(false)
+    expect(next.lastVisitDay).toBe('2026-04-15')
+    expect(next.lastVisitZone).toBe('America/New_York')
+    expect(next.lastVisitAtUtcMs).toBe(now.utcMs)
+  })
+
+  test('consecutive day in same tz → +1 (A2)', () => {
+    const prev = makeStore({currentStreak: 3, longestStreak: 3})
+    const now = {
+      utcMs: prev.lastVisitAtUtcMs + MS_DAY,
+      zone: 'America/New_York',
+      localDay: '2026-04-15',
+    }
+    const next = computeNextStreak(prev, now)
+    expect(next.currentStreak).toBe(4)
+    expect(next.longestStreak).toBe(4)
+    expect(next.graceUsedForCurrentStreak).toBe(false)
+  })
+
+  test('same-day second visit → unchanged streak, lastVisitAtUtcMs updated (A1)', () => {
+    const prev = makeStore({currentStreak: 5})
+    const now = {
+      utcMs: prev.lastVisitAtUtcMs + 2 * MS_HOUR,
+      zone: 'America/New_York',
+      localDay: '2026-04-14',
+    }
+    const next = computeNextStreak(prev, now)
+    expect(next.currentStreak).toBe(5)
+    expect(next.lastVisitAtUtcMs).toBe(now.utcMs)
+  })
+
+  test('exactly 1 day missed, grace unused → unchanged, graceUsed=true (A3)', () => {
+    // prev day 04-14, now 04-16 → delta 2 (one day skipped)
+    const prev = makeStore({currentStreak: 7, longestStreak: 7})
+    const now = {
+      utcMs: prev.lastVisitAtUtcMs + 2 * MS_DAY,
+      zone: 'America/New_York',
+      localDay: '2026-04-16',
+    }
+    const next = computeNextStreak(prev, now)
+    expect(next.currentStreak).toBe(7)
+    expect(next.graceUsedForCurrentStreak).toBe(true)
+    expect(next.lastVisitDay).toBe('2026-04-16')
+  })
+
+  test('1 day missed but grace already used → reset to 1 (A4)', () => {
+    const prev = makeStore({
+      currentStreak: 7,
+      longestStreak: 10,
+      graceUsedForCurrentStreak: true,
+    })
+    const now = {
+      utcMs: prev.lastVisitAtUtcMs + 2 * MS_DAY,
+      zone: 'America/New_York',
+      localDay: '2026-04-16',
+    }
+    const next = computeNextStreak(prev, now)
+    expect(next.currentStreak).toBe(1)
+    expect(next.graceUsedForCurrentStreak).toBe(false)
+    expect(next.longestStreak).toBe(10) // high-water preserved
+  })
+
+  test('2+ days missed → reset to 1, grace cleared (A4)', () => {
+    const prev = makeStore({currentStreak: 12, longestStreak: 12})
+    const now = {
+      utcMs: prev.lastVisitAtUtcMs + 4 * MS_DAY,
+      zone: 'America/New_York',
+      localDay: '2026-04-18',
+    }
+    const next = computeNextStreak(prev, now)
+    expect(next.currentStreak).toBe(1)
+    expect(next.graceUsedForCurrentStreak).toBe(false)
+    expect(next.longestStreak).toBe(12)
+  })
+
+  test('UTC delta <20h blocks increment regardless of local date (A5)', () => {
+    const prev = makeStore({currentStreak: 5})
+    const now = {
+      utcMs: prev.lastVisitAtUtcMs + 10 * MS_HOUR,
+      zone: 'America/New_York',
+      // Caller *claims* it's a new day, but 10h hasn't passed — reject.
+      localDay: '2026-04-15',
+    }
+    const next = computeNextStreak(prev, now)
+    expect(next).toBe(prev)
+  })
+
+  test('tz hop EWR→LAX same local day → no decrement, no increment (A5)', () => {
+    // Traveled westward. lastVisitAtUtcMs 14:00 UTC on 2026-04-14 in NY
+    // (10:00 EDT). Now 22:00 UTC on 2026-04-14 in LA (15:00 PDT).
+    // Same local day "2026-04-14" in LA.
+    const prev = makeStore({
+      currentStreak: 4,
+      lastVisitDay: '2026-04-14',
+      lastVisitZone: 'America/New_York',
+      lastVisitAtUtcMs: Date.UTC(2026, 3, 14, 14, 0),
+    })
+    const now = {
+      utcMs: Date.UTC(2026, 3, 14, 22, 0),
+      zone: 'America/Los_Angeles',
+      localDay: '2026-04-14',
+    }
+    const next = computeNextStreak(prev, now)
+    expect(next.currentStreak).toBe(4)
+  })
+
+  test('longestStreak never decreases', () => {
+    const prev = makeStore({currentStreak: 2, longestStreak: 99})
+    const now = {
+      utcMs: prev.lastVisitAtUtcMs + 4 * MS_DAY,
+      zone: 'America/New_York',
+      localDay: '2026-04-18',
+    }
+    const next = computeNextStreak(prev, now)
+    expect(next.currentStreak).toBe(1)
+    expect(next.longestStreak).toBe(99)
+  })
+
+  test('regression: new localDay earlier than prev does not decrement (A5)', () => {
+    const prev = makeStore({
+      currentStreak: 4,
+      lastVisitDay: '2026-04-14',
+    })
+    const now = {
+      utcMs: prev.lastVisitAtUtcMs + 21 * MS_HOUR,
+      zone: 'Pacific/Auckland',
+      localDay: '2026-04-13', // earlier!
+    }
+    const next = computeNextStreak(prev, now)
+    expect(next.currentStreak).toBe(4)
+  })
+
+  test('consecutive day across DST spring-forward', () => {
+    // prev day 2026-03-07 EST, now 2026-03-08 EDT
+    const prev = makeStore({
+      currentStreak: 3,
+      lastVisitDay: '2026-03-07',
+      lastVisitAtUtcMs: Date.UTC(2026, 2, 7, 18, 0),
+    })
+    const now = {
+      utcMs: Date.UTC(2026, 2, 8, 18, 0), // 24h later in UTC
+      zone: 'America/New_York',
+      localDay: '2026-03-08',
+    }
+    const next = computeNextStreak(prev, now)
+    expect(next.currentStreak).toBe(4)
+  })
+
+  test('version mismatch triggers defensive reset to 1', () => {
+    const prev = {
+      ...makeStore({currentStreak: 10, longestStreak: 10}),
+      version: 999 as any,
+    }
+    const now = {
+      utcMs: prev.lastVisitAtUtcMs + MS_DAY,
+      zone: 'America/New_York',
+      localDay: '2026-04-15',
+    }
+    const next = computeNextStreak(prev, now)
+    expect(next.version).toBe(STREAK_STORE_VERSION)
+    expect(next.currentStreak).toBe(1)
+  })
+})

--- a/src/features/activityAndRecap/__tests__/dayMath.test.ts
+++ b/src/features/activityAndRecap/__tests__/dayMath.test.ts
@@ -1,0 +1,82 @@
+import {describe, expect, test} from '@jest/globals'
+
+import {
+  daysBetweenLocalDays,
+  formatLocalDay,
+  parseLocalDay,
+} from '#/features/activityAndRecap/reducer/dayMath'
+
+describe('formatLocalDay', () => {
+  test('returns YYYY-MM-DD for UTC tz', () => {
+    const d = new Date('2026-04-15T12:00:00Z')
+    expect(formatLocalDay(d, 'UTC')).toBe('2026-04-15')
+  })
+
+  test('rolls back a day when crossing tz westward (EWR vs LAX near midnight UTC)', () => {
+    // 02:30 UTC Thursday → 22:30 Wednesday in America/New_York
+    //                  → 19:30 Wednesday in America/Los_Angeles
+    const d = new Date('2026-04-16T02:30:00Z')
+    expect(formatLocalDay(d, 'America/New_York')).toBe('2026-04-15')
+    expect(formatLocalDay(d, 'America/Los_Angeles')).toBe('2026-04-15')
+  })
+
+  test('handles DST spring-forward (America/New_York, 2026-03-08)', () => {
+    // DST starts at 07:00 UTC on 2026-03-08. 09:00 UTC is 05:00 EDT.
+    const d = new Date('2026-03-08T09:00:00Z')
+    expect(formatLocalDay(d, 'America/New_York')).toBe('2026-03-08')
+  })
+
+  test('handles DST fall-back (America/New_York, 2026-11-01)', () => {
+    // 03:30 UTC on 2026-11-01 is 23:30 EDT on 2026-10-31 (still Oct 31).
+    const d = new Date('2026-11-01T03:30:00Z')
+    expect(formatLocalDay(d, 'America/New_York')).toBe('2026-10-31')
+  })
+})
+
+describe('parseLocalDay', () => {
+  test('parses a valid date', () => {
+    expect(parseLocalDay('2026-04-15')).toEqual({
+      year: 2026,
+      month: 4,
+      day: 15,
+    })
+  })
+
+  test('returns null for malformed', () => {
+    expect(parseLocalDay('not a date')).toBeNull()
+    expect(parseLocalDay('2026-4-15')).toBeNull()
+    expect(parseLocalDay('2026/04/15')).toBeNull()
+  })
+})
+
+describe('daysBetweenLocalDays', () => {
+  test('same day → 0', () => {
+    expect(daysBetweenLocalDays('2026-04-15', '2026-04-15')).toBe(0)
+  })
+
+  test('consecutive days → 1', () => {
+    expect(daysBetweenLocalDays('2026-04-15', '2026-04-16')).toBe(1)
+  })
+
+  test('two-day gap → 2', () => {
+    expect(daysBetweenLocalDays('2026-04-15', '2026-04-17')).toBe(2)
+  })
+
+  test('negative delta on regression → -1', () => {
+    expect(daysBetweenLocalDays('2026-04-16', '2026-04-15')).toBe(-1)
+  })
+
+  test('month boundary crossing', () => {
+    expect(daysBetweenLocalDays('2026-03-31', '2026-04-01')).toBe(1)
+  })
+
+  test('DST spring-forward does not affect day count', () => {
+    // 2026-03-07 → 2026-03-09 (DST starts 2026-03-08) is still 2 days
+    expect(daysBetweenLocalDays('2026-03-07', '2026-03-09')).toBe(2)
+  })
+
+  test('null for malformed input', () => {
+    expect(daysBetweenLocalDays('bad', '2026-04-15')).toBeNull()
+    expect(daysBetweenLocalDays('2026-04-15', 'bad')).toBeNull()
+  })
+})

--- a/src/features/activityAndRecap/__tests__/followerDelta.test.ts
+++ b/src/features/activityAndRecap/__tests__/followerDelta.test.ts
@@ -1,0 +1,54 @@
+import {describe, expect, test} from '@jest/globals'
+
+import {followerDelta} from '#/features/activityAndRecap/reducer/followerDelta'
+
+describe('followerDelta', () => {
+  test('basic positive delta', () => {
+    const snaps = [
+      {day: '2026-04-13', count: 100},
+      {day: '2026-04-19', count: 107},
+    ]
+    expect(followerDelta(snaps, '2026-04-13', '2026-04-19')).toBe(7)
+  })
+
+  test('clamps negative delta to 0 (B4)', () => {
+    const snaps = [
+      {day: '2026-04-13', count: 120},
+      {day: '2026-04-19', count: 100},
+    ]
+    expect(followerDelta(snaps, '2026-04-13', '2026-04-19')).toBe(0)
+  })
+
+  test('missing start snapshot degrades to oldest available without throwing (B4, R2)', () => {
+    const snaps = [
+      {day: '2026-04-15', count: 90}, // oldest, will back-fill the start
+      {day: '2026-04-19', count: 95},
+    ]
+    expect(followerDelta(snaps, '2026-04-13', '2026-04-19')).toBe(5)
+  })
+
+  test('zero snapshots → 0', () => {
+    expect(followerDelta([], '2026-04-13', '2026-04-19')).toBe(0)
+  })
+
+  test('undefined snapshots → 0', () => {
+    expect(followerDelta(undefined, '2026-04-13', '2026-04-19')).toBe(0)
+  })
+
+  test('uses latest snapshot <= endDay for end (not a snapshot after the window)', () => {
+    const snaps = [
+      {day: '2026-04-13', count: 100},
+      {day: '2026-04-16', count: 105},
+      {day: '2026-04-25', count: 200}, // outside window
+    ]
+    expect(followerDelta(snaps, '2026-04-13', '2026-04-19')).toBe(5)
+  })
+
+  test('snapshots that land inside the window are usable as end', () => {
+    const snaps = [
+      {day: '2026-04-10', count: 80},
+      {day: '2026-04-15', count: 85},
+    ]
+    expect(followerDelta(snaps, '2026-04-13', '2026-04-19')).toBe(5)
+  })
+})

--- a/src/features/activityAndRecap/__tests__/isoWeek.test.ts
+++ b/src/features/activityAndRecap/__tests__/isoWeek.test.ts
@@ -1,0 +1,102 @@
+import {describe, expect, test} from '@jest/globals'
+
+import {
+  currentWeekIso,
+  formatWeekIso,
+  lastNWeekIsos,
+  parseWeekIsoToDate,
+  priorWeekIso,
+  weekEnd,
+  weekStart,
+  weekWindowForIso,
+} from '#/features/activityAndRecap/reducer/isoWeek'
+
+describe('formatWeekIso', () => {
+  test('Wed Apr 15, 2026 → 2026-W16', () => {
+    const d = new Date(2026, 3, 15, 12, 0)
+    expect(formatWeekIso(d)).toBe('2026-W16')
+  })
+
+  test('Sunday 2026-04-19 23:30 local → still 2026-W16', () => {
+    const d = new Date(2026, 3, 19, 23, 30)
+    expect(formatWeekIso(d)).toBe('2026-W16')
+  })
+
+  test('Monday 2026-04-20 00:30 local → 2026-W17', () => {
+    const d = new Date(2026, 3, 20, 0, 30)
+    expect(formatWeekIso(d)).toBe('2026-W17')
+  })
+})
+
+describe('weekStart / weekEnd', () => {
+  test('week containing Wed 2026-04-15: Mon 2026-04-13 → Sun 2026-04-19', () => {
+    const d = new Date(2026, 3, 15, 12, 0)
+    const start = weekStart(d)
+    const end = weekEnd(d)
+    // Mon Apr 13
+    expect(start.getFullYear()).toBe(2026)
+    expect(start.getMonth()).toBe(3)
+    expect(start.getDate()).toBe(13)
+    expect(start.getHours()).toBe(0)
+    expect(start.getMinutes()).toBe(0)
+    // Sun Apr 19 23:59:59.999
+    expect(end.getFullYear()).toBe(2026)
+    expect(end.getMonth()).toBe(3)
+    expect(end.getDate()).toBe(19)
+    expect(end.getHours()).toBe(23)
+    expect(end.getMinutes()).toBe(59)
+  })
+})
+
+describe('priorWeekIso / currentWeekIso', () => {
+  test('priorWeekIso on Wed 2026-04-15 returns 2026-W15', () => {
+    expect(priorWeekIso(new Date(2026, 3, 15, 12, 0))).toBe('2026-W15')
+  })
+
+  test('currentWeekIso on Wed 2026-04-15 returns 2026-W16', () => {
+    expect(currentWeekIso(new Date(2026, 3, 15, 12, 0))).toBe('2026-W16')
+  })
+
+  test('Monday 2026-04-20 at 05:59 local → current=W17, prior=W16 (B1 note)', () => {
+    // The 06:00 visibility gate is NOT part of week math — just a render gate.
+    const monday = new Date(2026, 3, 20, 5, 59)
+    expect(currentWeekIso(monday)).toBe('2026-W17')
+    expect(priorWeekIso(monday)).toBe('2026-W16')
+  })
+
+  test('Sunday 23:59 → current week is still N; Monday 00:00 → N+1', () => {
+    const sun = new Date(2026, 3, 19, 23, 59, 59)
+    const mon = new Date(2026, 3, 20, 0, 0, 0)
+    expect(currentWeekIso(sun)).toBe('2026-W16')
+    expect(currentWeekIso(mon)).toBe('2026-W17')
+  })
+})
+
+describe('lastNWeekIsos', () => {
+  test('returns 4 prior ISO week IDs, most recent first', () => {
+    const d = new Date(2026, 3, 15, 12, 0) // week 16
+    const weeks = lastNWeekIsos(d, 4)
+    expect(weeks).toEqual(['2026-W15', '2026-W14', '2026-W13', '2026-W12'])
+  })
+})
+
+describe('parseWeekIsoToDate / weekWindowForIso', () => {
+  test('roundtrips a valid weekIso', () => {
+    const d = parseWeekIsoToDate('2026-W15')
+    expect(d).not.toBeNull()
+    expect(formatWeekIso(d!)).toBe('2026-W15')
+  })
+
+  test('returns null for malformed weekIso', () => {
+    expect(parseWeekIsoToDate('bogus')).toBeNull()
+    expect(parseWeekIsoToDate('2026-W99')).toBeNull()
+    expect(weekWindowForIso('garbage')).toBeNull()
+  })
+
+  test('weekWindowForIso produces a sensible Mon–Sun window', () => {
+    const w = weekWindowForIso('2026-W15')
+    expect(w).not.toBeNull()
+    expect(w!.start.getDay()).toBe(1) // Monday
+    expect(w!.end.getDay()).toBe(0) // Sunday
+  })
+})

--- a/src/features/activityAndRecap/__tests__/rankTopPost.test.ts
+++ b/src/features/activityAndRecap/__tests__/rankTopPost.test.ts
@@ -1,0 +1,66 @@
+import {describe, expect, test} from '@jest/globals'
+
+import {
+  rankTopPost,
+  type TopPostCandidate,
+} from '#/features/activityAndRecap/reducer/rankTopPost'
+
+function mkPost(
+  uri: string,
+  likes: number,
+  reposts: number,
+  replies: number,
+  indexedAtMs: number,
+): TopPostCandidate {
+  return {
+    uri,
+    cid: `cid-${uri}`,
+    likeCount: likes,
+    repostCount: reposts,
+    replyCount: replies,
+    indexedAtMs,
+  }
+}
+
+describe('rankTopPost', () => {
+  test('sorts by likes+reposts+replies descending', () => {
+    const input = [
+      mkPost('a', 1, 0, 0, 100),
+      mkPost('b', 5, 2, 1, 100), // score 8
+      mkPost('c', 3, 1, 0, 100), // score 4
+    ]
+    const out = rankTopPost(input)
+    expect(out.map(p => p.uri)).toEqual(['b', 'c', 'a'])
+  })
+
+  test('tiebreaker: newer wins', () => {
+    const input = [mkPost('old', 2, 2, 0, 1000), mkPost('new', 2, 2, 0, 2000)]
+    const out = rankTopPost(input)
+    expect(out[0].uri).toBe('new')
+  })
+
+  test('does not mutate input', () => {
+    const input = [mkPost('a', 1, 0, 0, 100), mkPost('b', 5, 2, 1, 100)]
+    const snapshot = JSON.parse(JSON.stringify(input))
+    rankTopPost(input)
+    expect(input).toEqual(snapshot)
+  })
+
+  test('handles empty input', () => {
+    expect(rankTopPost([])).toEqual([])
+  })
+
+  test('coerces missing count fields to 0', () => {
+    const a = {
+      uri: 'a',
+      cid: 'ca',
+      indexedAtMs: 100,
+      likeCount: undefined as any,
+      repostCount: undefined as any,
+      replyCount: undefined as any,
+    }
+    const b = mkPost('b', 0, 0, 1, 200)
+    const out = rankTopPost([a, b])
+    expect(out[0].uri).toBe('b')
+  })
+})

--- a/src/features/activityAndRecap/__tests__/retryBudget.test.ts
+++ b/src/features/activityAndRecap/__tests__/retryBudget.test.ts
@@ -1,0 +1,47 @@
+import {beforeEach, describe, expect, test} from '@jest/globals'
+
+import {
+  __resetAllForTests,
+  resetAutoRetry,
+  tryAutoRetry,
+} from '#/features/activityAndRecap/queries/retryBudget'
+
+beforeEach(() => {
+  __resetAllForTests()
+})
+
+describe('retry budget (AC-B8)', () => {
+  test('allows 2 retries per hour, rejects 3rd', () => {
+    const t0 = 1_700_000_000_000
+    expect(tryAutoRetry('2026-W15', t0)).toBe(true)
+    expect(tryAutoRetry('2026-W15', t0 + 100)).toBe(true)
+    expect(tryAutoRetry('2026-W15', t0 + 200)).toBe(false)
+  })
+
+  test('hour rollover resets the budget', () => {
+    const t0 = 1_700_000_000_000
+    expect(tryAutoRetry('2026-W15', t0)).toBe(true)
+    expect(tryAutoRetry('2026-W15', t0 + 100)).toBe(true)
+    expect(tryAutoRetry('2026-W15', t0 + 200)).toBe(false)
+    // +1h
+    expect(tryAutoRetry('2026-W15', t0 + 60 * 60 * 1000 + 1)).toBe(true)
+  })
+
+  test('buckets are per-weekIso', () => {
+    const t0 = 1_700_000_000_000
+    expect(tryAutoRetry('2026-W15', t0)).toBe(true)
+    expect(tryAutoRetry('2026-W15', t0)).toBe(true)
+    // W14 has its own bucket
+    expect(tryAutoRetry('2026-W14', t0)).toBe(true)
+    expect(tryAutoRetry('2026-W14', t0)).toBe(true)
+  })
+
+  test('resetAutoRetry clears a specific bucket', () => {
+    const t0 = 1_700_000_000_000
+    tryAutoRetry('2026-W15', t0)
+    tryAutoRetry('2026-W15', t0)
+    expect(tryAutoRetry('2026-W15', t0)).toBe(false)
+    resetAutoRetry('2026-W15')
+    expect(tryAutoRetry('2026-W15', t0)).toBe(true)
+  })
+})

--- a/src/features/activityAndRecap/__tests__/storage.test.ts
+++ b/src/features/activityAndRecap/__tests__/storage.test.ts
@@ -1,0 +1,145 @@
+import {beforeEach, describe, expect, jest, test} from '@jest/globals'
+
+jest.mock('@bsky.app/react-native-mmkv', () => ({
+  MMKV: class MMKVMock {
+    _store = new Map<string, string>()
+    set(key: string, value: string) {
+      this._store.set(key, value)
+    }
+    getString(key: string) {
+      return this._store.get(key)
+    }
+    delete(key: string) {
+      this._store.delete(key)
+    }
+    addOnValueChangedListener(_cb: (key: string) => void) {
+      return {remove: () => {}}
+    }
+    clearAll() {
+      this._store.clear()
+    }
+  },
+}))
+
+import {MAX_FOLLOWER_SNAPSHOTS} from '#/features/activityAndRecap/constants'
+import {
+  clearAllForDid,
+  dismissRecapWeek,
+  getRecapCardFirstShown,
+  isRecapWeekDismissed,
+  markRecapCardFirstShown,
+  patchPrefs,
+  readFollowerSnapshots,
+  readPrefs,
+  readStreak,
+  upsertFollowerSnapshot,
+  writePrefs,
+  writeStreak,
+} from '#/features/activityAndRecap/storage'
+import {
+  STREAK_STORE_VERSION,
+  type StreakStore,
+} from '#/features/activityAndRecap/types'
+import {account} from '#/storage'
+
+const DID = 'did:plc:testuser'
+
+function baseStreak(): StreakStore {
+  return {
+    version: STREAK_STORE_VERSION,
+    currentStreak: 3,
+    longestStreak: 5,
+    lastVisitDay: '2026-04-14',
+    lastVisitZone: 'America/New_York',
+    lastVisitAtUtcMs: Date.UTC(2026, 3, 14),
+    graceUsedForCurrentStreak: false,
+  }
+}
+
+beforeEach(() => {
+  clearAllForDid(DID)
+})
+
+describe('streak read/write', () => {
+  test('roundtrips', () => {
+    expect(readStreak(DID)).toBeUndefined()
+    const s = baseStreak()
+    writeStreak(DID, s)
+    expect(readStreak(DID)).toEqual(s)
+  })
+
+  test('version mismatch returns raw value (reducer handles)', () => {
+    const broken = {...baseStreak(), version: 999 as any}
+    account.set([DID, 'streak'], broken)
+    const read = readStreak(DID)
+    expect(read?.version).toBe(999)
+  })
+})
+
+describe('follower snapshots ring buffer', () => {
+  test('upsert replaces same-day entry', () => {
+    upsertFollowerSnapshot(DID, {day: '2026-04-14', count: 100})
+    upsertFollowerSnapshot(DID, {day: '2026-04-14', count: 101})
+    const out = readFollowerSnapshots(DID)
+    expect(out).toHaveLength(1)
+    expect(out[0].count).toBe(101)
+  })
+
+  test('trims to MAX_FOLLOWER_SNAPSHOTS, dropping oldest', () => {
+    for (let i = 0; i < MAX_FOLLOWER_SNAPSHOTS + 3; i++) {
+      const d = new Date(2026, 0, 1 + i)
+      const iso = d.toISOString().slice(0, 10)
+      upsertFollowerSnapshot(DID, {day: iso, count: i})
+    }
+    const out = readFollowerSnapshots(DID)
+    expect(out).toHaveLength(MAX_FOLLOWER_SNAPSHOTS)
+    // First 3 inserted days should have been dropped.
+    expect(out[0].day).not.toBe('2026-01-01')
+  })
+
+  test('sorts by day ascending', () => {
+    upsertFollowerSnapshot(DID, {day: '2026-04-14', count: 100})
+    upsertFollowerSnapshot(DID, {day: '2026-04-13', count: 99})
+    upsertFollowerSnapshot(DID, {day: '2026-04-15', count: 101})
+    const out = readFollowerSnapshots(DID)
+    expect(out.map(s => s.day)).toEqual([
+      '2026-04-13',
+      '2026-04-14',
+      '2026-04-15',
+    ])
+  })
+})
+
+describe('prefs + dismissals + firstShown', () => {
+  test('readPrefs default empty; patchPrefs merges', () => {
+    expect(readPrefs(DID)).toEqual({})
+    patchPrefs(DID, {showStreak: true})
+    expect(readPrefs(DID)).toEqual({showStreak: true})
+    patchPrefs(DID, {showRecap: false})
+    expect(readPrefs(DID)).toEqual({showStreak: true, showRecap: false})
+  })
+
+  test('dismissRecapWeek persists + isRecapWeekDismissed detects', () => {
+    expect(isRecapWeekDismissed(DID, '2026-W15')).toBe(false)
+    dismissRecapWeek(DID, '2026-W15')
+    expect(isRecapWeekDismissed(DID, '2026-W15')).toBe(true)
+  })
+
+  test('markRecapCardFirstShown only writes first time', () => {
+    markRecapCardFirstShown(DID, '2026-W15', 1000)
+    markRecapCardFirstShown(DID, '2026-W15', 2000) // ignored
+    expect(getRecapCardFirstShown(DID, '2026-W15')).toBe(1000)
+  })
+})
+
+describe('clearAllForDid (A10)', () => {
+  test('removes streak, snapshots, and prefs', () => {
+    writeStreak(DID, baseStreak())
+    upsertFollowerSnapshot(DID, {day: '2026-04-14', count: 100})
+    writePrefs(DID, {showStreak: false, dismissedRecapWeekIds: ['2026-W15']})
+    clearAllForDid(DID)
+    expect(readStreak(DID)).toBeUndefined()
+    expect(readFollowerSnapshots(DID)).toEqual([])
+    expect(readPrefs(DID)).toEqual({})
+  })
+})

--- a/src/features/activityAndRecap/__tests__/useStreakTracker.test.tsx
+++ b/src/features/activityAndRecap/__tests__/useStreakTracker.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * Integration tests for useStreakTracker (S7).
+ *
+ * We mock the hook's collaborators (session, agent, AppState, route focus,
+ * preference, feature flag) and assert that:
+ *
+ *   - 30s contiguous foreground + Home active + feed-render signal increments
+ *     the streak exactly once per day (AC-A1, A2).
+ *   - 29s does NOT increment (AC-A1).
+ *   - Foreground without HomeTab focus does NOT increment (AC-A1, A6).
+ *   - Backgrounding before 30s aborts the timer (AC-A1).
+ *   - Toggling showStreak off short-circuits everything (AC-X1).
+ *   - Flag off short-circuits everything (AC-X6).
+ *   - Listener cleanup on unmount (R4).
+ */
+
+import React from 'react'
+import {beforeEach, describe, expect, jest, test} from '@jest/globals'
+import {act, render} from '@testing-library/react-native'
+
+// MMKV mock — used transitively by the storage module.
+jest.mock('@bsky.app/react-native-mmkv', () => ({
+  MMKV: class MMKVMock {
+    _store = new Map<string, string>()
+    set(key: string, value: string) {
+      this._store.set(key, value)
+    }
+    getString(key: string) {
+      return this._store.get(key)
+    }
+    delete(key: string) {
+      this._store.delete(key)
+    }
+    addOnValueChangedListener(_cb: (key: string) => void) {
+      return {remove: () => {}}
+    }
+    clearAll() {
+      this._store.clear()
+    }
+  },
+}))
+
+// All mock collaborators must be declared with `mock`-prefixed names so
+// Jest's hoisting-time variable guard accepts them. We expose a single
+// mutable state object and read from it inside each factory.
+const mockState = {
+  appStateListeners: [] as Array<(s: string) => void>,
+  appStateRemoveCount: 0,
+  appStateCurrent: 'active' as string,
+  isFocused: true,
+  hasSession: true,
+  did: 'did:plc:me',
+  featureOn: true,
+  showStreak: true,
+  getProfileCalls: 0,
+}
+
+jest.mock('react-native', () => ({
+  AppState: {
+    get currentState() {
+      return mockState.appStateCurrent
+    },
+    addEventListener: (_: string, cb: (s: string) => void) => {
+      mockState.appStateListeners.push(cb)
+      return {
+        remove: () => {
+          const idx = mockState.appStateListeners.indexOf(cb)
+          if (idx >= 0) mockState.appStateListeners.splice(idx, 1)
+          mockState.appStateRemoveCount += 1
+        },
+      }
+    },
+  },
+}))
+
+jest.mock('@react-navigation/native', () => ({
+  useIsFocused: () => mockState.isFocused,
+}))
+
+jest.mock('#/state/session', () => ({
+  useSession: () => ({
+    hasSession: mockState.hasSession,
+    currentAccount: mockState.hasSession ? {did: mockState.did} : undefined,
+  }),
+  useAgent: () => ({
+    app: {
+      bsky: {
+        actor: {
+          getProfile: async () => {
+            mockState.getProfileCalls += 1
+            return {data: {followersCount: 42}}
+          },
+        },
+      },
+    },
+  }),
+}))
+
+jest.mock(
+  '#/features/activityAndRecap/hooks/useStreaksAndRecapEnabled',
+  () => ({
+    useStreaksAndRecapEnabled: () => mockState.featureOn,
+  }),
+)
+jest.mock('#/features/activityAndRecap/hooks/useShowStreakPreference', () => ({
+  useShowStreakPreference: () => [mockState.showStreak, () => {}],
+}))
+
+import {STREAK_QUALIFYING_DWELL_MS} from '#/features/activityAndRecap/constants'
+import {
+  ActivityAndRecapProvider,
+  useStreakTracker,
+} from '#/features/activityAndRecap/hooks/useStreakTracker'
+import {clearAllForDid, readStreak} from '#/features/activityAndRecap/storage'
+
+function pushAppState(state: string) {
+  mockState.appStateCurrent = state
+  for (const cb of [...mockState.appStateListeners]) cb(state)
+}
+
+function FeedRenderSignaller({onMount}: {onMount: () => void}) {
+  React.useEffect(() => {
+    onMount()
+  }, [onMount])
+  return null
+}
+
+beforeEach(() => {
+  jest.useFakeTimers()
+  mockState.appStateListeners.length = 0
+  mockState.appStateRemoveCount = 0
+  mockState.appStateCurrent = 'active'
+  mockState.isFocused = true
+  mockState.hasSession = true
+  mockState.featureOn = true
+  mockState.showStreak = true
+  mockState.did = 'did:plc:me'
+  mockState.getProfileCalls = 0
+  clearAllForDid(mockState.did)
+})
+
+describe('useStreakTracker (S7)', () => {
+  test('30s foreground + Home focus + feed-render signal increments streak', () => {
+    function Tracker() {
+      const {signalFeedRender} = useStreakTracker()
+      return <FeedRenderSignaller onMount={signalFeedRender} />
+    }
+    render(<Tracker />)
+    act(() => {
+      jest.advanceTimersByTime(STREAK_QUALIFYING_DWELL_MS + 100)
+    })
+    const stored = readStreak(mockState.did)
+    expect(stored?.currentStreak).toBe(1)
+    expect(stored?.longestStreak).toBe(1)
+  })
+
+  test('29s does NOT increment', () => {
+    function Tracker() {
+      const {signalFeedRender} = useStreakTracker()
+      return <FeedRenderSignaller onMount={signalFeedRender} />
+    }
+    render(<Tracker />)
+    act(() => {
+      jest.advanceTimersByTime(STREAK_QUALIFYING_DWELL_MS - 1000)
+    })
+    expect(readStreak(mockState.did)).toBeUndefined()
+  })
+
+  test('without HomeTab focus, no increment', () => {
+    mockState.isFocused = false
+    function Tracker() {
+      const {signalFeedRender} = useStreakTracker()
+      return <FeedRenderSignaller onMount={signalFeedRender} />
+    }
+    render(<Tracker />)
+    act(() => {
+      jest.advanceTimersByTime(STREAK_QUALIFYING_DWELL_MS + 100)
+    })
+    expect(readStreak(mockState.did)).toBeUndefined()
+  })
+
+  test('backgrounding cancels in-flight timer', () => {
+    function Tracker() {
+      const {signalFeedRender} = useStreakTracker()
+      return <FeedRenderSignaller onMount={signalFeedRender} />
+    }
+    render(<Tracker />)
+    act(() => {
+      jest.advanceTimersByTime(10_000)
+      pushAppState('background')
+      jest.advanceTimersByTime(STREAK_QUALIFYING_DWELL_MS + 100)
+    })
+    expect(readStreak(mockState.did)).toBeUndefined()
+  })
+
+  test('showStreak preference off short-circuits', () => {
+    mockState.showStreak = false
+    function Tracker() {
+      const {signalFeedRender} = useStreakTracker()
+      return <FeedRenderSignaller onMount={signalFeedRender} />
+    }
+    render(<Tracker />)
+    act(() => {
+      jest.advanceTimersByTime(STREAK_QUALIFYING_DWELL_MS + 100)
+    })
+    expect(readStreak(mockState.did)).toBeUndefined()
+    expect(mockState.getProfileCalls).toBe(0)
+  })
+
+  test('flag off short-circuits and never reads storage', () => {
+    mockState.featureOn = false
+    function Tracker() {
+      const {signalFeedRender} = useStreakTracker()
+      return <FeedRenderSignaller onMount={signalFeedRender} />
+    }
+    render(<Tracker />)
+    act(() => {
+      jest.advanceTimersByTime(STREAK_QUALIFYING_DWELL_MS + 100)
+    })
+    expect(readStreak(mockState.did)).toBeUndefined()
+    expect(mockState.getProfileCalls).toBe(0)
+  })
+
+  test('signed-out short-circuits', () => {
+    mockState.hasSession = false
+    function Tracker() {
+      const {signalFeedRender} = useStreakTracker()
+      return <FeedRenderSignaller onMount={signalFeedRender} />
+    }
+    render(<Tracker />)
+    act(() => {
+      jest.advanceTimersByTime(STREAK_QUALIFYING_DWELL_MS + 100)
+    })
+    expect(mockState.getProfileCalls).toBe(0)
+  })
+
+  test('AppState listener removed on unmount', () => {
+    function Tracker() {
+      const {signalFeedRender} = useStreakTracker()
+      return <FeedRenderSignaller onMount={signalFeedRender} />
+    }
+    const {unmount} = render(<Tracker />)
+    unmount()
+    expect(mockState.appStateRemoveCount).toBeGreaterThan(0)
+    expect(mockState.appStateListeners.length).toBe(0)
+  })
+
+  test('ActivityAndRecapProvider mounts the tracker and renders null', () => {
+    const {toJSON} = render(<ActivityAndRecapProvider />)
+    expect(toJSON()).toBeNull()
+    act(() => {
+      jest.advanceTimersByTime(STREAK_QUALIFYING_DWELL_MS + 100)
+    })
+    // Fallback path (R5): the provider doesn't wire a feed-render signal,
+    // but the dwell alone qualifies per the documented fallback — so the
+    // streak increments once on provider mount.
+    const stored = readStreak(mockState.did)
+    expect(stored?.currentStreak).toBe(1)
+  })
+})

--- a/src/features/activityAndRecap/__tests__/useStreaksAndRecapEnabled.test.ts
+++ b/src/features/activityAndRecap/__tests__/useStreaksAndRecapEnabled.test.ts
@@ -1,0 +1,50 @@
+import {describe, expect, jest, test} from '@jest/globals'
+import {renderHook} from '@testing-library/react-native'
+
+const mockUseSession = jest.fn()
+const mockFeaturesEnabled = jest.fn()
+
+jest.mock('#/state/session', () => ({
+  useSession: () => mockUseSession(),
+}))
+
+jest.mock('#/analytics', () => ({
+  useAnalytics: () => ({
+    features: {
+      enabled: (f: string) => mockFeaturesEnabled(f),
+      StreaksAndRecapEnable: 'streaks_and_recap:enable',
+    },
+  }),
+}))
+
+// Imported after mocks.
+import {useStreaksAndRecapEnabled} from '#/features/activityAndRecap/hooks/useStreaksAndRecapEnabled'
+
+beforeEach(() => {
+  mockUseSession.mockReset()
+  mockFeaturesEnabled.mockReset()
+})
+
+describe('useStreaksAndRecapEnabled', () => {
+  test('returns false without session even when flag on (AC-X6, AC-A7)', () => {
+    mockUseSession.mockReturnValue({hasSession: false})
+    mockFeaturesEnabled.mockReturnValue(true)
+    const {result} = renderHook(() => useStreaksAndRecapEnabled())
+    expect(result.current).toBe(false)
+  })
+
+  test('returns false with session but flag off (AC-X6)', () => {
+    mockUseSession.mockReturnValue({hasSession: true})
+    mockFeaturesEnabled.mockReturnValue(false)
+    const {result} = renderHook(() => useStreaksAndRecapEnabled())
+    expect(result.current).toBe(false)
+  })
+
+  test('returns true only when session and flag are both on', () => {
+    mockUseSession.mockReturnValue({hasSession: true})
+    mockFeaturesEnabled.mockReturnValue(true)
+    const {result} = renderHook(() => useStreaksAndRecapEnabled())
+    expect(result.current).toBe(true)
+    expect(mockFeaturesEnabled).toHaveBeenCalledWith('streaks_and_recap:enable')
+  })
+})

--- a/src/features/activityAndRecap/__tests__/weeklyRecap.query.test.ts
+++ b/src/features/activityAndRecap/__tests__/weeklyRecap.query.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Unit tests for `computeWeeklyRecap` (the pure core of the weeklyRecap
+ * TanStack query). We exercise:
+ *   - getAuthorFeed pagination + R3 short-circuit (oldest predates window)
+ *   - WEEKLY_RECAP_MAX_PAGES hard cap
+ *   - own-author + in-window filtering
+ *   - top-post ranking + candidates list (B10)
+ *   - graceful follower-delta degrade when getProfile throws (R2)
+ *   - shape of the returned WeeklyRecap
+ */
+
+import {beforeEach, describe, expect, jest, test} from '@jest/globals'
+
+// Inline MMKV mock (required transitively via storage.ts -> readFollowerSnapshots).
+jest.mock('@bsky.app/react-native-mmkv', () => ({
+  MMKV: class MMKVMock {
+    _store = new Map<string, string>()
+    set(key: string, value: string) {
+      this._store.set(key, value)
+    }
+    getString(key: string) {
+      return this._store.get(key)
+    }
+    delete(key: string) {
+      this._store.delete(key)
+    }
+    addOnValueChangedListener(_cb: (key: string) => void) {
+      return {remove: () => {}}
+    }
+    clearAll() {
+      this._store.clear()
+    }
+  },
+}))
+
+// Stub the React hook modules so importing weeklyRecap.ts doesn't drag the
+// session / dialog / native module graph into the test bundle. We only test
+// the pure `computeWeeklyRecap` function here; useWeeklyRecapQuery is
+// covered by the integration suite in QA.
+jest.mock(
+  '#/features/activityAndRecap/hooks/useStreaksAndRecapEnabled',
+  () => ({
+    useStreaksAndRecapEnabled: () => false,
+  }),
+)
+jest.mock('#/features/activityAndRecap/hooks/useShowRecapPreference', () => ({
+  useShowRecapPreference: () => [false, () => {}],
+}))
+jest.mock('#/state/session', () => ({
+  useAgent: () => ({}),
+  useSession: () => ({currentAccount: undefined}),
+}))
+jest.mock('#/state/queries', () => ({
+  STALE: {HOURS: {ONE: 60 * 60 * 1000}},
+  GCTIME: {INFINITY: Infinity},
+}))
+
+import {
+  WEEKLY_RECAP_MAX_PAGES,
+  WEEKLY_RECAP_PAGE_LIMIT,
+} from '#/features/activityAndRecap/constants'
+import {computeWeeklyRecap} from '#/features/activityAndRecap/queries/weeklyRecap'
+import {upsertFollowerSnapshot} from '#/features/activityAndRecap/storage'
+
+const DID = 'did:plc:author'
+const ZONE = 'America/New_York'
+const WEEK = '2026-W15' // Mon Apr 6 — Sun Apr 12, 2026 (local)
+
+// Helpers ------------------------------------------------------------------
+function isoOnDay(year: number, month: number, day: number, hour = 12) {
+  return new Date(Date.UTC(year, month - 1, day, hour)).toISOString()
+}
+
+function postItem(opts: {
+  uri: string
+  cid: string
+  indexedAt: string
+  authorDid?: string
+  likeCount?: number
+  repostCount?: number
+  replyCount?: number
+}) {
+  return {
+    post: {
+      uri: opts.uri,
+      cid: opts.cid,
+      indexedAt: opts.indexedAt,
+      author: {did: opts.authorDid ?? DID},
+      likeCount: opts.likeCount ?? 0,
+      repostCount: opts.repostCount ?? 0,
+      replyCount: opts.replyCount ?? 0,
+    },
+  }
+}
+
+/**
+ * Build a fake AtpAgent with controllable getAuthorFeed pages and a
+ * configurable getProfile response.
+ */
+function makeAgent(opts: {
+  pages: Array<{feed: any[]; cursor?: string}>
+  followersCount?: number
+  profileThrows?: boolean
+}) {
+  const getAuthorFeed = jest.fn(async ({cursor: _cursor}: any) => {
+    const idx = getAuthorFeed.mock.calls.length - 1
+    const page = opts.pages[idx] ?? {feed: [], cursor: undefined}
+    return {data: page}
+  })
+  const getProfile = jest.fn(async () => {
+    if (opts.profileThrows) throw new Error('boom')
+    return {data: {followersCount: opts.followersCount ?? 0}}
+  })
+  return {
+    getAuthorFeed,
+    getProfile,
+    app: {
+      bsky: {
+        feed: {getAuthorFeed},
+        actor: {getProfile},
+      },
+    },
+  } as any
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+// Tests --------------------------------------------------------------------
+describe('computeWeeklyRecap', () => {
+  test('returns canonical empty shape when no posts at all', async () => {
+    const agent = makeAgent({
+      pages: [{feed: [], cursor: undefined}],
+      followersCount: 100,
+    })
+    const recap = await computeWeeklyRecap({
+      agent,
+      did: DID,
+      weekIso: WEEK,
+      zone: ZONE,
+      now: Date.UTC(2026, 3, 13, 12),
+    })
+    expect(recap.weekIso).toBe(WEEK)
+    expect(recap.postsCount).toBe(0)
+    expect(recap.topPost).toBeNull()
+    expect(recap.topPostCandidates).toEqual([])
+    expect(recap.followerDelta).toBe(0) // no prior snapshot in storage
+    expect(typeof recap.windowStart).toBe('string')
+    expect(typeof recap.windowEnd).toBe('string')
+  })
+
+  test('counts only own-author in-window posts and ranks topPost', async () => {
+    // Seed a start-of-window follower snapshot so the delta has a baseline.
+    // The synthesized "today" snapshot (count=105 below) lands at endDay
+    // when `now` is set to a Date inside the window.
+    upsertFollowerSnapshot(DID, {day: '2026-04-06', count: 100})
+
+    const agent = makeAgent({
+      pages: [
+        {
+          feed: [
+            // Three in-window own posts — the top one should be the second
+            // (3+1+0 = 4 engagement vs 1+0+0 = 1, 0+0+0 = 0).
+            postItem({
+              uri: 'at://x/1',
+              cid: 'b1',
+              indexedAt: isoOnDay(2026, 4, 7),
+              likeCount: 1,
+            }),
+            postItem({
+              uri: 'at://x/2',
+              cid: 'b2',
+              indexedAt: isoOnDay(2026, 4, 8),
+              likeCount: 3,
+              repostCount: 1,
+            }),
+            postItem({
+              uri: 'at://x/3',
+              cid: 'b3',
+              indexedAt: isoOnDay(2026, 4, 9),
+            }),
+            // Out-of-window — ignored.
+            postItem({
+              uri: 'at://x/old',
+              cid: 'bold',
+              indexedAt: isoOnDay(2026, 3, 30),
+            }),
+            // Other-author — ignored.
+            postItem({
+              uri: 'at://y/1',
+              cid: 'bo',
+              indexedAt: isoOnDay(2026, 4, 9),
+              authorDid: 'did:plc:other',
+            }),
+          ],
+          cursor: undefined,
+        },
+      ],
+      followersCount: 105,
+    })
+
+    const recap = await computeWeeklyRecap({
+      agent,
+      did: DID,
+      weekIso: WEEK,
+      zone: ZONE,
+      // Inside the window (Sun Apr 12 EDT local) so the synthesized
+      // "today" snapshot is at endDay and the delta resolves.
+      now: Date.UTC(2026, 3, 12, 16),
+    })
+    expect(recap.postsCount).toBe(3)
+    expect(recap.topPost).toEqual({uri: 'at://x/2', cid: 'b2'})
+    // All three in-window candidates should appear, ordered by score desc.
+    expect(recap.topPostCandidates).toEqual([
+      {uri: 'at://x/2', cid: 'b2'},
+      {uri: 'at://x/1', cid: 'b1'},
+      {uri: 'at://x/3', cid: 'b3'},
+    ])
+    expect(recap.followerDelta).toBe(5)
+  })
+
+  test('R3: short-circuits pagination when oldest item predates window', async () => {
+    const agent = makeAgent({
+      pages: [
+        {
+          feed: [
+            postItem({
+              uri: 'at://x/new',
+              cid: 'b',
+              indexedAt: isoOnDay(2026, 4, 8),
+            }),
+            // Tail item is BEFORE window → triggers short-circuit.
+            postItem({
+              uri: 'at://x/older',
+              cid: 'bo',
+              indexedAt: isoOnDay(2026, 3, 1),
+            }),
+          ],
+          cursor: 'next',
+        },
+        {feed: [], cursor: undefined},
+      ],
+      followersCount: 0,
+    })
+
+    await computeWeeklyRecap({
+      agent,
+      did: DID,
+      weekIso: WEEK,
+      zone: ZONE,
+      now: Date.UTC(2026, 3, 13, 12),
+    })
+    // Only first page should have been fetched.
+    expect(agent.getAuthorFeed).toHaveBeenCalledTimes(1)
+    expect(agent.getAuthorFeed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor: DID,
+        limit: WEEKLY_RECAP_PAGE_LIMIT,
+        filter: 'posts_with_replies',
+      }),
+    )
+  })
+
+  test('hard cap: never fetches more than WEEKLY_RECAP_MAX_PAGES', async () => {
+    // Every page returns items still inside the window (so the R3
+    // short-circuit never trips) and a non-empty cursor.
+    const pages = Array.from({length: WEEKLY_RECAP_MAX_PAGES + 3}, (_, i) => ({
+      feed: [
+        postItem({
+          uri: `at://x/p${i}`,
+          cid: `b${i}`,
+          indexedAt: isoOnDay(2026, 4, 8),
+        }),
+      ],
+      cursor: `c${i}`,
+    }))
+    const agent = makeAgent({pages, followersCount: 0})
+
+    await computeWeeklyRecap({
+      agent,
+      did: DID,
+      weekIso: WEEK,
+      zone: ZONE,
+      now: Date.UTC(2026, 3, 13, 12),
+    })
+    expect(agent.getAuthorFeed).toHaveBeenCalledTimes(WEEKLY_RECAP_MAX_PAGES)
+  })
+
+  test('R2: degrades to followerDelta=0 when getProfile throws', async () => {
+    const agent = makeAgent({
+      pages: [{feed: [], cursor: undefined}],
+      profileThrows: true,
+    })
+    const recap = await computeWeeklyRecap({
+      agent,
+      did: DID,
+      weekIso: WEEK,
+      zone: ZONE,
+      now: Date.UTC(2026, 3, 13, 12),
+    })
+    expect(recap.followerDelta).toBe(0)
+    // Still produced a valid recap shape.
+    expect(recap.weekIso).toBe(WEEK)
+  })
+
+  test('throws on malformed weekIso', async () => {
+    const agent = makeAgent({pages: [{feed: [], cursor: undefined}]})
+    await expect(
+      computeWeeklyRecap({
+        agent,
+        did: DID,
+        weekIso: 'not-a-week',
+        zone: ZONE,
+      }),
+    ).rejects.toThrow(/invalid weekIso/)
+  })
+
+  test('topPost is null but candidates empty when only out-of-window own posts exist', async () => {
+    const agent = makeAgent({
+      pages: [
+        {
+          feed: [
+            postItem({
+              uri: 'at://x/old',
+              cid: 'b',
+              indexedAt: isoOnDay(2026, 3, 30),
+            }),
+          ],
+          cursor: undefined,
+        },
+      ],
+    })
+    const recap = await computeWeeklyRecap({
+      agent,
+      did: DID,
+      weekIso: WEEK,
+      zone: ZONE,
+      now: Date.UTC(2026, 3, 13, 12),
+    })
+    expect(recap.postsCount).toBe(0)
+    expect(recap.topPost).toBeNull()
+    expect(recap.topPostCandidates).toEqual([])
+  })
+})

--- a/src/features/activityAndRecap/analytics/events.ts
+++ b/src/features/activityAndRecap/analytics/events.ts
@@ -1,0 +1,70 @@
+/**
+ * Typed analytics event builders for Activity & Recap (AC-B12).
+ *
+ * Payloads carry BOOLEANS ONLY — no counts, no URIs. This is a product
+ * guardrail (B12): we use these to size the KPI dashboard without ever
+ * leaking engagement numbers off-device.
+ *
+ * Usage:
+ *   const ax = useAnalytics()
+ *   ax.metric(...recapCardShown({postsCount, followerDelta, topPost}))
+ */
+
+import {type WeeklyRecap} from '#/features/activityAndRecap/types'
+
+export function streakIndicatorShown(
+  has_streak: boolean,
+): ['streak:indicatorShown', {has_streak: boolean}] {
+  return ['streak:indicatorShown', {has_streak}]
+}
+
+export function streakExplainerOpened(): ['streak:explainerOpened', {}] {
+  return ['streak:explainerOpened', {}]
+}
+
+export function streakOptIn(): ['streak:optIn', {}] {
+  return ['streak:optIn', {}]
+}
+
+export function streakOptOut(): ['streak:optOut', {}] {
+  return ['streak:optOut', {}]
+}
+
+export type RecapBooleans = {
+  has_posts: boolean
+  has_top_post: boolean
+  has_follower_delta: boolean
+}
+
+/**
+ * Build a recap:cardShown payload from the full recap object, stripping
+ * all numeric metrics down to booleans. Per B12.
+ */
+export function recapCardShown(
+  recap: Pick<WeeklyRecap, 'postsCount' | 'followerDelta' | 'topPost'>,
+): ['recap:cardShown', RecapBooleans] {
+  return [
+    'recap:cardShown',
+    {
+      has_posts: (recap.postsCount ?? 0) > 0,
+      has_top_post: recap.topPost != null,
+      has_follower_delta: (recap.followerDelta ?? 0) > 0,
+    },
+  ]
+}
+
+export function recapCardTapped(): ['recap:cardTapped', {}] {
+  return ['recap:cardTapped', {}]
+}
+
+export function recapCardDismissed(): ['recap:cardDismissed', {}] {
+  return ['recap:cardDismissed', {}]
+}
+
+export function recapOptIn(): ['recap:optIn', {}] {
+  return ['recap:optIn', {}]
+}
+
+export function recapOptOut(): ['recap:optOut', {}] {
+  return ['recap:optOut', {}]
+}

--- a/src/features/activityAndRecap/clearActivityAndRecapDataForDid.ts
+++ b/src/features/activityAndRecap/clearActivityAndRecapDataForDid.ts
@@ -1,0 +1,13 @@
+/**
+ * Account-removal cleanup hook for Activity & Recap (AC-A10).
+ *
+ * Called by `removeAccount` in `src/state/session/index.tsx` alongside
+ * `clearAgeAssuranceDataForDid`. Thin wrapper around `storage.clearAllForDid`
+ * so the session file only depends on a single exported function from the
+ * feature module.
+ */
+import {clearAllForDid} from '#/features/activityAndRecap/storage'
+
+export function clearActivityAndRecapDataForDid({did}: {did: string}): void {
+  clearAllForDid(did)
+}

--- a/src/features/activityAndRecap/components/RecapMetricTile/index.tsx
+++ b/src/features/activityAndRecap/components/RecapMetricTile/index.tsx
@@ -1,0 +1,49 @@
+/**
+ * RecapMetricTile (S13/S15) — small labeled metric block used by both the
+ * compact `WeeklyRecapCard` (Notifications header) and the full-screen
+ * `RecapScreen`. Renders a label + value + optional sublabel; static atoms
+ * only, theme tokens for color. No animation, no haptic (B9, G3 spirit).
+ *
+ * Renders a "value" as a string so the caller decides
+ * pluralization/formatting — this keeps Lingui calls at the call site.
+ */
+
+import {View} from 'react-native'
+
+import {atoms as a, useTheme} from '#/alf'
+import {Text} from '#/components/Typography'
+
+export function RecapMetricTile({
+  label,
+  value,
+  sublabel,
+  testID,
+}: {
+  label: string
+  value: string
+  sublabel?: string
+  testID?: string
+}) {
+  const t = useTheme()
+  return (
+    <View
+      testID={testID}
+      style={[
+        a.flex_1,
+        a.p_md,
+        a.rounded_md,
+        a.gap_2xs,
+        t.atoms.bg_contrast_25,
+      ]}>
+      <Text style={[a.text_xs, a.font_bold, t.atoms.text_contrast_medium]}>
+        {label}
+      </Text>
+      <Text style={[a.text_2xl, a.font_bold, t.atoms.text]}>{value}</Text>
+      {sublabel ? (
+        <Text style={[a.text_xs, t.atoms.text_contrast_medium]}>
+          {sublabel}
+        </Text>
+      ) : null}
+    </View>
+  )
+}

--- a/src/features/activityAndRecap/components/StreakExplainerDialog/index.tsx
+++ b/src/features/activityAndRecap/components/StreakExplainerDialog/index.tsx
@@ -1,0 +1,115 @@
+/**
+ * StreakExplainerDialog (S10).
+ *
+ * Shared bottom-sheet (native) / modal (web) implementation via
+ * `#/components/Dialog`. Renders currentStreak, longestStreak, the rule
+ * sheet, and a grace-day note (only when graceUsedForCurrentStreak is
+ * true — G2). The "Open Settings" link uses the dialog-close callback
+ * pattern (CLAUDE.md footgun) before navigating.
+ *
+ * No share CTA (A8, G5).
+ */
+
+import React from 'react'
+import {View} from 'react-native'
+import {msg, plural} from '@lingui/core/macro'
+import {useLingui} from '@lingui/react'
+import {Trans} from '@lingui/react/macro'
+import {useNavigation} from '@react-navigation/native'
+
+import {type NavigationProp} from '#/lib/routes/types'
+import {atoms as a, useTheme} from '#/alf'
+import {Button, ButtonText} from '#/components/Button'
+import * as Dialog from '#/components/Dialog'
+import {Text} from '#/components/Typography'
+import {useStreakStore} from '#/features/activityAndRecap/hooks/useStreakStore'
+
+/**
+ * Re-export Dialog.useDialogControl as a named hook so the rest of the
+ * feature has a single import surface for the explainer's control.
+ */
+export const useStreakExplainerControl = Dialog.useDialogControl
+
+export function StreakExplainerDialog({
+  control,
+}: {
+  control: Dialog.DialogControlProps
+}): React.ReactElement {
+  return (
+    <Dialog.Outer control={control}>
+      <Dialog.Handle />
+      <StreakExplainerInner control={control} />
+    </Dialog.Outer>
+  )
+}
+
+function StreakExplainerInner({
+  control,
+}: {
+  control: Dialog.DialogControlProps
+}): React.ReactElement {
+  const t = useTheme()
+  const {_} = useLingui()
+  const store = useStreakStore()
+  const navigation = useNavigation<NavigationProp>()
+
+  const current = store?.currentStreak ?? 0
+  const longest = store?.longestStreak ?? 0
+  const graced = !!store?.graceUsedForCurrentStreak
+
+  const onSettingsPress = () => {
+    // CLAUDE.md footgun: dialog close callback BEFORE navigation.
+    control.close(() => {
+      navigation.navigate('ActivityAndRecap')
+    })
+  }
+
+  return (
+    <Dialog.ScrollableInner label={_(msg`Streak explainer`)}>
+      <Dialog.Header>
+        <Dialog.HeaderText>
+          <Trans>Your Bluesky streak</Trans>
+        </Dialog.HeaderText>
+      </Dialog.Header>
+
+      <View style={[a.gap_md, a.pt_sm]}>
+        <Text style={[a.text_lg, a.font_bold, t.atoms.text]}>
+          {_(
+            msg`${plural(current, {one: '# day', other: '# days'})} current streak`,
+          )}
+        </Text>
+
+        <Text style={[a.text_md, t.atoms.text_contrast_medium]}>
+          {_(msg`Longest: ${plural(longest, {one: '# day', other: '# days'})}`)}
+        </Text>
+
+        <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+          <Trans>
+            Visit Bluesky once a day to keep your streak going. Miss a single
+            day and we'll quietly forgive it once per streak.
+          </Trans>
+        </Text>
+
+        {graced && (
+          <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+            <Trans>
+              You used your grace day for this streak — try not to miss another!
+            </Trans>
+          </Text>
+        )}
+
+        <Button
+          label={_(msg`Open Activity & Recap settings`)}
+          color="secondary"
+          size="small"
+          onPress={onSettingsPress}>
+          <ButtonText>
+            <Trans>Open settings</Trans>
+          </ButtonText>
+        </Button>
+      </View>
+
+      <Dialog.Close />
+    </Dialog.ScrollableInner>
+  )
+}

--- a/src/features/activityAndRecap/components/StreakIndicator/index.tsx
+++ b/src/features/activityAndRecap/components/StreakIndicator/index.tsx
@@ -1,0 +1,70 @@
+/**
+ * StreakIndicator (native) — flame + integer in the Home header right slot.
+ *
+ * Visibility is gated (in this exact order) on:
+ *   1. useStreaksAndRecapEnabled() (A7, X6)
+ *   2. hasSession (A7)
+ *   3. showStreak preference (X1)
+ *   4. currentStreak >= STREAK_INDICATOR_MIN (A4, G4)
+ *
+ * Pressing opens the StreakExplainerDialog (S10). No animation, no haptic,
+ * no sound (G3). Layout-only. Mounted from HomeHeaderLayoutMobile (S18).
+ */
+
+import React from 'react'
+import {Pressable} from 'react-native'
+import {msg, plural} from '@lingui/core/macro'
+import {useLingui} from '@lingui/react'
+
+import {atoms as a, useTheme} from '#/alf'
+import {Flame_Stroke2_Corner1_Rounded as FlameIcon} from '#/components/icons/Flame'
+import {Text} from '#/components/Typography'
+import {useStreakExplainerControl} from '#/features/activityAndRecap/components/StreakExplainerDialog'
+import {STREAK_INDICATOR_MIN} from '#/features/activityAndRecap/constants'
+import {useShowStreakPreference} from '#/features/activityAndRecap/hooks/useShowStreakPreference'
+import {useStreaksAndRecapEnabled} from '#/features/activityAndRecap/hooks/useStreaksAndRecapEnabled'
+import {useStreakStore} from '#/features/activityAndRecap/hooks/useStreakStore'
+
+export function StreakIndicator(): React.ReactElement | null {
+  const featureOn = useStreaksAndRecapEnabled()
+  // Hard early-return BEFORE any storage / preference reads (X6).
+  if (!featureOn) return null
+  return <StreakIndicatorInner />
+}
+
+function StreakIndicatorInner(): React.ReactElement | null {
+  const t = useTheme()
+  const {_} = useLingui()
+  const [showStreak] = useShowStreakPreference()
+  const store = useStreakStore()
+  const control = useStreakExplainerControl()
+
+  if (!showStreak) return null
+  if (!store) return null
+  const streak = store.currentStreak
+  if (streak < STREAK_INDICATOR_MIN) return null
+
+  const label = _(
+    msg`${plural(streak, {one: '# day', other: '# days'})} Bluesky streak`,
+  )
+
+  return (
+    <Pressable
+      testID="streakIndicator"
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityHint={_(msg`Opens the streak explainer`)}
+      onPress={() => control.open()}
+      style={[
+        a.flex_row,
+        a.align_center,
+        a.gap_xs,
+        a.px_xs,
+        a.py_2xs,
+        a.rounded_full,
+      ]}>
+      <FlameIcon width={18} fill={t.atoms.text.color} />
+      <Text style={[a.text_md, a.font_bold, t.atoms.text]}>{streak}</Text>
+    </Pressable>
+  )
+}

--- a/src/features/activityAndRecap/components/StreakIndicator/index.tsx
+++ b/src/features/activityAndRecap/components/StreakIndicator/index.tsx
@@ -12,14 +12,17 @@
  */
 
 import React from 'react'
-import {Pressable} from 'react-native'
+import {Pressable, View} from 'react-native'
 import {msg, plural} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 
 import {atoms as a, useTheme} from '#/alf'
 import {Flame_Stroke2_Corner1_Rounded as FlameIcon} from '#/components/icons/Flame'
 import {Text} from '#/components/Typography'
-import {useStreakExplainerControl} from '#/features/activityAndRecap/components/StreakExplainerDialog'
+import {
+  StreakExplainerDialog,
+  useStreakExplainerControl,
+} from '#/features/activityAndRecap/components/StreakExplainerDialog'
 import {STREAK_INDICATOR_MIN} from '#/features/activityAndRecap/constants'
 import {useShowStreakPreference} from '#/features/activityAndRecap/hooks/useShowStreakPreference'
 import {useStreaksAndRecapEnabled} from '#/features/activityAndRecap/hooks/useStreaksAndRecapEnabled'
@@ -49,22 +52,25 @@ function StreakIndicatorInner(): React.ReactElement | null {
   )
 
   return (
-    <Pressable
-      testID="streakIndicator"
-      accessibilityRole="button"
-      accessibilityLabel={label}
-      accessibilityHint={_(msg`Opens the streak explainer`)}
-      onPress={() => control.open()}
-      style={[
-        a.flex_row,
-        a.align_center,
-        a.gap_xs,
-        a.px_xs,
-        a.py_2xs,
-        a.rounded_full,
-      ]}>
-      <FlameIcon width={18} fill={t.atoms.text.color} />
-      <Text style={[a.text_md, a.font_bold, t.atoms.text]}>{streak}</Text>
-    </Pressable>
+    <View>
+      <Pressable
+        testID="streakIndicator"
+        accessibilityRole="button"
+        accessibilityLabel={label}
+        accessibilityHint={_(msg`Opens the streak explainer`)}
+        onPress={() => control.open()}
+        style={[
+          a.flex_row,
+          a.align_center,
+          a.gap_xs,
+          a.px_xs,
+          a.py_2xs,
+          a.rounded_full,
+        ]}>
+        <FlameIcon width={18} fill={t.atoms.text.color} />
+        <Text style={[a.text_md, a.font_bold, t.atoms.text]}>{streak}</Text>
+      </Pressable>
+      <StreakExplainerDialog control={control} />
+    </View>
   )
 }

--- a/src/features/activityAndRecap/components/StreakIndicator/index.web.tsx
+++ b/src/features/activityAndRecap/components/StreakIndicator/index.web.tsx
@@ -1,0 +1,65 @@
+/**
+ * StreakIndicator (web).
+ *
+ * Same atoms as the native variant; uses a button-shaped Pressable for the
+ * desktop/tablet header row. Visibility gates and accessibility label
+ * are identical to the native variant — see ./index.tsx for the contract.
+ */
+
+import React from 'react'
+import {Pressable} from 'react-native'
+import {msg, plural} from '@lingui/core/macro'
+import {useLingui} from '@lingui/react'
+
+import {atoms as a, useTheme, web} from '#/alf'
+import {Flame_Stroke2_Corner1_Rounded as FlameIcon} from '#/components/icons/Flame'
+import {Text} from '#/components/Typography'
+import {useStreakExplainerControl} from '#/features/activityAndRecap/components/StreakExplainerDialog'
+import {STREAK_INDICATOR_MIN} from '#/features/activityAndRecap/constants'
+import {useShowStreakPreference} from '#/features/activityAndRecap/hooks/useShowStreakPreference'
+import {useStreaksAndRecapEnabled} from '#/features/activityAndRecap/hooks/useStreaksAndRecapEnabled'
+import {useStreakStore} from '#/features/activityAndRecap/hooks/useStreakStore'
+
+export function StreakIndicator(): React.ReactElement | null {
+  const featureOn = useStreaksAndRecapEnabled()
+  if (!featureOn) return null
+  return <StreakIndicatorInner />
+}
+
+function StreakIndicatorInner(): React.ReactElement | null {
+  const t = useTheme()
+  const {_} = useLingui()
+  const [showStreak] = useShowStreakPreference()
+  const store = useStreakStore()
+  const control = useStreakExplainerControl()
+
+  if (!showStreak) return null
+  if (!store) return null
+  const streak = store.currentStreak
+  if (streak < STREAK_INDICATOR_MIN) return null
+
+  const label = _(
+    msg`${plural(streak, {one: '# day', other: '# days'})} Bluesky streak`,
+  )
+
+  return (
+    <Pressable
+      testID="streakIndicator"
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityHint={_(msg`Opens the streak explainer`)}
+      onPress={() => control.open()}
+      style={[
+        a.flex_row,
+        a.align_center,
+        a.gap_xs,
+        a.px_sm,
+        a.py_2xs,
+        a.rounded_full,
+        web({cursor: 'pointer'}),
+      ]}>
+      <FlameIcon width={18} fill={t.atoms.text.color} />
+      <Text style={[a.text_md, a.font_bold, t.atoms.text]}>{streak}</Text>
+    </Pressable>
+  )
+}

--- a/src/features/activityAndRecap/components/StreakIndicator/index.web.tsx
+++ b/src/features/activityAndRecap/components/StreakIndicator/index.web.tsx
@@ -7,14 +7,17 @@
  */
 
 import React from 'react'
-import {Pressable} from 'react-native'
+import {Pressable, View} from 'react-native'
 import {msg, plural} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 
 import {atoms as a, useTheme, web} from '#/alf'
 import {Flame_Stroke2_Corner1_Rounded as FlameIcon} from '#/components/icons/Flame'
 import {Text} from '#/components/Typography'
-import {useStreakExplainerControl} from '#/features/activityAndRecap/components/StreakExplainerDialog'
+import {
+  StreakExplainerDialog,
+  useStreakExplainerControl,
+} from '#/features/activityAndRecap/components/StreakExplainerDialog'
 import {STREAK_INDICATOR_MIN} from '#/features/activityAndRecap/constants'
 import {useShowStreakPreference} from '#/features/activityAndRecap/hooks/useShowStreakPreference'
 import {useStreaksAndRecapEnabled} from '#/features/activityAndRecap/hooks/useStreaksAndRecapEnabled'
@@ -43,23 +46,26 @@ function StreakIndicatorInner(): React.ReactElement | null {
   )
 
   return (
-    <Pressable
-      testID="streakIndicator"
-      accessibilityRole="button"
-      accessibilityLabel={label}
-      accessibilityHint={_(msg`Opens the streak explainer`)}
-      onPress={() => control.open()}
-      style={[
-        a.flex_row,
-        a.align_center,
-        a.gap_xs,
-        a.px_sm,
-        a.py_2xs,
-        a.rounded_full,
-        web({cursor: 'pointer'}),
-      ]}>
-      <FlameIcon width={18} fill={t.atoms.text.color} />
-      <Text style={[a.text_md, a.font_bold, t.atoms.text]}>{streak}</Text>
-    </Pressable>
+    <View>
+      <Pressable
+        testID="streakIndicator"
+        accessibilityRole="button"
+        accessibilityLabel={label}
+        accessibilityHint={_(msg`Opens the streak explainer`)}
+        onPress={() => control.open()}
+        style={[
+          a.flex_row,
+          a.align_center,
+          a.gap_xs,
+          a.px_sm,
+          a.py_2xs,
+          a.rounded_full,
+          web({cursor: 'pointer'}),
+        ]}>
+        <FlameIcon width={18} fill={t.atoms.text.color} />
+        <Text style={[a.text_md, a.font_bold, t.atoms.text]}>{streak}</Text>
+      </Pressable>
+      <StreakExplainerDialog control={control} />
+    </View>
   )
 }

--- a/src/features/activityAndRecap/components/WeeklyRecapCard/index.tsx
+++ b/src/features/activityAndRecap/components/WeeklyRecapCard/index.tsx
@@ -1,0 +1,193 @@
+/**
+ * WeeklyRecapCard (S13) — compact dismissible card mounted in the
+ * Notifications header (S19).
+ *
+ * Behavior:
+ *   - Visibility resolved by useRecapCardVisibility (B1, B5, B6, G7). When
+ *     null, the card returns null (no XRPC, no render).
+ *   - Renders three preview lines: posts count, follower delta, top post.
+ *     Zero-posts copy is the EXACT string from RECAP_ZERO_POSTS_COPY (B4).
+ *   - Tap navigates to the Recap route with weekId (B3).
+ *   - Dedicated focusable dismiss button (a11y, B9). Dismiss callback writes
+ *     to account MMKV via useDismissRecapCard.
+ *   - Stamps firstShownAt on first render (B6 anchor).
+ *   - Fires recap:cardShown / recap:cardTapped / recap:cardDismissed
+ *     analytics with booleans-only payloads (B12).
+ *   - opacity-only transition gated on useReducedMotion (B9).
+ *
+ * The card NEVER reads `useWeeklyRecapQuery` itself when invisible (B11).
+ */
+
+import React from 'react'
+import {Pressable, View} from 'react-native'
+import {useReducedMotion} from 'react-native-reanimated'
+import {msg, plural} from '@lingui/core/macro'
+import {useLingui} from '@lingui/react'
+import {Trans} from '@lingui/react/macro'
+import {useNavigation} from '@react-navigation/native'
+
+import {type NavigationProp} from '#/lib/routes/types'
+import {useSession} from '#/state/session'
+import {atoms as a, useTheme, web} from '#/alf'
+import {Button, ButtonIcon} from '#/components/Button'
+import {TimesLarge_Stroke2_Corner0_Rounded as TimesIcon} from '#/components/icons/Times'
+import {Text} from '#/components/Typography'
+import {useAnalytics} from '#/analytics'
+import {
+  recapCardDismissed,
+  recapCardShown,
+  recapCardTapped,
+} from '#/features/activityAndRecap/analytics/events'
+import {RecapMetricTile} from '#/features/activityAndRecap/components/RecapMetricTile'
+import {RECAP_ZERO_POSTS_COPY} from '#/features/activityAndRecap/constants'
+import {useDismissRecapCard} from '#/features/activityAndRecap/hooks/useDismissRecapCard'
+import {useRecapCardVisibility} from '#/features/activityAndRecap/hooks/useRecapCardVisibility'
+import {useWeeklyRecapQuery} from '#/features/activityAndRecap/queries/weeklyRecap'
+import {markRecapCardFirstShown} from '#/features/activityAndRecap/storage'
+
+export function WeeklyRecapCard(): React.ReactElement | null {
+  const weekIso = useRecapCardVisibility()
+  // Hard early-return BEFORE any XRPC/storage reads (B11, X6).
+  if (!weekIso) return null
+  return <WeeklyRecapCardInner weekIso={weekIso} />
+}
+
+function WeeklyRecapCardInner({
+  weekIso,
+}: {
+  weekIso: string
+}): React.ReactElement | null {
+  const t = useTheme()
+  const {_} = useLingui()
+  const ax = useAnalytics()
+  const navigation = useNavigation<NavigationProp>()
+  const {currentAccount} = useSession()
+  const dismiss = useDismissRecapCard()
+  const reducedMotion = useReducedMotion()
+  const did = currentAccount?.did
+
+  const {data, isLoading, isError} = useWeeklyRecapQuery({weekIso})
+
+  // B6: stamp firstShownAt on first paint so the 7-day expiry anchor begins
+  // even before the user interacts. We only need this once per (did,weekIso).
+  const stampedRef = React.useRef(false)
+  React.useEffect(() => {
+    if (stampedRef.current) return
+    if (!did) return
+    stampedRef.current = true
+    markRecapCardFirstShown(did, weekIso, Date.now())
+  }, [did, weekIso])
+
+  // B12: emit recap:cardShown ONCE on first successful load (booleans only).
+  const shownEmittedRef = React.useRef(false)
+  React.useEffect(() => {
+    if (shownEmittedRef.current) return
+    if (!data) return
+    shownEmittedRef.current = true
+    ax.metric(...recapCardShown(data))
+  }, [ax, data])
+
+  if (isLoading) {
+    // Render a low-noise placeholder so the slot doesn't pop when data lands.
+    return (
+      <View
+        testID="weeklyRecapCard"
+        style={[
+          a.p_md,
+          a.mx_md,
+          a.my_sm,
+          a.rounded_md,
+          t.atoms.bg_contrast_25,
+        ]}>
+        <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+          <Trans>Loading your week on Bluesky…</Trans>
+        </Text>
+      </View>
+    )
+  }
+
+  // R3 / B8: surface as silent if errored — manual retry lives on RecapScreen.
+  if (isError || !data) return null
+
+  const onTap = () => {
+    ax.metric(...recapCardTapped())
+    navigation.navigate('Recap', {weekId: weekIso})
+  }
+
+  const onDismiss = () => {
+    ax.metric(...recapCardDismissed())
+    dismiss(weekIso)
+  }
+
+  const postsLabel = _(
+    msg`${plural(data.postsCount, {one: '# post', other: '# posts'})}`,
+  )
+  const followersLabel = _(
+    msg`${plural(data.followerDelta, {
+      one: '# new follower',
+      other: '# new followers',
+    })}`,
+  )
+  const opacityStyle = reducedMotion ? null : web({transition: 'opacity 200ms'})
+
+  return (
+    <Pressable
+      testID="weeklyRecapCard"
+      accessibilityRole="button"
+      accessibilityLabel={_(msg`Your week on Bluesky`)}
+      accessibilityHint={_(msg`Opens this week's recap`)}
+      onPress={onTap}
+      style={[
+        a.p_md,
+        a.mx_md,
+        a.my_sm,
+        a.rounded_md,
+        a.gap_sm,
+        t.atoms.bg_contrast_25,
+        opacityStyle,
+      ]}>
+      <View style={[a.flex_row, a.align_center, a.justify_between]}>
+        <Text style={[a.text_md, a.font_bold, t.atoms.text]}>
+          <Trans>Your week on Bluesky</Trans>
+        </Text>
+        <Button
+          label={_(msg`Dismiss recap`)}
+          size="tiny"
+          color="secondary"
+          shape="round"
+          onPress={onDismiss}>
+          <ButtonIcon icon={TimesIcon} />
+        </Button>
+      </View>
+
+      {data.postsCount === 0 ? (
+        <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+          {/*
+            B4: zero-posts copy MUST be exactly RECAP_ZERO_POSTS_COPY.
+            We pass it through Lingui's `_` so it still gets translated, but
+            the source string is the literal constant.
+          */}
+          {_(msg`${RECAP_ZERO_POSTS_COPY}`)}
+        </Text>
+      ) : (
+        <View style={[a.flex_row, a.gap_sm]}>
+          <RecapMetricTile
+            testID="weeklyRecapCard-posts"
+            label={_(msg`Posts`)}
+            value={postsLabel}
+          />
+          <RecapMetricTile
+            testID="weeklyRecapCard-followers"
+            label={_(msg`Followers`)}
+            value={followersLabel}
+          />
+          <RecapMetricTile
+            testID="weeklyRecapCard-topPost"
+            label={_(msg`Top post`)}
+            value={data.topPost ? _(msg`Tap to view`) : _(msg`—`)}
+          />
+        </View>
+      )}
+    </Pressable>
+  )
+}

--- a/src/features/activityAndRecap/constants.ts
+++ b/src/features/activityAndRecap/constants.ts
@@ -1,0 +1,53 @@
+/**
+ * Tuning knobs for the Activity & Recap feature. Consolidated so product
+ * can reason about all bounds/limits in one place.
+ */
+
+/** Ring-buffer cap for daily follower snapshots (~5 weeks). */
+export const MAX_FOLLOWER_SNAPSHOTS = 35
+
+/** Cap on persisted dismissed weekIds. */
+export const MAX_DISMISSED_RECAP_WEEKS = 8
+
+/**
+ * UTC monotonic guard: block streak increment unless at least 20h have
+ * passed since the last recorded visit. Prevents "tz hop to increment"
+ * abuse. (A5)
+ */
+export const STREAK_UTC_MONOTONIC_GUARD_MS = 20 * 60 * 60 * 1000
+
+/**
+ * Contiguous foreground dwell required to qualify as a "visit". Default
+ * per ambiguity Q_A1_dwell: contiguous, not cumulative. (A1)
+ */
+export const STREAK_QUALIFYING_DWELL_MS = 30 * 1000
+
+/** Streak indicator hides below this value. (A4, G4) */
+export const STREAK_INDICATOR_MIN = 2
+
+/** Recap card auto-hides this long after first render. (B6) */
+export const RECAP_CARD_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+
+/** Recap card becomes available at or after this local time on Monday. (B1) */
+export const RECAP_CARD_MONDAY_SHOW_HOUR_LOCAL = 6
+
+/** Past recaps surfaces this many prior ISO weeks. (B5) */
+export const PAST_RECAPS_WINDOW = 4
+
+/** Hard cap on getAuthorFeed pagination for the weekly recap. (R3) */
+export const WEEKLY_RECAP_MAX_PAGES = 6
+
+/** Page size for getAuthorFeed. */
+export const WEEKLY_RECAP_PAGE_LIMIT = 50
+
+/** Auto-retry budget per weekIso per wall-clock hour. (B8) */
+export const WEEKLY_RECAP_AUTO_RETRY_BUDGET = 2
+
+/** Budget window size. (B8) */
+export const WEEKLY_RECAP_AUTO_RETRY_WINDOW_MS = 60 * 60 * 1000
+
+/**
+ * Zero-posts copy for the recap. EXACT STRING per B4 — do not reword.
+ * Used directly as a translation source message.
+ */
+export const RECAP_ZERO_POSTS_COPY = 'No posts this week — that’s fine.'

--- a/src/features/activityAndRecap/hooks/useDismissRecapCard.ts
+++ b/src/features/activityAndRecap/hooks/useDismissRecapCard.ts
@@ -1,0 +1,31 @@
+/**
+ * useDismissRecapCard (S12) — returns a stable callback that records the
+ * user's dismissal of a weekIso into account-scoped MMKV (B5).
+ *
+ * Also stamps `firstShownAt` on first call when missing (B6) so the auto-
+ * expiry window can begin even if the dismissal precedes any other render
+ * marking.
+ */
+
+import {useCallback} from 'react'
+
+import {useSession} from '#/state/session'
+import {
+  dismissRecapWeek,
+  markRecapCardFirstShown,
+} from '#/features/activityAndRecap/storage'
+
+export function useDismissRecapCard(): (weekIso: string) => void {
+  const {currentAccount} = useSession()
+  const did = currentAccount?.did
+  return useCallback(
+    (weekIso: string) => {
+      if (!did) return
+      // Stamp firstShownAt if the user dismissed before any render mark
+      // (defensive — the card normally stamps it on first paint).
+      markRecapCardFirstShown(did, weekIso, Date.now())
+      dismissRecapWeek(did, weekIso)
+    },
+    [did],
+  )
+}

--- a/src/features/activityAndRecap/hooks/useRecapCardVisibility.ts
+++ b/src/features/activityAndRecap/hooks/useRecapCardVisibility.ts
@@ -1,0 +1,109 @@
+/**
+ * useRecapCardVisibility (S12) — orchestrates whether the WeeklyRecapCard
+ * should mount on the Notifications header slot.
+ *
+ * Predicate (all must be true):
+ *   - useStreaksAndRecapEnabled() (X6)
+ *   - hasSession (A7)
+ *   - showRecap preference (X1)
+ *   - prior week had a qualifying visit (G7) — heuristic: streak store
+ *     `lastVisitDay` falls within the prior ISO week
+ *   - !dismissed[weekIso] (B5)
+ *   - firstShownAt == null OR (now - firstShownAt) < RECAP_CARD_MAX_AGE_MS (B6)
+ *   - now >= Monday RECAP_CARD_MONDAY_SHOW_HOUR_LOCAL (B1)
+ *
+ * Returns the resolved weekIso when visible (so the card can pass it
+ * straight to `useWeeklyRecapQuery`); null when hidden.
+ */
+
+import {useSession} from '#/state/session'
+import {
+  RECAP_CARD_MAX_AGE_MS,
+  RECAP_CARD_MONDAY_SHOW_HOUR_LOCAL,
+} from '#/features/activityAndRecap/constants'
+import {useShowRecapPreference} from '#/features/activityAndRecap/hooks/useShowRecapPreference'
+import {useStreaksAndRecapEnabled} from '#/features/activityAndRecap/hooks/useStreaksAndRecapEnabled'
+import {useStreakStore} from '#/features/activityAndRecap/hooks/useStreakStore'
+import {
+  priorWeekIso,
+  weekWindowForIso,
+} from '#/features/activityAndRecap/reducer/isoWeek'
+import {
+  getRecapCardFirstShown,
+  isRecapWeekDismissed,
+} from '#/features/activityAndRecap/storage'
+
+/**
+ * Returns the prior weekIso when the card should be visible, otherwise null.
+ *
+ * Pure(-ish): only reads MMKV via the storage helpers; never writes. The
+ * `now` parameter is injectable for tests.
+ */
+export function useRecapCardVisibility(now: Date = new Date()): string | null {
+  const featureOn = useStreaksAndRecapEnabled()
+  const {hasSession, currentAccount} = useSession()
+  const [showRecap] = useShowRecapPreference()
+  const streak = useStreakStore()
+
+  if (!featureOn) return null
+  if (!hasSession) return null
+  if (!showRecap) return null
+  const did = currentAccount?.did
+  if (!did) return null
+
+  // B1: card surfaces only on or after Monday 06:00 local.
+  if (!isAfterMondaySurfaceHour(now)) return null
+
+  const weekIso = priorWeekIso(now)
+  const window = weekWindowForIso(weekIso)
+  if (!window) return null
+
+  // G7: don't surface for users with zero qualifying visits in the prior
+  // week. Heuristic: lastVisitDay must fall within the window. We avoid
+  // over-counting by treating an absent streak store as "no visit".
+  if (!streak) return null
+  const lastVisitMs = parseDayString(streak.lastVisitDay)
+  if (lastVisitMs == null) return null
+  if (
+    lastVisitMs < window.start.getTime() ||
+    lastVisitMs > window.end.getTime() + 24 * 60 * 60 * 1000
+  ) {
+    return null
+  }
+
+  // B5: respect user's dismissal for this weekIso.
+  if (isRecapWeekDismissed(did, weekIso)) return null
+
+  // B6: auto-hide after 7d from firstShownAt.
+  const firstShown = getRecapCardFirstShown(did, weekIso)
+  if (
+    firstShown != null &&
+    now.getTime() - firstShown >= RECAP_CARD_MAX_AGE_MS
+  ) {
+    return null
+  }
+
+  return weekIso
+}
+
+function isAfterMondaySurfaceHour(now: Date): boolean {
+  // Local-time Monday cutoff. Sunday<23:59 → already invisible (last week's
+  // window hasn't closed). Monday<06:00 → still invisible.
+  const dow = now.getDay() // 0 Sunday, 1 Monday, ..., 6 Saturday
+  if (dow === 0) return false
+  if (dow === 1 && now.getHours() < RECAP_CARD_MONDAY_SHOW_HOUR_LOCAL) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Parse a 'YYYY-MM-DD' day string into a UTC ms anchor (used for window
+ * comparison). The window itself is local; the comparison only requires
+ * relative ordering, so a UTC anchor is sufficient.
+ */
+function parseDayString(day: string): number | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(day)
+  if (!m) return null
+  return Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
+}

--- a/src/features/activityAndRecap/hooks/useShowRecapPreference.ts
+++ b/src/features/activityAndRecap/hooks/useShowRecapPreference.ts
@@ -1,0 +1,32 @@
+/**
+ * Per-account "show weekly recap" toggle (AC-X1 / AC-X2 / AC-B11).
+ *
+ * Default is ON. When false, the recap card hides AND the weeklyRecap
+ * query never fires (its `enabled` gate reads this hook).
+ */
+
+import {useCallback} from 'react'
+
+import {useSession} from '#/state/session'
+import {type ActivityAndRecapPrefs} from '#/features/activityAndRecap/types'
+import {account, useStorage} from '#/storage'
+
+export function useShowRecapPreference(): [boolean, (next: boolean) => void] {
+  const {currentAccount} = useSession()
+  const did = currentAccount?.did ?? ''
+  const [prefs, setPrefs] = useStorage<typeof account, 'activityAndRecap'>(
+    account,
+    [did, 'activityAndRecap'],
+  )
+
+  const value = prefs?.showRecap ?? true
+  const setter = useCallback(
+    (next: boolean) => {
+      if (!did) return
+      const patch: ActivityAndRecapPrefs = {...(prefs ?? {}), showRecap: next}
+      setPrefs(patch)
+    },
+    [did, prefs, setPrefs],
+  )
+  return [value, setter]
+}

--- a/src/features/activityAndRecap/hooks/useShowStreakPreference.ts
+++ b/src/features/activityAndRecap/hooks/useShowStreakPreference.ts
@@ -1,0 +1,43 @@
+/**
+ * Per-account "show streak indicator" toggle (AC-X1 / AC-X2).
+ *
+ * Built on `useStorage(account, [did, 'activityAndRecap'])` so:
+ *   - The toggle is per-account (MMKV DID scope).
+ *   - Re-renders on DID switch (storage instance swaps cleanly).
+ *   - No `agent.app.bsky.actor.putPreferences` call ever fires (AC-X2).
+ *
+ * Default is ON (AC-X1). Grace-day flag is intentionally NOT exposed
+ * through this module — only the explainer dialog reads
+ * `graceUsedForCurrentStreak` directly from storage (G2).
+ */
+
+import {useCallback} from 'react'
+
+import {useSession} from '#/state/session'
+import {type ActivityAndRecapPrefs} from '#/features/activityAndRecap/types'
+import {account, useStorage} from '#/storage'
+
+/**
+ * Returns `[showStreak, setShowStreak]`. When no session is present,
+ * `showStreak` is always `true` (default-on semantics) and the setter
+ * is a no-op.
+ */
+export function useShowStreakPreference(): [boolean, (next: boolean) => void] {
+  const {currentAccount} = useSession()
+  const did = currentAccount?.did ?? ''
+  const [prefs, setPrefs] = useStorage<typeof account, 'activityAndRecap'>(
+    account,
+    [did, 'activityAndRecap'],
+  )
+
+  const value = prefs?.showStreak ?? true
+  const setter = useCallback(
+    (next: boolean) => {
+      if (!did) return
+      const patch: ActivityAndRecapPrefs = {...(prefs ?? {}), showStreak: next}
+      setPrefs(patch)
+    },
+    [did, prefs, setPrefs],
+  )
+  return [value, setter]
+}

--- a/src/features/activityAndRecap/hooks/useStreakStore.ts
+++ b/src/features/activityAndRecap/hooks/useStreakStore.ts
@@ -1,0 +1,19 @@
+/**
+ * Reactive reader for the account-scoped StreakStore.
+ *
+ * Subscribes to the underlying MMKV key so consumers re-render when the
+ * streak tracker writes a new value. Use this in the indicator and the
+ * explainer dialog; do NOT use it for mutation — writes go through the
+ * tracker / reducer path.
+ */
+
+import {useSession} from '#/state/session'
+import {type StreakStore} from '#/features/activityAndRecap/types'
+import {account, useStorage} from '#/storage'
+
+export function useStreakStore(): StreakStore | undefined {
+  const {currentAccount} = useSession()
+  const did = currentAccount?.did ?? ''
+  const [value] = useStorage<typeof account, 'streak'>(account, [did, 'streak'])
+  return value
+}

--- a/src/features/activityAndRecap/hooks/useStreakTracker.ts
+++ b/src/features/activityAndRecap/hooks/useStreakTracker.ts
@@ -1,0 +1,182 @@
+/**
+ * useStreakTracker (S7) — observes app foreground + Home tab focus and a
+ * "feed-rendered" signal, then arms a 30-second contiguous-dwell timer.
+ * On expiry it consults `computeNextStreak`, persists the new state, and
+ * captures a follower snapshot for the recap delta.
+ *
+ * Mounted exactly once via `<ActivityAndRecapProvider/>` from the
+ * signed-in shell (S20). The hook is no-op when:
+ *   - feature flag StreaksAndRecapEnable is off (X6),
+ *   - no session (A7),
+ *   - showStreak preference is off (X1).
+ *
+ * Feed-render signal:
+ *   The qualifying-visit definition (AC-A1) requires AT LEAST one feed
+ *   render. The primary path is for the Home PostFeed to call
+ *   `signalFeedRender()` returned from this hook. Fallback (R5): if no
+ *   caller invokes the signal, the dwell timer alone qualifies — coarser
+ *   but shippable. We document this by calling the signal opt-in via the
+ *   returned tuple, and treating a missing signal as "fallback path".
+ *
+ * Listener cleanup uses `useOnAppStateChange` (src/lib/appState.ts:15)
+ * which already wires subscription removal — see R4 mitigation.
+ */
+
+import {useCallback, useEffect, useRef, useState} from 'react'
+import {AppState} from 'react-native'
+import {useIsFocused} from '@react-navigation/native'
+
+import {useAgent, useSession} from '#/state/session'
+import {STREAK_QUALIFYING_DWELL_MS} from '#/features/activityAndRecap/constants'
+import {useShowStreakPreference} from '#/features/activityAndRecap/hooks/useShowStreakPreference'
+import {useStreaksAndRecapEnabled} from '#/features/activityAndRecap/hooks/useStreaksAndRecapEnabled'
+import {computeNextStreak} from '#/features/activityAndRecap/reducer/computeNextStreak'
+import {
+  formatLocalDay,
+  getCurrentZone,
+} from '#/features/activityAndRecap/reducer/dayMath'
+import {
+  readStreak,
+  upsertFollowerSnapshot,
+  writeStreak,
+} from '#/features/activityAndRecap/storage'
+import {type NowInput} from '#/features/activityAndRecap/types'
+
+type UseStreakTrackerReturn = {
+  /**
+   * Call from the Home PostFeed when the first batch of items has rendered.
+   * Idempotent within a single session-foreground window.
+   */
+  signalFeedRender: () => void
+}
+
+export function useStreakTracker(): UseStreakTrackerReturn {
+  const featureOn = useStreaksAndRecapEnabled()
+  const {hasSession, currentAccount} = useSession()
+  const [showStreak] = useShowStreakPreference()
+  const isFocused = useIsFocused()
+  const agent = useAgent()
+  const did = currentAccount?.did
+
+  // Refs for the dwell-timer state machine.
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const sawFeedRenderRef = useRef<boolean>(false)
+  // Re-render trigger so we can re-evaluate the gate when the caller
+  // asks us to (signalFeedRender).
+  const [renderNonce, setRenderNonce] = useState(0)
+
+  const enabled = !!(featureOn && hasSession && showStreak && did)
+
+  // Timer arming/teardown effect — re-runs whenever the gate changes,
+  // when AppState transitions to/from active (handled by re-evaluating
+  // the gate via state below), or when route focus changes.
+  useEffect(() => {
+    if (!enabled) {
+      // Clear any prior timer if conditions stop being met.
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+      return
+    }
+
+    // Subscribe to AppState; re-evaluate on transitions.
+    let mounted = true
+    const appStateSub = AppState.addEventListener('change', state => {
+      if (!mounted) return
+      if (state !== 'active') {
+        // Backgrounded: cancel in-flight timer.
+        if (timerRef.current) {
+          clearTimeout(timerRef.current)
+          timerRef.current = null
+        }
+      } else {
+        // Re-foreground: re-arm via state nonce so the effect re-runs.
+        setRenderNonce(n => n + 1)
+      }
+    })
+
+    const isActive = AppState.currentState === 'active'
+    const shouldArm = isActive && isFocused
+
+    if (shouldArm && !timerRef.current) {
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null
+        // Final guard — bail if any condition flipped while the timer ran.
+        if (!enabled) return
+        if (AppState.currentState !== 'active') return
+        // We treat absence of a feed-render signal as the documented
+        // fallback (R5) — i.e. the dwell alone qualifies. Either way we
+        // proceed to commit on expiry.
+        commitVisit({
+          did: did,
+          agent,
+        }).catch(() => {
+          /* swallow — graceful degrade */
+        })
+      }, STREAK_QUALIFYING_DWELL_MS)
+    }
+
+    return () => {
+      mounted = false
+      appStateSub.remove()
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+  }, [enabled, isFocused, did, agent, renderNonce])
+
+  // Reset the per-foreground "saw feed render" flag when we go inactive.
+  useEffect(() => {
+    if (!isFocused) sawFeedRenderRef.current = false
+  }, [isFocused])
+
+  const signalFeedRender = useCallback(() => {
+    sawFeedRenderRef.current = true
+    // Bumping the nonce re-runs the timer-arming effect, which is a no-op
+    // if a timer is already armed. This keeps the feed-render signal
+    // additive without disrupting an in-flight dwell.
+    setRenderNonce(n => n + 1)
+  }, [])
+
+  return {signalFeedRender}
+}
+
+/**
+ * Persist a streak update + follower snapshot for the current visit. Pure
+ * with respect to React state — only touches storage and the agent.
+ */
+async function commitVisit(args: {
+  did: string
+  agent: ReturnType<typeof useAgent>
+}): Promise<void> {
+  const {did, agent} = args
+  const zone = getCurrentZone()
+  const nowMs = Date.now()
+  const localDay = formatLocalDay(new Date(nowMs), zone)
+  const input: NowInput = {utcMs: nowMs, localDay, zone}
+  const prev = readStreak(did)
+  const next = computeNextStreak(prev, input)
+  // Only write when something actually changed (cheap path).
+  if (prev !== next) writeStreak(did, next)
+
+  // Capture a follower snapshot — at most once per local day per the
+  // tracker's call frequency. upsertFollowerSnapshot dedupes by day.
+  try {
+    const res = await agent.app.bsky.actor.getProfile({actor: did})
+    const count = res.data.followersCount ?? 0
+    upsertFollowerSnapshot(did, {day: localDay, count})
+  } catch {
+    /* graceful degrade */
+  }
+}
+
+/**
+ * Provider component that mounts the tracker exactly once. Renders null.
+ * Mounted from the signed-in session shell (S20).
+ */
+export function ActivityAndRecapProvider(): null {
+  useStreakTracker()
+  return null
+}

--- a/src/features/activityAndRecap/hooks/useStreaksAndRecapEnabled.ts
+++ b/src/features/activityAndRecap/hooks/useStreaksAndRecapEnabled.ts
@@ -1,0 +1,21 @@
+/**
+ * Central feature-flag hook for Activity & Recap (ticket i9KLo7kw).
+ *
+ * Every consumer surface must call this at the top of the entry component
+ * and early-return `null` when it returns `false`. That guarantees
+ * zero-footprint behavior when the flag is off (no storage reads, no
+ * query enqueues, no side effects).
+ *
+ * Combines session + flag checks:
+ *   - `hasSession === true` (AC-A7: no streak for logged-out users)
+ *   - `StreaksAndRecapEnable` feature gate (AC-X6)
+ */
+
+import {useSession} from '#/state/session'
+import {useAnalytics} from '#/analytics'
+
+export function useStreaksAndRecapEnabled(): boolean {
+  const {hasSession} = useSession()
+  const ax = useAnalytics()
+  return hasSession && ax.features.enabled(ax.features.StreaksAndRecapEnable)
+}

--- a/src/features/activityAndRecap/index.ts
+++ b/src/features/activityAndRecap/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Activity & Recap feature (ticket i9KLo7kw).
+ *
+ * Single feature module owning the streak indicator, weekly recap, and
+ * the per-account Settings sub-screen. All gated by
+ * `useStreaksAndRecapEnabled()` + per-account preference toggles.
+ *
+ * Entry points:
+ * - `ActivityAndRecapProvider` — mounts `useStreakTracker` in the signed-in shell (S20).
+ * - `clearActivityAndRecapDataForDid` — called on account removal (S21).
+ * - Components: `StreakIndicator`, `WeeklyRecapCard`, `StreakExplainerDialog`.
+ * - Screens: `RecapScreen`, `PastRecapsScreen`, `ActivityAndRecapSettingsScreen`.
+ */
+export {clearActivityAndRecapDataForDid} from '#/features/activityAndRecap/clearActivityAndRecapDataForDid'
+export * from '#/features/activityAndRecap/constants'
+export {useStreaksAndRecapEnabled} from '#/features/activityAndRecap/hooks/useStreaksAndRecapEnabled'
+export {ActivityAndRecapProvider} from '#/features/activityAndRecap/hooks/useStreakTracker'
+export * from '#/features/activityAndRecap/types'

--- a/src/features/activityAndRecap/queries/retryBudget.ts
+++ b/src/features/activityAndRecap/queries/retryBudget.ts
@@ -1,0 +1,58 @@
+/**
+ * Per-weekIso auto-retry budget (AC-B8).
+ *
+ * TanStack Query's `retry` option alone is insufficient because it resets
+ * on remount. We wrap the queryFn with this budget gate so the 2-per-hour
+ * auto-retry limit survives re-mounts. Manual "Try again" bypasses.
+ *
+ * Backed by an in-memory map; no MMKV persistence in v0 (cheaper and
+ * sufficient for anti-flap).
+ */
+
+import {
+  WEEKLY_RECAP_AUTO_RETRY_BUDGET,
+  WEEKLY_RECAP_AUTO_RETRY_WINDOW_MS,
+} from '#/features/activityAndRecap/constants'
+
+type Bucket = {
+  windowStart: number
+  retries: number
+}
+
+const buckets = new Map<string, Bucket>()
+
+/**
+ * Returns true if this attempt is within budget; increments the counter.
+ * Call only on auto-retry paths. Manual retry paths skip this gate.
+ *
+ * @param weekIso e.g. '2026-W15'
+ * @param now   default `Date.now()` — injectable for tests
+ */
+export function tryAutoRetry(
+  weekIso: string,
+  now: number = Date.now(),
+): boolean {
+  const bucket = buckets.get(weekIso)
+  if (
+    !bucket ||
+    now - bucket.windowStart >= WEEKLY_RECAP_AUTO_RETRY_WINDOW_MS
+  ) {
+    buckets.set(weekIso, {windowStart: now, retries: 1})
+    return true
+  }
+  if (bucket.retries >= WEEKLY_RECAP_AUTO_RETRY_BUDGET) {
+    return false
+  }
+  bucket.retries += 1
+  return true
+}
+
+/** Reset the retry bucket for a weekIso. Called on successful fetch. */
+export function resetAutoRetry(weekIso: string): void {
+  buckets.delete(weekIso)
+}
+
+/** For tests. */
+export function __resetAllForTests(): void {
+  buckets.clear()
+}

--- a/src/features/activityAndRecap/queries/weeklyRecap.ts
+++ b/src/features/activityAndRecap/queries/weeklyRecap.ts
@@ -1,0 +1,207 @@
+/**
+ * TanStack Query for the weekly recap (AC-B2, B4, B8, B10, B11, R3).
+ *
+ * Key shape (see `src/state/queries/util.ts:28`):
+ *   createQueryKey('weeklyRecap', {did, weekIso}, {persistedVersion: 1})
+ *
+ * Behavior:
+ *   - `enabled` gate combines hasSession + StreaksAndRecapEnable +
+ *     showRecap preference + weekIso != null. When toggle is off, the
+ *     query never fires (AC-B11 zero-XRPC).
+ *   - `getAuthorFeed` pagination hard-capped at WEEKLY_RECAP_MAX_PAGES;
+ *     short-circuits when oldest indexedAt < windowStart (R3).
+ *   - `getProfile` is called once to capture follower snapshot.
+ *   - Only `{uri, cid}` persists for `topPost` and `topPostCandidates`;
+ *     the Recap screen re-fetches the full post so it inherits moderation
+ *     filtering (B10).
+ *   - Auto-retry capped at 2/hr/weekIso via retryBudget.ts (B8). Manual
+ *     retry bypasses.
+ */
+
+import {type AppBskyFeedDefs, type AtpAgent} from '@atproto/api'
+import {useQuery} from '@tanstack/react-query'
+
+import {GCTIME, STALE} from '#/state/queries'
+import {createQueryKey} from '#/state/queries/util'
+import {useAgent, useSession} from '#/state/session'
+import {
+  RECAP_ZERO_POSTS_COPY,
+  WEEKLY_RECAP_MAX_PAGES,
+  WEEKLY_RECAP_PAGE_LIMIT,
+} from '#/features/activityAndRecap/constants'
+import {useShowRecapPreference} from '#/features/activityAndRecap/hooks/useShowRecapPreference'
+import {useStreaksAndRecapEnabled} from '#/features/activityAndRecap/hooks/useStreaksAndRecapEnabled'
+import {
+  resetAutoRetry,
+  tryAutoRetry,
+} from '#/features/activityAndRecap/queries/retryBudget'
+import {formatLocalDay} from '#/features/activityAndRecap/reducer/dayMath'
+import {followerDelta as computeFollowerDelta} from '#/features/activityAndRecap/reducer/followerDelta'
+import {weekWindowForIso} from '#/features/activityAndRecap/reducer/isoWeek'
+import {
+  rankTopPost,
+  type TopPostCandidate,
+} from '#/features/activityAndRecap/reducer/rankTopPost'
+import {readFollowerSnapshots} from '#/features/activityAndRecap/storage'
+import {type WeeklyRecap} from '#/features/activityAndRecap/types'
+
+// Exported for potential external invalidation. Kept intentionally simple.
+export const weeklyRecapQueryKeyRoot = 'weeklyRecap'
+
+export const createWeeklyRecapQueryKey = (args: {
+  did: string
+  weekIso: string
+}) => createQueryKey(weeklyRecapQueryKeyRoot, args, {persistedVersion: 1})
+
+/** Exported for tests + Recap screen zero-posts copy. */
+export const ZERO_POSTS_COPY = RECAP_ZERO_POSTS_COPY
+
+type FeedViewPost = AppBskyFeedDefs.FeedViewPost
+
+/**
+ * Pure core of the queryFn. Exported for unit tests so we can exercise
+ * pagination + short-circuit + moderation-candidate gathering without
+ * touching the TanStack Query plumbing.
+ */
+export async function computeWeeklyRecap(args: {
+  agent: AtpAgent
+  did: string
+  weekIso: string
+  zone: string
+  /** Injectable clock for tests; defaults to Date.now(). */
+  now?: number
+}): Promise<WeeklyRecap> {
+  const {agent, did, weekIso, zone, now = Date.now()} = args
+  const window = weekWindowForIso(weekIso)
+  if (!window) {
+    throw new Error(`[weeklyRecap] invalid weekIso: ${weekIso}`)
+  }
+  const windowStartMs = window.start.getTime()
+  const windowEndMs = window.end.getTime()
+
+  // --- Paginated getAuthorFeed ---
+  const collected: FeedViewPost[] = []
+  let cursor: string | undefined
+  for (let page = 0; page < WEEKLY_RECAP_MAX_PAGES; page++) {
+    const res = await agent.app.bsky.feed.getAuthorFeed({
+      actor: did,
+      limit: WEEKLY_RECAP_PAGE_LIMIT,
+      cursor,
+      filter: 'posts_with_replies',
+    })
+    const items = res.data.feed ?? []
+    if (items.length === 0) break
+    for (const item of items) collected.push(item)
+    cursor = res.data.cursor
+
+    // R3 short-circuit: if the oldest item on this page predates windowStart,
+    // we're done.
+    const oldest = items[items.length - 1]
+    const oldestAt = oldest?.post?.indexedAt
+      ? new Date(oldest.post.indexedAt).getTime()
+      : undefined
+    if (oldestAt != null && oldestAt < windowStartMs) break
+    if (!cursor) break
+  }
+
+  // --- Filter in-window own-authored posts ---
+  const inWindow: FeedViewPost[] = collected.filter(item => {
+    const post = item.post
+    if (!post) return false
+    const tMs = new Date(post.indexedAt).getTime()
+    if (tMs < windowStartMs || tMs > windowEndMs) return false
+    // Own-authored check (includes replies by self; reposts have a
+    // different `reason` that still lists the reposting actor as `by`).
+    return post.author?.did === did
+  })
+
+  // Count combined (posts + self-replies + self-reposts) per Q_B2_posts default.
+  const postsCount = inWindow.length
+
+  // Rank candidates using the pure helper.
+  const candidates: TopPostCandidate[] = inWindow
+    .map(({post}) => ({
+      uri: post.uri,
+      cid: post.cid,
+      likeCount: post.likeCount ?? 0,
+      repostCount: post.repostCount ?? 0,
+      replyCount: post.replyCount ?? 0,
+      indexedAtMs: new Date(post.indexedAt).getTime(),
+    }))
+    .filter(c => c.uri && c.cid)
+  const ranked = rankTopPost(candidates)
+  const topPost =
+    ranked.length > 0 ? {uri: ranked[0].uri, cid: ranked[0].cid} : null
+  const topPostCandidates = ranked.map(c => ({uri: c.uri, cid: c.cid}))
+
+  // --- Follower delta via one getProfile + ring buffer ---
+  let followerDelta = 0
+  try {
+    const res = await agent.app.bsky.actor.getProfile({actor: did})
+    const count = res.data.followersCount ?? 0
+    const today = formatLocalDay(new Date(now), zone)
+    // Don't write storage here — that's the tracker's job. We just read the
+    // existing ring buffer to compute the delta with the freshly-fetched
+    // current count as an optimistic "end" value.
+    const snaps = readFollowerSnapshots(did)
+    const startDay = formatLocalDay(window.start, zone)
+    const endDay = formatLocalDay(window.end, zone)
+    // Synthesize a snapshot for `today` if the real ring buffer doesn't
+    // already have a more recent entry (commonly the case once the tracker
+    // has run today). We don't mutate storage here.
+    const synthesized = [...snaps, {day: today, count}]
+    followerDelta = computeFollowerDelta(synthesized, startDay, endDay)
+  } catch {
+    // Graceful degrade per R2.
+    followerDelta = 0
+  }
+
+  return {
+    weekIso,
+    windowStart: window.start.toISOString(),
+    windowEnd: window.end.toISOString(),
+    postsCount,
+    followerDelta,
+    topPost,
+    topPostCandidates,
+    fetchedAtUtcMs: now,
+  }
+}
+
+/**
+ * Hook entry point. Caller-owned `enabled` gate combines the flag +
+ * showRecap preference + weekIso presence. Per B11, toggle-off means
+ * zero XRPC calls.
+ */
+export function useWeeklyRecapQuery({
+  weekIso,
+}: {
+  weekIso: string | null | undefined
+}) {
+  const featureOn = useStreaksAndRecapEnabled()
+  const [showRecap] = useShowRecapPreference()
+  const {currentAccount} = useSession()
+  const agent = useAgent()
+  const did = currentAccount?.did ?? ''
+  const zone = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+  return useQuery<WeeklyRecap>({
+    queryKey: createWeeklyRecapQueryKey({did, weekIso: weekIso ?? ''}),
+    queryFn: async () => {
+      // Auto-retry gate — attempt counter burns on every call except the
+      // first. TanStack retries come through here and will short-circuit
+      // after the budget is exhausted.
+      if (!weekIso) throw new Error('[weeklyRecap] missing weekIso')
+      const ok = tryAutoRetry(weekIso)
+      if (!ok) throw new Error('[weeklyRecap] auto-retry budget exhausted')
+      const result = await computeWeeklyRecap({agent, did, weekIso, zone})
+      resetAutoRetry(weekIso)
+      return result
+    },
+    enabled: !!(featureOn && showRecap && did && weekIso),
+    staleTime: STALE.HOURS.ONE,
+    gcTime: GCTIME.INFINITY,
+    // TanStack-native retry disabled — our own budget module owns this.
+    retry: false,
+  })
+}

--- a/src/features/activityAndRecap/reducer/computeNextStreak.ts
+++ b/src/features/activityAndRecap/reducer/computeNextStreak.ts
@@ -1,0 +1,138 @@
+/**
+ * Pure reducer for the Activity & Recap streak (ticket i9KLo7kw).
+ *
+ * Zero React/RN dependencies. Exhaustively unit-tested (AC-A2/A3/A4/A5).
+ * The rule sheet lives in `requirements.md §3.3`; summary:
+ *
+ *   1. UTC monotonic guard (>20h) blocks tz-hop abuse (A5).
+ *   2. Same-day dedupe: update anchor, return otherwise unchanged (A1).
+ *   3. Consecutive day: +1, clear grace (A2).
+ *   4. 1 day skipped + grace unused: keep streak, mark grace used (A3, G2).
+ *   5. 1 day skipped + grace used, or 2+ days skipped: reset to 1 (A4).
+ *   6. First visit ever: currentStreak = 1 (A2).
+ *   7. Tz regression never decrements (A5).
+ *   8. longestStreak = max(prev, current); update last-visit fields.
+ */
+
+import {STREAK_UTC_MONOTONIC_GUARD_MS} from '#/features/activityAndRecap/constants'
+import {daysBetweenLocalDays} from '#/features/activityAndRecap/reducer/dayMath'
+import {
+  type NowInput,
+  STREAK_STORE_VERSION,
+  type StreakStore,
+} from '#/features/activityAndRecap/types'
+
+/**
+ * Compute the next `StreakStore` given the prior state and a `NowInput`.
+ *
+ * Returning the unchanged `prev` is a signal to the caller that nothing
+ * needs to be persisted (cheap fast path). Callers MUST still re-write
+ * the anchor when we update `lastVisitAtUtcMs` — we return a new object
+ * in that case.
+ */
+export function computeNextStreak(
+  prev: StreakStore | undefined,
+  now: NowInput,
+): StreakStore {
+  // Rule 6: first visit ever.
+  if (!prev) {
+    return {
+      version: STREAK_STORE_VERSION,
+      currentStreak: 1,
+      longestStreak: 1,
+      lastVisitDay: now.localDay,
+      lastVisitZone: now.zone,
+      lastVisitAtUtcMs: now.utcMs,
+      graceUsedForCurrentStreak: false,
+    }
+  }
+
+  // Defensive: missing/invalid version triggers reset-by-first-visit semantics.
+  // This keeps persisted data robust to forward-compat without throwing.
+  if (prev.version !== STREAK_STORE_VERSION) {
+    return {
+      version: STREAK_STORE_VERSION,
+      currentStreak: 1,
+      longestStreak: Math.max(prev.longestStreak ?? 0, 1),
+      lastVisitDay: now.localDay,
+      lastVisitZone: now.zone,
+      lastVisitAtUtcMs: now.utcMs,
+      graceUsedForCurrentStreak: false,
+    }
+  }
+
+  // Rule 2: same local day (evaluated first so the anchor ratchets even
+  // on rapid re-foregrounds within a day). Using the callsite's
+  // `now.localDay` against the stored `lastVisitDay` — both strings are
+  // in their own zone. A westward tz hop within the same physical day
+  // can still land us here (see Rule 7 test).
+  if (prev.lastVisitDay === now.localDay) {
+    return {
+      ...prev,
+      lastVisitAtUtcMs: Math.max(prev.lastVisitAtUtcMs, now.utcMs),
+      lastVisitZone: now.zone,
+    }
+  }
+
+  // Rule 1: UTC monotonic guard — must wait >=20h since the last
+  // recorded visit before incrementing. Evaluated after same-day dedupe
+  // so that a quick re-foreground inside the same day updates the
+  // anchor but does nothing else.
+  const dtMs = now.utcMs - prev.lastVisitAtUtcMs
+  if (dtMs >= 0 && dtMs < STREAK_UTC_MONOTONIC_GUARD_MS) {
+    return prev
+  }
+
+  // Calendar-days delta. We compute in the prior-visit zone's calendar by
+  // using the prior `lastVisitDay` and `now.localDay` strings directly.
+  // Rule 7: if the new local day is equal or earlier than the prior
+  // recorded one, never decrement — treat as same-day.
+  const delta = daysBetweenLocalDays(prev.lastVisitDay, now.localDay)
+  if (delta === null || delta <= 0) {
+    // Malformed or regression: treat as same-day but ratchet the anchor.
+    return {
+      ...prev,
+      lastVisitAtUtcMs: now.utcMs,
+      lastVisitZone: now.zone,
+    }
+  }
+
+  if (delta === 1) {
+    // Rule 3: consecutive day.
+    const nextStreak = prev.currentStreak + 1
+    return {
+      ...prev,
+      currentStreak: nextStreak,
+      longestStreak: Math.max(prev.longestStreak, nextStreak),
+      lastVisitDay: now.localDay,
+      lastVisitZone: now.zone,
+      lastVisitAtUtcMs: now.utcMs,
+      graceUsedForCurrentStreak: false,
+    }
+  }
+
+  if (delta === 2 && !prev.graceUsedForCurrentStreak) {
+    // Rule 4: exactly one day skipped, grace unused. Silent forgiveness.
+    return {
+      ...prev,
+      // currentStreak unchanged
+      longestStreak: Math.max(prev.longestStreak, prev.currentStreak),
+      lastVisitDay: now.localDay,
+      lastVisitZone: now.zone,
+      lastVisitAtUtcMs: now.utcMs,
+      graceUsedForCurrentStreak: true,
+    }
+  }
+
+  // Rule 5: 2+ days skipped (delta>=3) OR delta===2 with grace already
+  // used. Reset to 1 and clear grace.
+  return {
+    version: STREAK_STORE_VERSION,
+    currentStreak: 1,
+    longestStreak: Math.max(prev.longestStreak, 1),
+    lastVisitDay: now.localDay,
+    lastVisitZone: now.zone,
+    lastVisitAtUtcMs: now.utcMs,
+    graceUsedForCurrentStreak: false,
+  }
+}

--- a/src/features/activityAndRecap/reducer/dayMath.ts
+++ b/src/features/activityAndRecap/reducer/dayMath.ts
@@ -1,0 +1,67 @@
+/**
+ * IANA-tz day-math helpers. Pure. Zero RN dependencies.
+ *
+ * Day string = `Intl.DateTimeFormat('en-CA', {timeZone: zone}).format(date)`
+ * which returns `YYYY-MM-DD` regardless of DST. The en-CA locale is the
+ * only one that guarantees numeric YYYY-MM-DD by default.
+ */
+
+/**
+ * Format a Date as `YYYY-MM-DD` in the given IANA tz.
+ * `zone` must be a resolvable IANA timezone (e.g. 'America/New_York').
+ */
+export function formatLocalDay(date: Date, zone: string): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: zone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date)
+}
+
+/**
+ * Returns the caller's current IANA tz, e.g. 'America/New_York'.
+ */
+export function getCurrentZone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone
+}
+
+/**
+ * Parse a 'YYYY-MM-DD' string into a simple numeric triple. Returns null
+ * if the input is malformed — the reducer treats that as "unknown".
+ */
+export function parseLocalDay(
+  day: string,
+): {year: number; month: number; day: number} | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(day)
+  if (!m) return null
+  const year = Number(m[1])
+  const month = Number(m[2])
+  const dom = Number(m[3])
+  if (
+    !Number.isFinite(year) ||
+    !Number.isFinite(month) ||
+    !Number.isFinite(dom)
+  ) {
+    return null
+  }
+  return {year, month, day: dom}
+}
+
+/**
+ * Days elapsed from `a` to `b` based on calendar dates alone (in whatever
+ * tz produced both strings). Positive if b > a. Returns null for malformed
+ * input.
+ *
+ * Uses UTC midnight as the arithmetic anchor — this is calendar-only math
+ * and we explicitly do NOT care about tz for this operation.
+ */
+export function daysBetweenLocalDays(a: string, b: string): number | null {
+  const pa = parseLocalDay(a)
+  const pb = parseLocalDay(b)
+  if (!pa || !pb) return null
+  const MS_DAY = 24 * 60 * 60 * 1000
+  const utcA = Date.UTC(pa.year, pa.month - 1, pa.day)
+  const utcB = Date.UTC(pb.year, pb.month - 1, pb.day)
+  return Math.round((utcB - utcA) / MS_DAY)
+}

--- a/src/features/activityAndRecap/reducer/followerDelta.ts
+++ b/src/features/activityAndRecap/reducer/followerDelta.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure helper for net new-followers calculation (AC-B4).
+ *
+ * Clamps negative deltas to 0. Degrades gracefully when a snapshot is
+ * missing: uses the oldest-available snapshot as a floor; if neither end
+ * of the window is present, returns 0.
+ */
+
+import {type FollowerSnapshot} from '#/features/activityAndRecap/types'
+
+/**
+ * Return a snapshot whose `day` string <= `dayIso` (latest such entry).
+ * Returns undefined if none exists.
+ */
+function snapshotAtOrBefore(
+  snapshots: readonly FollowerSnapshot[],
+  dayIso: string,
+): FollowerSnapshot | undefined {
+  // Snapshots are not guaranteed to be sorted; sort a shallow copy once.
+  const sorted = [...snapshots].sort((a, b) => a.day.localeCompare(b.day))
+  let match: FollowerSnapshot | undefined
+  for (const s of sorted) {
+    if (s.day <= dayIso) match = s
+    else break
+  }
+  return match
+}
+
+/**
+ * Return a snapshot whose `day` string >= `dayIso` (earliest such entry).
+ */
+function snapshotAtOrAfter(
+  snapshots: readonly FollowerSnapshot[],
+  dayIso: string,
+): FollowerSnapshot | undefined {
+  const sorted = [...snapshots].sort((a, b) => a.day.localeCompare(b.day))
+  for (const s of sorted) {
+    if (s.day >= dayIso) return s
+  }
+  return undefined
+}
+
+/**
+ * `max(0, end - start)` using snapshot ring-buffer lookup. If `startDay`
+ * is not covered, we fall back to the oldest available snapshot; if
+ * `endDay` is not covered, we fall back to the most recent snapshot
+ * on or before `endDay`. If neither is available, returns 0.
+ *
+ * @param snapshots Account-scoped ring buffer.
+ * @param startDay  'YYYY-MM-DD' local — Monday 00:00 of the window.
+ * @param endDay    'YYYY-MM-DD' local — Sunday 23:59 of the window.
+ */
+export function followerDelta(
+  snapshots: readonly FollowerSnapshot[] | undefined,
+  startDay: string,
+  endDay: string,
+): number {
+  if (!snapshots || snapshots.length === 0) return 0
+
+  // Prefer an exact or earlier snapshot for the start. If none exists,
+  // use the oldest available snapshot as the floor (graceful degrade).
+  const startSnap =
+    snapshotAtOrBefore(snapshots, startDay) ??
+    snapshotAtOrAfter(snapshots, startDay)
+  const endSnap =
+    snapshotAtOrBefore(snapshots, endDay) ??
+    snapshotAtOrAfter(snapshots, endDay)
+
+  if (!startSnap || !endSnap) return 0
+
+  const diff = (endSnap.count ?? 0) - (startSnap.count ?? 0)
+  return Math.max(0, diff)
+}

--- a/src/features/activityAndRecap/reducer/isoWeek.ts
+++ b/src/features/activityAndRecap/reducer/isoWeek.ts
@@ -1,0 +1,110 @@
+/**
+ * ISO-week helpers for the weekly recap (ticket i9KLo7kw).
+ *
+ * Week ID is 'YYYY-Www' (e.g. '2026-W15'), Monday 00:00 through
+ * Sunday 23:59:59.999 local. The 06:00 Monday surface-visibility gate
+ * (B1) is enforced separately in `useRecapCardVisibility`.
+ *
+ * Uses date-fns for ISO week/year math (sanctioned per ARCHITECTURE.md).
+ */
+
+import {
+  addDays,
+  endOfISOWeek,
+  getISOWeek,
+  getISOWeekYear,
+  startOfISOWeek,
+  subWeeks,
+} from 'date-fns'
+
+/** Format an ISO week as 'YYYY-Www' (2-digit week). */
+export function formatWeekIso(date: Date): string {
+  const year = getISOWeekYear(date)
+  const week = getISOWeek(date)
+  return `${year}-W${String(week).padStart(2, '0')}`
+}
+
+/**
+ * Return the Monday-00:00 local start date for the ISO week containing
+ * `date`. Honors the caller's local tz (date-fns uses the local offset).
+ */
+export function weekStart(date: Date): Date {
+  return startOfISOWeek(date)
+}
+
+/** Sunday 23:59:59.999 local end of the ISO week containing `date`. */
+export function weekEnd(date: Date): Date {
+  return endOfISOWeek(date)
+}
+
+/**
+ * Return the weekIso for the previous ISO week (for the recap card,
+ * which always looks back at N-1).
+ */
+export function priorWeekIso(date: Date): string {
+  return formatWeekIso(subWeeks(date, 1))
+}
+
+/**
+ * Return the current weekIso.
+ */
+export function currentWeekIso(date: Date): string {
+  return formatWeekIso(date)
+}
+
+/**
+ * Enumerate the last `count` ISO weeks' IDs, most recent first. Used by
+ * PastRecaps (B5) with count=4.
+ */
+export function lastNWeekIsos(date: Date, count: number): string[] {
+  const out: string[] = []
+  for (let i = 1; i <= count; i++) {
+    out.push(formatWeekIso(subWeeks(date, i)))
+  }
+  return out
+}
+
+/**
+ * Return the [start, end] local Date range for the ISO week of `date`.
+ */
+export function weekWindow(date: Date): {start: Date; end: Date} {
+  return {start: weekStart(date), end: weekEnd(date)}
+}
+
+/**
+ * Given a weekIso like '2026-W15', reconstruct a reference Date
+ * inside that week (Thursday of the ISO week — which is always in the
+ * ISO year). Useful for building the window from a stored weekIso.
+ */
+export function parseWeekIsoToDate(weekIso: string): Date | null {
+  const m = /^(\d{4})-W(\d{2})$/.exec(weekIso)
+  if (!m) return null
+  const year = Number(m[1])
+  const week = Number(m[2])
+  if (
+    !Number.isFinite(year) ||
+    !Number.isFinite(week) ||
+    week < 1 ||
+    week > 53
+  ) {
+    return null
+  }
+  // Jan 4 is always in ISO week 1 of `year`. Walk forward `week-1` weeks
+  // and land on Thursday.
+  const jan4 = new Date(year, 0, 4)
+  const w1Monday = startOfISOWeek(jan4)
+  const targetMonday = addDays(w1Monday, (week - 1) * 7)
+  return addDays(targetMonday, 3) // Thursday — safely inside the week
+}
+
+/**
+ * Resolve the Mon 00:00 / Sun 23:59:59.999 window for a weekIso.
+ * Returns null if the weekIso is malformed.
+ */
+export function weekWindowForIso(
+  weekIso: string,
+): {start: Date; end: Date} | null {
+  const anchor = parseWeekIsoToDate(weekIso)
+  if (!anchor) return null
+  return weekWindow(anchor)
+}

--- a/src/features/activityAndRecap/reducer/rankTopPost.ts
+++ b/src/features/activityAndRecap/reducer/rankTopPost.ts
@@ -1,0 +1,34 @@
+/**
+ * Pure ranking helper for the weekly recap top-post selection (AC-B2).
+ *
+ * Sort by `likeCount + repostCount + replyCount` descending; tiebreaker
+ * newer wins (Q3 default). Input is an array of opaque "candidate"
+ * objects with engagement fields + indexedAt — we return a ranked copy.
+ */
+
+export type TopPostCandidate = {
+  uri: string
+  cid: string
+  /** Millisecond epoch. Typically `new Date(post.indexedAt).getTime()`. */
+  indexedAtMs: number
+  likeCount: number
+  repostCount: number
+  replyCount: number
+}
+
+/**
+ * Return candidates sorted by engagement desc with newer-wins tiebreaker.
+ * The return is a new array; the input is not mutated.
+ */
+export function rankTopPost(
+  candidates: readonly TopPostCandidate[],
+): TopPostCandidate[] {
+  const score = (c: TopPostCandidate) =>
+    (c.likeCount ?? 0) + (c.repostCount ?? 0) + (c.replyCount ?? 0)
+  return [...candidates].sort((a, b) => {
+    const sb = score(b)
+    const sa = score(a)
+    if (sb !== sa) return sb - sa
+    return (b.indexedAtMs ?? 0) - (a.indexedAtMs ?? 0)
+  })
+}

--- a/src/features/activityAndRecap/storage.ts
+++ b/src/features/activityAndRecap/storage.ts
@@ -1,0 +1,133 @@
+/**
+ * Account-scoped storage wrapper for the Activity & Recap feature.
+ *
+ * All reads/writes go through the `account` Storage<> instance exported
+ * from `#/storage` — never the raw MMKV (ARCHITECTURE.md §5 Rule).
+ * Defensive reads apply a version guard for `StreakStore`; mismatched
+ * versions are handled at the reducer boundary (see computeNextStreak).
+ */
+
+import {
+  MAX_DISMISSED_RECAP_WEEKS,
+  MAX_FOLLOWER_SNAPSHOTS,
+} from '#/features/activityAndRecap/constants'
+import {
+  type ActivityAndRecapPrefs,
+  type FollowerSnapshot,
+  STREAK_STORE_VERSION,
+  type StreakStore,
+} from '#/features/activityAndRecap/types'
+import {account} from '#/storage'
+
+/* ---------- Streak ---------- */
+
+export function readStreak(did: string): StreakStore | undefined {
+  const value = account.get([did, 'streak'])
+  if (!value) return undefined
+  if (value.version !== STREAK_STORE_VERSION) {
+    // Version mismatch is handled by the reducer (defensive reset on next visit).
+    return value
+  }
+  return value
+}
+
+export function writeStreak(did: string, next: StreakStore): void {
+  account.set([did, 'streak'], next)
+}
+
+/* ---------- Follower snapshots (ring buffer) ---------- */
+
+export function readFollowerSnapshots(did: string): FollowerSnapshot[] {
+  return account.get([did, 'followerSnapshots']) ?? []
+}
+
+/**
+ * Append a snapshot; if an entry for the same day already exists, replace
+ * it. Trim to `MAX_FOLLOWER_SNAPSHOTS` entries (drop oldest).
+ */
+export function upsertFollowerSnapshot(
+  did: string,
+  snapshot: FollowerSnapshot,
+): void {
+  const existing = readFollowerSnapshots(did)
+  const without = existing.filter(s => s.day !== snapshot.day)
+  const next = [...without, snapshot].sort((a, b) => a.day.localeCompare(b.day))
+  const trimmed =
+    next.length > MAX_FOLLOWER_SNAPSHOTS
+      ? next.slice(next.length - MAX_FOLLOWER_SNAPSHOTS)
+      : next
+  account.set([did, 'followerSnapshots'], trimmed)
+}
+
+/* ---------- Prefs (toggles + dismissals + firstShown) ---------- */
+
+export function readPrefs(did: string): ActivityAndRecapPrefs {
+  return account.get([did, 'activityAndRecap']) ?? {}
+}
+
+export function writePrefs(did: string, prefs: ActivityAndRecapPrefs): void {
+  account.set([did, 'activityAndRecap'], prefs)
+}
+
+/** Merge a patch into the prefs blob. Caller-friendly. */
+export function patchPrefs(
+  did: string,
+  patch: Partial<ActivityAndRecapPrefs>,
+): ActivityAndRecapPrefs {
+  const prev = readPrefs(did)
+  const next: ActivityAndRecapPrefs = {...prev, ...patch}
+  writePrefs(did, next)
+  return next
+}
+
+export function dismissRecapWeek(did: string, weekIso: string): void {
+  const prev = readPrefs(did)
+  const ids = new Set(prev.dismissedRecapWeekIds ?? [])
+  ids.add(weekIso)
+  // Bound the set; keep the most recent `MAX_DISMISSED_RECAP_WEEKS`
+  // (lexicographic comparison works for 'YYYY-Www').
+  const sorted = Array.from(ids).sort()
+  const trimmed =
+    sorted.length > MAX_DISMISSED_RECAP_WEEKS
+      ? sorted.slice(sorted.length - MAX_DISMISSED_RECAP_WEEKS)
+      : sorted
+  writePrefs(did, {...prev, dismissedRecapWeekIds: trimmed})
+}
+
+export function isRecapWeekDismissed(did: string, weekIso: string): boolean {
+  return !!readPrefs(did).dismissedRecapWeekIds?.includes(weekIso)
+}
+
+export function markRecapCardFirstShown(
+  did: string,
+  weekIso: string,
+  utcMs: number,
+): void {
+  const prev = readPrefs(did)
+  const map = {...(prev.recapCardFirstShown ?? {})}
+  if (!map[weekIso]) {
+    map[weekIso] = utcMs
+    writePrefs(did, {...prev, recapCardFirstShown: map})
+  }
+}
+
+export function getRecapCardFirstShown(
+  did: string,
+  weekIso: string,
+): number | undefined {
+  return readPrefs(did).recapCardFirstShown?.[weekIso]
+}
+
+/* ---------- Cleanup (AC-A10) ---------- */
+
+/**
+ * Remove ALL Activity & Recap state for a given DID. Called by
+ * `removeAccount` in the session reducer (S21).
+ *
+ * Co-exported from the feature root via `clearActivityAndRecapDataForDid.ts`.
+ */
+export function clearAllForDid(did: string): void {
+  account.remove([did, 'streak'])
+  account.remove([did, 'followerSnapshots'])
+  account.remove([did, 'activityAndRecap'])
+}

--- a/src/features/activityAndRecap/types.ts
+++ b/src/features/activityAndRecap/types.ts
@@ -1,0 +1,96 @@
+/**
+ * Types for the Activity & Recap feature (ticket i9KLo7kw).
+ *
+ * All persisted shapes are versioned and stored in Account-scoped MMKV
+ * (tier 3). See `storage.ts` for reads/writes and `constants.ts` for
+ * bounds / tuning knobs.
+ */
+
+export const STREAK_STORE_VERSION = 1
+
+/**
+ * Account-scoped streak state. Missing means "never visited".
+ */
+export type StreakStore = {
+  /** Schema version for forward-compat */
+  version: typeof STREAK_STORE_VERSION
+  /** 0 after fresh install / post-reset */
+  currentStreak: number
+  /** High-water mark, never decreases */
+  longestStreak: number
+  /** 'YYYY-MM-DD' in `lastVisitZone` */
+  lastVisitDay: string
+  /** IANA tz, e.g. 'America/New_York' (A5) */
+  lastVisitZone: string
+  /** UTC epoch ms — the monotonic guard anchor (A5) */
+  lastVisitAtUtcMs: number
+  /** Set true when we forgive exactly 1 missed day (A3, G2) */
+  graceUsedForCurrentStreak: boolean
+}
+
+/**
+ * One per-day snapshot of the follower count. Ring-buffered in account
+ * MMKV; size bounded by `MAX_FOLLOWER_SNAPSHOTS`.
+ */
+export type FollowerSnapshot = {
+  /** 'YYYY-MM-DD' local day */
+  day: string
+  /** `followersCount` from getProfile at capture time */
+  count: number
+}
+
+/**
+ * Consolidated activity & recap preferences + dismissals.
+ * Per-account (AC-X2) via MMKV scoped by DID.
+ */
+export type ActivityAndRecapPrefs = {
+  /** AC-X1: default true. When false, StreakIndicator hides. */
+  showStreak?: boolean
+  /** AC-X1: default true. When false, WeeklyRecapCard hides and query never fires (B11). */
+  showRecap?: boolean
+  /** ISO week IDs (e.g. '2026-W15'). Bounded via `MAX_DISMISSED_RECAP_WEEKS`. */
+  dismissedRecapWeekIds?: string[]
+  /** weekIso -> UTC ms of first render. Used for B6 auto-expiry. */
+  recapCardFirstShown?: Record<string, number>
+}
+
+/**
+ * Weekly recap payload cached in TanStack Query (tier 4).
+ *
+ * Only `{uri, cid}` is persisted for `topPost` — the Recap screen re-fetches
+ * the full post so it inherits moderation filtering at render time (B10).
+ */
+export type WeeklyRecap = {
+  /** 'YYYY-Www' */
+  weekIso: string
+  /** ISO datetime, Monday 00:00 local */
+  windowStart: string
+  /** ISO datetime, Sunday 23:59:59 local */
+  windowEnd: string
+  /**
+   * Single combined count of posts authored in the window
+   * (originals + self-replies + self-reposts). See Q_B2_posts default.
+   */
+  postsCount: number
+  /** `max(0, end - start)` snapshot delta (B4) */
+  followerDelta: number
+  /** Null when moderation fallback has been exhausted (B10). */
+  topPost: {uri: string; cid: string} | null
+  /**
+   * Additional ranked candidates used for moderation fallback at render
+   * time (B10). Not shown to the user; only consumed by the Recap screen.
+   */
+  topPostCandidates: {uri: string; cid: string}[]
+  fetchedAtUtcMs: number
+}
+
+/**
+ * Pure-function day/time input; constructed from `Date.now()` at call site.
+ * Exposes the monotonic UTC anchor, the IANA tz, and the resolved local
+ * YYYY-MM-DD for that tz.
+ */
+export type NowInput = {
+  utcMs: number
+  zone: string
+  localDay: string
+}

--- a/src/lib/routes/types.ts
+++ b/src/lib/routes/types.ts
@@ -90,6 +90,10 @@ export type CommonNavigatorParams = {
   VideoFeed: VideoFeedSourceContext
   Bookmarks: undefined
   FindContactsFlow: undefined
+  // Activity & Recap (ticket i9KLo7kw)
+  Recap: {weekId: string}
+  PastRecaps: undefined
+  ActivityAndRecap: undefined
 }
 
 export type BottomTabNavigatorParams = CommonNavigatorParams & {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -94,4 +94,8 @@ export const router = new Router<AllNavigatableRoutes>({
   VideoFeed: '/video-feed',
   Bookmarks: '/saved',
   FindContactsFlow: '/find-contacts',
+  // Activity & Recap (ticket i9KLo7kw)
+  Recap: '/recap/:weekId',
+  PastRecaps: '/recaps',
+  ActivityAndRecap: '/settings/activity-and-recap',
 })

--- a/src/screens/PastRecaps/index.tsx
+++ b/src/screens/PastRecaps/index.tsx
@@ -1,0 +1,79 @@
+/**
+ * PastRecapsScreen (S16) — list of the last `PAST_RECAPS_WINDOW` ISO weeks
+ * (default 4) (B5). Each row navigates to the Recap route, where the
+ * existing weeklyRecap query handles cache hit / refetch.
+ *
+ * No separate storage; this screen is a pure index into the existing
+ * weeklyRecap query keyspace.
+ */
+
+import {useMemo} from 'react'
+import {msg} from '@lingui/core/macro'
+import {useLingui} from '@lingui/react'
+import {Trans} from '@lingui/react/macro'
+import {type NativeStackScreenProps} from '@react-navigation/native-stack'
+
+import {type CommonNavigatorParams} from '#/lib/routes/types'
+import * as SettingsList from '#/screens/Settings/components/SettingsList'
+import {ListSparkle_Stroke2_Corner0_Rounded as ListSparkleIcon} from '#/components/icons/ListSparkle'
+import * as Layout from '#/components/Layout'
+import {PAST_RECAPS_WINDOW} from '#/features/activityAndRecap/constants'
+import {useStreaksAndRecapEnabled} from '#/features/activityAndRecap/hooks/useStreaksAndRecapEnabled'
+import {
+  lastNWeekIsos,
+  weekWindowForIso,
+} from '#/features/activityAndRecap/reducer/isoWeek'
+
+type Props = NativeStackScreenProps<CommonNavigatorParams, 'PastRecaps'>
+
+export function PastRecapsScreen({}: Props) {
+  const {_, i18n} = useLingui()
+  const featureOn = useStreaksAndRecapEnabled()
+
+  // Stable list per render — recompute only when the day changes (cheap).
+  const weekIds = useMemo(
+    () => lastNWeekIsos(new Date(), PAST_RECAPS_WINDOW),
+    [],
+  )
+
+  return (
+    <Layout.Screen testID="pastRecapsScreen">
+      <Layout.Header.Outer>
+        <Layout.Header.BackButton />
+        <Layout.Header.Content>
+          <Layout.Header.TitleText>
+            <Trans>Past recaps</Trans>
+          </Layout.Header.TitleText>
+        </Layout.Header.Content>
+        <Layout.Header.Slot />
+      </Layout.Header.Outer>
+      <Layout.Content>
+        {featureOn ? (
+          <SettingsList.Container>
+            {weekIds.map(weekIso => {
+              const window = weekWindowForIso(weekIso)
+              const startStr = window
+                ? i18n.date(window.start, {month: 'short', day: 'numeric'})
+                : weekIso
+              const endStr = window
+                ? i18n.date(window.end, {month: 'short', day: 'numeric'})
+                : ''
+              const rangeLabel = window
+                ? _(msg`${startStr} – ${endStr}`)
+                : weekIso
+              return (
+                <SettingsList.LinkItem
+                  key={weekIso}
+                  to={`/recap/${weekIso}`}
+                  label={_(msg`Week of ${startStr}`)}>
+                  <SettingsList.ItemIcon icon={ListSparkleIcon} />
+                  <SettingsList.ItemText>{rangeLabel}</SettingsList.ItemText>
+                </SettingsList.LinkItem>
+              )
+            })}
+          </SettingsList.Container>
+        ) : null}
+      </Layout.Content>
+    </Layout.Screen>
+  )
+}

--- a/src/screens/Recap/components/RecapHeader.tsx
+++ b/src/screens/Recap/components/RecapHeader.tsx
@@ -1,0 +1,39 @@
+/**
+ * RecapHeader (S15) — title + week range subline used by RecapScreen.
+ *
+ * Receives the resolved window from the parent (the parent already owns
+ * the weekIso → window math via `weekWindowForIso`), so this component
+ * stays pure presentational.
+ */
+
+import {View} from 'react-native'
+import {useLingui} from '@lingui/react'
+import {Trans} from '@lingui/react/macro'
+
+import {atoms as a, useTheme} from '#/alf'
+import {Text} from '#/components/Typography'
+
+export function RecapHeader({
+  windowStart,
+  windowEnd,
+}: {
+  windowStart: Date
+  windowEnd: Date
+}) {
+  const t = useTheme()
+  const {i18n} = useLingui()
+  // Use Lingui's i18n.date helper so the locale governs the format.
+  const startStr = i18n.date(windowStart, {month: 'short', day: 'numeric'})
+  const endStr = i18n.date(windowEnd, {month: 'short', day: 'numeric'})
+
+  return (
+    <View style={[a.px_lg, a.py_md, a.gap_2xs]}>
+      <Text style={[a.text_2xl, a.font_bold, t.atoms.text]}>
+        <Trans>Your week on Bluesky</Trans>
+      </Text>
+      <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+        {startStr} – {endStr}
+      </Text>
+    </View>
+  )
+}

--- a/src/screens/Recap/components/TopPostEmbed.tsx
+++ b/src/screens/Recap/components/TopPostEmbed.tsx
@@ -1,0 +1,70 @@
+/**
+ * TopPostEmbed (S15, B10) — fetches the top post by uri and renders via the
+ * shared `Post` component. If the fetched view is a tombstone (or fetch
+ * fails), promote the next-highest candidate. When all candidates are
+ * exhausted, render an inline "no top post available" line.
+ *
+ * The fallback iteration happens client-side rather than at query time so
+ * that moderation filtering benefits from the user's current preferences
+ * (which might evolve between the recap fetch and the recap view).
+ */
+
+import {useMemo, useState} from 'react'
+import {View} from 'react-native'
+import {Trans} from '@lingui/react/macro'
+
+import {usePostQuery} from '#/state/queries/post'
+import {Post} from '#/view/com/post/Post'
+import {atoms as a, useTheme} from '#/alf'
+import {Text} from '#/components/Typography'
+
+type Ref = {uri: string; cid: string}
+
+export function TopPostEmbed({candidates}: {candidates: Ref[]}) {
+  const t = useTheme()
+  const [index, setIndex] = useState(0)
+  const current = candidates[index]
+  const {data, isError, isLoading} = usePostQuery(current?.uri)
+
+  // Promote next candidate on hard fetch error (B10 fallback).
+  const handleError = () => {
+    if (index + 1 < candidates.length) setIndex(index + 1)
+  }
+
+  // Trigger promotion exactly once per index when query errors.
+  useMemo(() => {
+    if (isError) handleError()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isError, index])
+
+  if (!current) return <NoTopPost />
+  if (isLoading) {
+    return (
+      <View style={[a.px_lg, a.py_md]}>
+        <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+          <Trans>Loading top post…</Trans>
+        </Text>
+      </View>
+    )
+  }
+  // Already-handled error: usePostQuery's useMemo bumped the index.
+  if (isError) return null
+  if (!data) return <NoTopPost />
+
+  return (
+    <View style={[a.px_lg, a.py_sm]}>
+      <Post post={data} />
+    </View>
+  )
+}
+
+function NoTopPost() {
+  const t = useTheme()
+  return (
+    <View style={[a.px_lg, a.py_md]}>
+      <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+        <Trans>No top post to feature this week.</Trans>
+      </Text>
+    </View>
+  )
+}

--- a/src/screens/Recap/index.tsx
+++ b/src/screens/Recap/index.tsx
@@ -1,0 +1,158 @@
+/**
+ * RecapScreen (S15) — full-screen route for "Your week on Bluesky".
+ *
+ * Renders three metric tiles (posts, new followers, top post) for the week
+ * referenced by `route.params.weekId`. Top post renders via the existing
+ * `Post` component which inherits moderation filtering (B10). On fetch
+ * error, surfaces a manual "Try again" button — manual retry bypasses the
+ * 2/hr automatic budget enforced in `retryBudget.ts` (B8).
+ *
+ * Hidden when the feature flag is off (X6).
+ */
+
+import {View} from 'react-native'
+import {msg, plural} from '@lingui/core/macro'
+import {useLingui} from '@lingui/react'
+import {Trans} from '@lingui/react/macro'
+import {type NativeStackScreenProps} from '@react-navigation/native-stack'
+
+import {type CommonNavigatorParams} from '#/lib/routes/types'
+import {atoms as a, useTheme} from '#/alf'
+import {Button, ButtonText} from '#/components/Button'
+import * as Layout from '#/components/Layout'
+import {Text} from '#/components/Typography'
+import {RecapMetricTile} from '#/features/activityAndRecap/components/RecapMetricTile'
+import {useStreaksAndRecapEnabled} from '#/features/activityAndRecap/hooks/useStreaksAndRecapEnabled'
+import {resetAutoRetry} from '#/features/activityAndRecap/queries/retryBudget'
+import {useWeeklyRecapQuery} from '#/features/activityAndRecap/queries/weeklyRecap'
+import {weekWindowForIso} from '#/features/activityAndRecap/reducer/isoWeek'
+import {RecapHeader} from './components/RecapHeader'
+import {TopPostEmbed} from './components/TopPostEmbed'
+
+type Props = NativeStackScreenProps<CommonNavigatorParams, 'Recap'>
+
+export function RecapScreen({route}: Props) {
+  const featureOn = useStreaksAndRecapEnabled()
+  const weekIso = route.params?.weekId ?? null
+
+  return (
+    <Layout.Screen testID="recapScreen">
+      <Layout.Header.Outer>
+        <Layout.Header.BackButton />
+        <Layout.Header.Content>
+          <Layout.Header.TitleText>
+            <Trans>Recap</Trans>
+          </Layout.Header.TitleText>
+        </Layout.Header.Content>
+        <Layout.Header.Slot />
+      </Layout.Header.Outer>
+      <Layout.Content>
+        {featureOn && weekIso ? (
+          <RecapBody weekIso={weekIso} />
+        ) : (
+          <View style={[a.p_lg]}>
+            <Text>
+              <Trans>This recap isn't available right now.</Trans>
+            </Text>
+          </View>
+        )}
+      </Layout.Content>
+    </Layout.Screen>
+  )
+}
+
+function RecapBody({weekIso}: {weekIso: string}) {
+  const {_} = useLingui()
+  const t = useTheme()
+  const window = weekWindowForIso(weekIso)
+  const {data, isLoading, isError, refetch} = useWeeklyRecapQuery({weekIso})
+
+  if (!window) {
+    return (
+      <View style={[a.p_lg]}>
+        <Text style={[t.atoms.text_contrast_medium]}>
+          <Trans>This recap isn't available right now.</Trans>
+        </Text>
+      </View>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <View style={[a.p_lg]}>
+        <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+          <Trans>Computing your week…</Trans>
+        </Text>
+      </View>
+    )
+  }
+
+  if (isError || !data) {
+    return (
+      <View style={[a.p_lg, a.gap_md]}>
+        <Text style={[t.atoms.text]}>
+          <Trans>We couldn't load this recap.</Trans>
+        </Text>
+        <Button
+          label={_(msg`Try again`)}
+          color="primary"
+          size="small"
+          onPress={() => {
+            // B8 manual-retry bypass: clear the per-week auto-retry counter
+            // before refetching so the queryFn isn't short-circuited.
+            resetAutoRetry(weekIso)
+            refetch()
+          }}>
+          <ButtonText>
+            <Trans>Try again</Trans>
+          </ButtonText>
+        </Button>
+      </View>
+    )
+  }
+
+  const postsLabel = _(
+    msg`${plural(data.postsCount, {one: '# post', other: '# posts'})}`,
+  )
+  const followersLabel = _(
+    msg`${plural(data.followerDelta, {
+      one: '# new follower',
+      other: '# new followers',
+    })}`,
+  )
+
+  // B10: prefer topPostCandidates so we can promote past tombstones at
+  // render time. Fall back to the singleton topPost when present.
+  const candidates =
+    data.topPostCandidates && data.topPostCandidates.length > 0
+      ? data.topPostCandidates
+      : data.topPost
+        ? [data.topPost]
+        : []
+
+  return (
+    <View>
+      <RecapHeader windowStart={window.start} windowEnd={window.end} />
+
+      <View style={[a.flex_row, a.gap_sm, a.px_lg, a.pb_md]}>
+        <RecapMetricTile
+          testID="recapScreen-posts"
+          label={_(msg`Posts`)}
+          value={postsLabel}
+        />
+        <RecapMetricTile
+          testID="recapScreen-followers"
+          label={_(msg`Followers`)}
+          value={followersLabel}
+        />
+      </View>
+
+      <View style={[a.px_lg, a.pt_sm]}>
+        <Text style={[a.text_sm, a.font_bold, t.atoms.text_contrast_medium]}>
+          <Trans>Top post</Trans>
+        </Text>
+      </View>
+      <TopPostEmbed candidates={candidates} />
+    </View>
+  )
+}

--- a/src/screens/Settings/ActivityAndRecap/index.tsx
+++ b/src/screens/Settings/ActivityAndRecap/index.tsx
@@ -1,0 +1,104 @@
+/**
+ * Activity & Recap settings sub-screen (S17, ticket i9KLo7kw).
+ *
+ * Two toggles: "Show daily streak" and "Show weekly recap" — both default
+ * ON (X1). Past recaps link below. Fires the streak:optIn/Out and
+ * recap:optIn/Out analytics events on toggle changes (B12 booleans-only
+ * payloads). No re-prompt logic (G10).
+ *
+ * Hidden from the Content & Media list when the feature flag is off
+ * (handled by ContentAndMediaSettings via useStreaksAndRecapEnabled).
+ */
+
+import {msg} from '@lingui/core/macro'
+import {useLingui} from '@lingui/react'
+import {Trans} from '@lingui/react/macro'
+import {type NativeStackScreenProps} from '@react-navigation/native-stack'
+
+import {type CommonNavigatorParams} from '#/lib/routes/types'
+import * as SettingsList from '#/screens/Settings/components/SettingsList'
+import * as Toggle from '#/components/forms/Toggle'
+import {Flame_Stroke2_Corner1_Rounded as FlameIcon} from '#/components/icons/Flame'
+import {ListSparkle_Stroke2_Corner0_Rounded as ListSparkleIcon} from '#/components/icons/ListSparkle'
+import {Sparkle_Stroke2_Corner0_Rounded as SparkleIcon} from '#/components/icons/Sparkle'
+import * as Layout from '#/components/Layout'
+import {useAnalytics} from '#/analytics'
+import {
+  recapOptIn,
+  recapOptOut,
+  streakOptIn,
+  streakOptOut,
+} from '#/features/activityAndRecap/analytics/events'
+import {useShowRecapPreference} from '#/features/activityAndRecap/hooks/useShowRecapPreference'
+import {useShowStreakPreference} from '#/features/activityAndRecap/hooks/useShowStreakPreference'
+import {useStreaksAndRecapEnabled} from '#/features/activityAndRecap/hooks/useStreaksAndRecapEnabled'
+
+type Props = NativeStackScreenProps<CommonNavigatorParams, 'ActivityAndRecap'>
+export function ActivityAndRecapSettingsScreen({}: Props) {
+  const {_} = useLingui()
+  const ax = useAnalytics()
+  const featureOn = useStreaksAndRecapEnabled()
+  const [showStreak, setShowStreak] = useShowStreakPreference()
+  const [showRecap, setShowRecap] = useShowRecapPreference()
+
+  return (
+    <Layout.Screen>
+      <Layout.Header.Outer>
+        <Layout.Header.BackButton />
+        <Layout.Header.Content>
+          <Layout.Header.TitleText>
+            <Trans>Activity & Recap</Trans>
+          </Layout.Header.TitleText>
+        </Layout.Header.Content>
+        <Layout.Header.Slot />
+      </Layout.Header.Outer>
+      <Layout.Content>
+        {featureOn ? (
+          <SettingsList.Container>
+            <Toggle.Item
+              name="show_daily_streak"
+              label={_(msg`Show daily streak`)}
+              value={showStreak}
+              onChange={(value: boolean) => {
+                setShowStreak(value)
+                if (value) ax.metric(...streakOptIn())
+                else ax.metric(...streakOptOut())
+              }}>
+              <SettingsList.Item>
+                <SettingsList.ItemIcon icon={FlameIcon} />
+                <SettingsList.ItemText>
+                  <Trans>Show daily streak</Trans>
+                </SettingsList.ItemText>
+                <Toggle.Platform />
+              </SettingsList.Item>
+            </Toggle.Item>
+            <Toggle.Item
+              name="show_weekly_recap"
+              label={_(msg`Show weekly recap`)}
+              value={showRecap}
+              onChange={(value: boolean) => {
+                setShowRecap(value)
+                if (value) ax.metric(...recapOptIn())
+                else ax.metric(...recapOptOut())
+              }}>
+              <SettingsList.Item>
+                <SettingsList.ItemIcon icon={SparkleIcon} />
+                <SettingsList.ItemText>
+                  <Trans>Show weekly recap</Trans>
+                </SettingsList.ItemText>
+                <Toggle.Platform />
+              </SettingsList.Item>
+            </Toggle.Item>
+            <SettingsList.Divider />
+            <SettingsList.LinkItem to="/recaps" label={_(msg`Past recaps`)}>
+              <SettingsList.ItemIcon icon={ListSparkleIcon} />
+              <SettingsList.ItemText>
+                <Trans>Past recaps</Trans>
+              </SettingsList.ItemText>
+            </SettingsList.LinkItem>
+          </SettingsList.Container>
+        ) : null}
+      </Layout.Content>
+    </Layout.Screen>
+  )
+}

--- a/src/screens/Settings/ContentAndMediaSettings.tsx
+++ b/src/screens/Settings/ContentAndMediaSettings.tsx
@@ -18,6 +18,7 @@ import * as SettingsList from '#/screens/Settings/components/SettingsList'
 import * as Toggle from '#/components/forms/Toggle'
 import {Bubbles_Stroke2_Corner2_Rounded as BubblesIcon} from '#/components/icons/Bubble'
 import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
+import {Flame_Stroke2_Corner1_Rounded as FlameIcon} from '#/components/icons/Flame'
 import {Hashtag_Stroke2_Corner0_Rounded as HashtagIcon} from '#/components/icons/Hashtag'
 import {Home_Stroke2_Corner2_Rounded as HomeIcon} from '#/components/icons/Home'
 import {Macintosh_Stroke2_Corner2_Rounded as MacintoshIcon} from '#/components/icons/Macintosh'
@@ -27,6 +28,7 @@ import {Window_Stroke2_Corner2_Rounded as WindowIcon} from '#/components/icons/W
 import * as Layout from '#/components/Layout'
 import {useAnalytics} from '#/analytics'
 import {IS_NATIVE} from '#/env'
+import {useStreaksAndRecapEnabled} from '#/features/activityAndRecap/hooks/useStreaksAndRecapEnabled'
 
 type Props = NativeStackScreenProps<
   CommonNavigatorParams,
@@ -43,6 +45,8 @@ export function ContentAndMediaSettingsScreen({}: Props) {
   const {trendingDisabled, trendingVideoDisabled} = useTrendingSettings()
   const {setTrendingDisabled, setTrendingVideoDisabled} =
     useTrendingSettingsApi()
+  // G_settings: Activity & Recap entry hidden when feature flag off (X6).
+  const streaksAndRecapEnabled = useStreaksAndRecapEnabled()
 
   return (
     <Layout.Screen>
@@ -97,6 +101,16 @@ export function ContentAndMediaSettingsScreen({}: Props) {
               <Trans>Your interests</Trans>
             </SettingsList.ItemText>
           </SettingsList.LinkItem>
+          {streaksAndRecapEnabled ? (
+            <SettingsList.LinkItem
+              to="/settings/activity-and-recap"
+              label={_(msg`Activity & Recap`)}>
+              <SettingsList.ItemIcon icon={FlameIcon} />
+              <SettingsList.ItemText>
+                <Trans>Activity & Recap</Trans>
+              </SettingsList.ItemText>
+            </SettingsList.LinkItem>
+          ) : null}
           <SettingsList.Divider />
           {IS_NATIVE && (
             <Toggle.Item

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -39,6 +39,7 @@ import {
   clearAgeAssuranceData,
   clearAgeAssuranceDataForDid,
 } from '#/ageAssurance/data'
+import {clearActivityAndRecapDataForDid} from '#/features/activityAndRecap/clearActivityAndRecapDataForDid'
 
 const StateContext = createContext<SessionStateContext>({
   accounts: [],
@@ -305,6 +306,9 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       })
       addSessionDebugLog({type: 'method:end', method: 'removeAccount', account})
       clearAgeAssuranceDataForDid({did: account.did})
+      // S21 (A10): wipe streak + follower snapshots + recap prefs/dismissals
+      // for this DID. Account-scoped MMKV cleanup mirrors age-assurance.
+      clearActivityAndRecapDataForDid({did: account.did})
     },
     [store, cancelPendingTask],
   )

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -1,4 +1,9 @@
 import {type ID as PolicyUpdate202508} from '#/components/PolicyUpdateOverlay/updates/202508/config'
+import {
+  type ActivityAndRecapPrefs,
+  type FollowerSnapshot,
+  type StreakStore,
+} from '#/features/activityAndRecap/types'
 import {type Geolocation} from '#/geolocation/types'
 
 /**
@@ -79,4 +84,22 @@ export type Account = {
   birthdateLastUpdatedAt?: string
 
   lastSelectedHomeFeed?: string
+
+  /**
+   * Activity & Recap (ticket i9KLo7kw) — daily-visit streak state.
+   * Missing = never visited. See `src/features/activityAndRecap/types.ts`.
+   */
+  streak?: StreakStore
+
+  /**
+   * Activity & Recap — per-day follower-count snapshots used to compute
+   * "new followers this week" (R2). Ring-buffered; max 35 entries.
+   */
+  followerSnapshots?: FollowerSnapshot[]
+
+  /**
+   * Activity & Recap — per-account preferences and dismissals.
+   * Default-on toggles (AC-X1) handled at the read hook boundary.
+   */
+  activityAndRecap?: ActivityAndRecapPrefs
 }

--- a/src/view/com/home/HomeHeaderLayout.web.tsx
+++ b/src/view/com/home/HomeHeaderLayout.web.tsx
@@ -14,6 +14,8 @@ import {ButtonIcon} from '#/components/Button'
 import {Hashtag_Stroke2_Corner0_Rounded as FeedsIcon} from '#/components/icons/Hashtag'
 import * as Layout from '#/components/Layout'
 import {Link} from '#/components/Link'
+import {ActivityAndRecapProvider} from '#/features/activityAndRecap'
+import {StreakIndicator} from '#/features/activityAndRecap/components/StreakIndicator'
 
 export function HomeHeaderLayout(props: {
   children: React.ReactNode
@@ -51,17 +53,21 @@ function HomeHeaderLayoutDesktopAndTablet({
             <View style={[a.flex_1, a.align_center, a.justify_center]}>
               <Logo width={kawaii ? 60 : 28} />
             </View>
-            <Link
-              to="/feeds"
-              hitSlop={HITSLOP_10}
-              label={_(msg`View your feeds and explore more`)}
-              size="small"
-              variant="ghost"
-              color="secondary"
-              shape="square"
-              style={[a.justify_center]}>
-              <ButtonIcon icon={FeedsIcon} size="lg" />
-            </Link>
+            <View style={[a.flex_row, a.align_center, a.gap_xs]}>
+              {/* S18: streak flame visible only on Home tab. */}
+              <StreakIndicator />
+              <Link
+                to="/feeds"
+                hitSlop={HITSLOP_10}
+                label={_(msg`View your feeds and explore more`)}
+                size="small"
+                variant="ghost"
+                color="secondary"
+                shape="square"
+                style={[a.justify_center]}>
+                <ButtonIcon icon={FeedsIcon} size="lg" />
+              </Link>
+            </View>
           </View>
         </Layout.Center>
       )}
@@ -73,6 +79,12 @@ function HomeHeaderLayoutDesktopAndTablet({
         }}>
         {children}
       </Layout.Center>
+      {/*
+        S20: web tracker mount site (mirrors HomeHeaderLayoutMobile). The
+        provider renders null and only invokes useStreakTracker. The hook
+        gates internally on flag + showStreak preference.
+      */}
+      <ActivityAndRecapProvider />
     </>
   )
 }

--- a/src/view/com/home/HomeHeaderLayoutMobile.tsx
+++ b/src/view/com/home/HomeHeaderLayoutMobile.tsx
@@ -20,6 +20,8 @@ import {Hashtag_Stroke2_Corner0_Rounded as FeedsIcon} from '#/components/icons/H
 import * as Layout from '#/components/Layout'
 import {Link} from '#/components/Link'
 import {IS_DEV, IS_LIQUID_GLASS} from '#/env'
+import {ActivityAndRecapProvider} from '#/features/activityAndRecap'
+import {StreakIndicator} from '#/features/activityAndRecap/components/StreakIndicator'
 
 export function HomeHeaderLayoutMobile({
   children,
@@ -75,26 +77,38 @@ export function HomeHeaderLayoutMobile({
 
         <Layout.Header.Slot>
           {hasSession && (
-            <Link
-              testID="viewHeaderHomeFeedPrefsBtn"
-              to={{screen: 'Feeds'}}
-              hitSlop={HITSLOP_10}
-              label={_(msg`View your feeds and explore more`)}
-              size="small"
-              variant="ghost"
-              color="secondary"
-              shape="square"
-              style={[
-                a.justify_center,
-                {marginRight: -Layout.BUTTON_VISUAL_ALIGNMENT_OFFSET},
-                a.bg_transparent,
-              ]}>
-              <ButtonIcon icon={FeedsIcon} size="lg" />
-            </Link>
+            <View style={[a.flex_row, a.align_center, a.gap_xs]}>
+              {/* S18: streak flame visible only on Home tab. */}
+              <StreakIndicator />
+              <Link
+                testID="viewHeaderHomeFeedPrefsBtn"
+                to={{screen: 'Feeds'}}
+                hitSlop={HITSLOP_10}
+                label={_(msg`View your feeds and explore more`)}
+                size="small"
+                variant="ghost"
+                color="secondary"
+                shape="square"
+                style={[
+                  a.justify_center,
+                  {marginRight: -Layout.BUTTON_VISUAL_ALIGNMENT_OFFSET},
+                  a.bg_transparent,
+                ]}>
+                <ButtonIcon icon={FeedsIcon} size="lg" />
+              </Link>
+            </View>
           )}
         </Layout.Header.Slot>
       </Layout.Header.Outer>
       {children}
+      {/*
+        S20: tracker mount site. Provider renders null and only invokes
+        useStreakTracker. Lives in HomeHeaderLayoutMobile because the Home
+        tab is the only surface where qualifying-visit detection makes
+        sense (A1, A6); the hook itself short-circuits when feature flag
+        or showStreak preference is off (X6).
+      */}
+      <ActivityAndRecapProvider />
     </Animated.View>
   )
 }

--- a/src/view/screens/Notifications.tsx
+++ b/src/view/screens/Notifications.tsx
@@ -39,6 +39,7 @@ import * as Layout from '#/components/Layout'
 import {InlineLinkText, Link} from '#/components/Link'
 import {Loader} from '#/components/Loader'
 import {IS_NATIVE} from '#/env'
+import {WeeklyRecapCard} from '#/features/activityAndRecap/components/WeeklyRecapCard'
 
 // We don't currently persist this across reloads since
 // you gotta visit All to clear the badge anyway.
@@ -268,7 +269,11 @@ function NotificationsTab({
           ListHeaderComponent={
             filter === 'mentions' ? (
               <DisabledNotificationsWarning active={isFocusedAndActive} />
-            ) : null
+            ) : (
+              // S19: weekly recap card auto-hides when invisibility predicate
+              // (B1/B5/B6/G7) returns null. Card lives only on the All tab.
+              <WeeklyRecapCard />
+            )
           }
         />
       </MainScrollProvider>


### PR DESCRIPTION
## Summary
- **Streak indicator** (flame + count) in Home header — native and web — visible at streak ≥2, per-account client-local MMKV. Qualifying visit: ≥30s foreground + ≥1 feed render. Silent grace day (1 missed day forgiven), reset after ≥2 missed. Anti-manipulation: IANA device tz day-anchor, UTC monotonic 20h guard.
- **Weekly recap card** pinned to Notifications tab on Monday ≥06:00 local for prior ISO week — posts authored, net new followers, top-engagement post. 7-day auto-expiry, dismissible, 4-week rolling history in Settings.
- **Settings → Activity & Recap** sub-screen with per-account toggles (default ON). Opt-out prevents computation entirely.
- Feature-gated via `StreaksAndRecapEnable` (4 surfaces). Client-only storage, no new lexicon, no PDS record. Humane-first guardrails: no loss-aversion, no push, no social pressure.

Covers ACs: A1–A10, B1–B12, X1–X6 from [Trello card](https://trello.com/c/i9KLo7kw).

## Test plan
- [ ] `yarn typecheck` passes
- [ ] `yarn lint` passes
- [ ] `yarn test` — 574 tests pass (102 new), 0 failures
- [ ] Streak indicator appears after 2 consecutive qualifying visits on Home tab
- [ ] Tap indicator → explainer dialog with current/longest streak, grace-day rule, Settings link
- [ ] `control.close(() => navigate)` pattern verified for dialog→Settings nav
- [ ] Recap card appears in Notifications on Monday for prior week with ≥1 visit
- [ ] Tap recap card → full-screen Recap route with top-post embed
- [ ] Settings toggles take effect <1s, persist per-account, no restart
- [ ] Account switch swaps streak/recap data; account removal clears it
- [ ] Feature flag OFF hides all surfaces
- [ ] RTL, large text, screen reader labels verified
- [ ] All strings Lingui-wrapped (no hardcoded English)

🤖 Generated with [Claude Code](https://claude.com/claude-code)