### PR TITLE
Don't sqaure corners around emoji-only messages

### DIFF
--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -162,12 +162,16 @@ let MessageItem = ({
   const hasReactions = message.reactions && message.reactions.length > 0
   const prevHasReactions =
     prevIsMessage && prevMessage.reactions && prevMessage.reactions.length > 0
+  const isNextEmojiOnly = nextIsMessage && isOnlyEmoji(nextMessage.text)
+  const isPrevEmojiOnly = prevIsMessage && isOnlyEmoji(prevMessage.text)
   const squaredBottomCorner =
     !hasReactions &&
+    !isNextEmojiOnly &&
     isInCluster &&
     (isInMiddleOfCluster || effectiveFirstInCluster)
   const squaredTopCorner =
     !prevHasReactions &&
+    !isPrevEmojiOnly &&
     isInCluster &&
     (isInMiddleOfCluster || effectiveLastInCluster)
 


### PR DESCRIPTION
These messages don’t have a a bubble, so it doesn’t make sense visually to cluster them.

**Before**
<img width="155" height="137" alt="before" src="https://github.com/user-attachments/assets/41c55a1f-5685-46ef-8560-055530af5671" />

**After**
<img width="154" height="134" alt="after" src="https://github.com/user-attachments/assets/c5ef66b2-5aea-4b19-936e-3c38341fb28b" />