### PR TITLE
update locale in klipy api

### DIFF
--- a/src/features/gifPicker/queries.ts
+++ b/src/features/gifPicker/queries.ts
@@ -60,8 +60,8 @@ function createKlipyApi<Input extends object>(
 
     const locale = getLocales?.()?.[0]
 
-    if (locale) {
-      params.set('locale', locale.languageTag.replace('-', '_'))
+    if (locale?.regionCode) {
+      params.set('locale', locale.regionCode.toLowerCase())
     }
 
     for (const [key, value] of Object.entries(input)) {


### PR DESCRIPTION
the locale queryparam only accepts an ISO code. without it, fuzzy matching breaks on KLIPY search.

<img width="1250" height="1476" alt="CleanShot 2026-05-06 at 13 54 52@2x" src="https://github.com/user-attachments/assets/f0f9414b-d711-48e3-9472-9ece8c43a611" />
