### PR TITLE
Fix image cropping not saving on iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@braintree/sanitize-url": "^6.0.2",
     "@bsky.app/alf": "^0.1.9",
     "@bsky.app/expo-guess-language": "^0.2.8",
-    "@bsky.app/expo-image-crop-tool": "^0.5.0",
+    "@bsky.app/expo-image-crop-tool": "^0.5.1",
     "@bsky.app/expo-scroll-edge-effect": "^0.1.4",
     "@bsky.app/expo-translate-text": "^0.2.9",
     "@bsky.app/react-native-mmkv": "2.12.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,7 +260,7 @@ importers:
         specifier: ^0.2.8
         version: 0.2.8(expo@54.0.34(@babel/core@7.29.0)(react-native-webview@13.15.0(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@bsky.app/expo-image-crop-tool':
-        specifier: ^0.5.0
+        specifier: ^0.5.1
         version: 0.5.1(expo@54.0.34(@babel/core@7.29.0)(react-native-webview@13.15.0(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@bsky.app/expo-scroll-edge-effect':
         specifier: ^0.1.4

--- a/src/state/gallery.ts
+++ b/src/state/gallery.ts
@@ -19,6 +19,7 @@ import {openCropper} from '#/lib/media/picker'
 import {type PickerImage} from '#/lib/media/picker.shared'
 import {getDataUriSize} from '#/lib/media/util'
 import {isCancelledError} from '#/lib/strings/errors'
+import {logger} from '#/logger'
 import {IS_NATIVE, IS_WEB} from '#/env'
 
 export type ImageTransformation = {
@@ -149,6 +150,7 @@ export async function cropImage(img: ComposerImage): Promise<ComposerImage> {
     }
   } catch (e) {
     if (!isCancelledError(e)) {
+      logger.error('Failed to crop image', {safeMessage: e})
       return img
     }
 


### PR DESCRIPTION
## Summary

- Bump `@bsky.app/expo-image-crop-tool` to `0.5.1` ([PR](https://github.com/bluesky-social/expo-image-crop-tool/pull/20)), which fixes the iOS cropper to write to `cachesDirectory` instead of `NSTemporaryDirectory`.
- Log non-cancellation errors from `cropImage` via `logger.error` so the next breakage in this path doesn't hide behind the silent fallback.

## Why

On iOS, cropping an image in the composer produced the original uncropped preview. The root cause was in the cropper library: it wrote the cropped JPEG into `NSTemporaryDirectory`, but `expo-file-system`'s `moveAsync` only grants write permission on `caches`, `documents`, `applicationSupport`, and app-group directories. The subsequent `moveAsync` call in `moveIfNecessary` threw `File '…/tmp/…/..' is not writable`, which our catch block in `cropImage` swallowed and returned the original `img`.

Android was unaffected because the Kotlin side already wrote into the app's `cacheDir`.

The `logger.error` addition is a secondary mitigation — `cropImage` still falls back to the original image on non-cancellation errors (to avoid breaking the compose flow), but failures now surface in Sentry instead of silently producing the reported symptom.

## Test plan

- [ ] iOS: open composer → add photo → tap edit → crop → confirm. Cropped preview replaces original.
- [ ] iOS: cancel the crop. Composer still shows the original, no error.
- [ ] Android: regression check — crop still works end-to-end.
- [ ] Web: regression check — `EditImageDialog.web.tsx` path untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)