### PR TITLE
Bump mod SDK and add more details to mod info dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "icons:optimize": "svgo -f ./assets/icons"
   },
   "dependencies": {
-    "@atproto/api": "^0.19.12",
+    "@atproto/api": "^0.19.13",
     "@atproto/syntax": "0.5.2",
     "@bitdrift/react-native": "^0.6.8",
     "@braintree/sanitize-url": "^6.0.2",

--- a/src/components/moderation/ModerationDetailsDialog.tsx
+++ b/src/components/moderation/ModerationDetailsDialog.tsx
@@ -9,7 +9,8 @@ import {useModerationCauseDescription} from '#/lib/moderation/useModerationCause
 import {makeProfileLink} from '#/lib/routes/links'
 import {listUriToHref} from '#/lib/strings/url-helpers'
 import {useSession} from '#/state/session'
-import {atoms as a, useGutters, useTheme} from '#/alf'
+import {atoms as a, useGutters, useTheme, web} from '#/alf'
+import {Admonition} from '#/components/Admonition'
 import * as Dialog from '#/components/Dialog'
 import {InlineLinkText} from '#/components/Link'
 import {type AppModerationCause} from '#/components/Pills'
@@ -143,7 +144,10 @@ function ModerationDetailsDialogInner({
         paddingLeft: 0,
         paddingRight: 0,
         paddingBottom: 0,
-      }}>
+      }}
+      style={web({
+        maxWidth: 460,
+      })}>
       <View style={[xGutters, a.pb_lg]}>
         <Text emoji style={[t.atoms.text, a.text_2xl, a.font_bold, a.mb_sm]}>
           {name}
@@ -151,6 +155,15 @@ function ModerationDetailsDialogInner({
         <Text style={[t.atoms.text, a.text_sm, a.leading_snug]}>
           {description}
         </Text>
+
+        {desc.isSubjectAccount && (
+          <Admonition type="info" style={[a.mt_md]}>
+            <Trans>
+              This moderation was applied to the entire user account and will
+              appear on all posts.
+            </Trans>
+          </Admonition>
+        )}
       </View>
 
       {modcause?.type === 'label' && (

--- a/src/state/queries/preferences/index.ts
+++ b/src/state/queries/preferences/index.ts
@@ -84,7 +84,10 @@ export function usePreferencesQuery() {
          * Prefs are all downstream of age assurance now. For logged-out
          * users, we override moderation prefs based on AA state.
          */
-        if (aa.state.access !== aa.Access.Full) {
+        if (
+          aa.state.access !== aa.Access.Full ||
+          aa.flags.adultContentDisabled
+        ) {
           data = {
             ...data,
             moderationPrefs: makeAgeRestrictedModerationPrefs(

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -379,7 +379,7 @@ function ProfileScreenLoaded({
     <ScreenHider
       testID="profileView"
       style={styles.container}
-      screenDescription={_(msg`profile`)}
+      screenDescription={_(msg`user`)}
       modui={moderation.ui('profileView')}>
       <PagerWithHeader
         testID="profilePager"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,10 +20,10 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@atproto/api@^0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.19.12.tgz#0c21d7de070270f6596f908e6d8dd590b2933395"
-  integrity sha512-5CxDPBPxWx30ZM0UwjsmY67l+Kl8lTiLnH/8QvymsuJuRwA47CVfqo+QzEwJSkojNm7s0mTp7Ln2mR+OcFGBuw==
+"@atproto/api@^0.19.13":
+  version "0.19.13"
+  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.19.13.tgz#92c74dbc2fd84d79d62715e520da69f7c9012f66"
+  integrity sha512-1/LVbETVQTJFYv3Oa2Px1B/uFCRAwU0cRaoEDqdABgLHMKcWLlYJR1f9IyMdJ2JyLxcRviz6vViJI2BB8D0jcQ==
   dependencies:
     "@atproto/common-web" "^0.4.21"
     "@atproto/lexicon" "^0.6.2"


### PR DESCRIPTION
This PR ensures that account-level moderation labels correctly apply to profile surfaces as well, in response to regulation needs. It also adds some clarity to the `ModerationDetailsDialog` for cases where labels are applied to the account, since this has caused some confusion in the past. We need to invest more time here.