### PR TITLE
Differentiate reactions that include the viewer

### DIFF
--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -269,6 +269,10 @@ let MessageItem = ({
 
   const reactions = useMemo(() => message.reactions ?? [], [message.reactions])
 
+  const hasSelfReacted = reactions.some(
+    r => r.sender.did === currentAccount?.did,
+  )
+
   const reactionsLabel = useMemo(() => {
     if (reactions.length === 0) return ''
     if (reactions.length === 1) {
@@ -322,7 +326,11 @@ let MessageItem = ({
               a.rounded_lg,
               a.border,
               t.atoms.border_contrast_low,
-              t.atoms.bg_contrast_25,
+              hasSelfReacted
+                ? {
+                    backgroundColor: t.palette.primary_100,
+                  }
+                : t.atoms.bg_contrast_25,
               t.atoms.shadow_sm,
               {
                 paddingTop: platform({android: 2, default: 3}),
@@ -368,7 +376,11 @@ let MessageItem = ({
                 <Text
                   style={[
                     a.text_xs,
-                    t.atoms.text_contrast_medium,
+                    hasSelfReacted
+                      ? {
+                          color: t.palette.primary_900,
+                        }
+                      : t.atoms.text_contrast_high,
                     {textAlignVertical: 'center', includeFontPadding: false},
                   ]}>
                   {reactions.length}


### PR DESCRIPTION
Applies a tint to the background of the bubble to indicate you reacted to a message.

<img width="178" height="77" alt="self" src="https://github.com/user-attachments/assets/2d49513e-540e-408c-af34-d6dbced43722" />