### PR TITLE
Preserve memoization of message list

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -484,11 +484,6 @@
       "count": 3
     }
   },
-  "src/state/messages/convo/agent.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 2
-    }
-  },
   "src/state/messages/events/agent.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2

--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -21,6 +21,7 @@ import Animated, {
 } from 'react-native-reanimated'
 import {
   AppBskyEmbedRecord,
+  type ChatBskyActorDefs,
   ChatBskyConvoDefs,
   RichText as RichTextAPI,
 } from '@atproto/api'
@@ -91,9 +92,21 @@ function isWithinClusterBoundary({
 let MessageItem = ({
   item,
   isGroupChat = false,
+  prevMessage,
+  nextMessage,
+  relatedProfiles,
 }: {
   item: ConvoItem & {type: 'message' | 'pending-message'}
   isGroupChat?: boolean
+  prevMessage:
+    | ChatBskyConvoDefs.MessageView
+    | ChatBskyConvoDefs.DeletedMessageView
+    | null
+  nextMessage:
+    | ChatBskyConvoDefs.MessageView
+    | ChatBskyConvoDefs.DeletedMessageView
+    | null
+  relatedProfiles: Map<string, ChatBskyActorDefs.ProfileViewBasic>
 }): React.ReactNode => {
   const t = useTheme()
   const {currentAccount} = useSession()
@@ -101,12 +114,12 @@ let MessageItem = ({
   const moderationOpts = useModerationOpts()
   const queryClient = useQueryClient()
 
-  const profile = item.relatedProfiles.get(item.message.sender.did)
+  const {message} = item
+  const profile = relatedProfiles.get(message.sender.did)
 
   const reactionsControl = useDialogControl()
   const reactionTapRef = useRef(false)
 
-  const {message, nextMessage, prevMessage} = item
   const isPending = item.type === 'pending-message'
 
   const displayName = profile ? createSanitizedDisplayName(profile) : null
@@ -280,7 +293,7 @@ let MessageItem = ({
         return l`You reacted ${reaction.value}`
       } else {
         const senderDid = reaction.sender.did
-        const memberSender = item.relatedProfiles.get(senderDid)
+        const memberSender = relatedProfiles.get(senderDid)
         if (memberSender) {
           return l`${createSanitizedDisplayName(memberSender)} reacted ${reaction.value}`
         }
@@ -291,13 +304,7 @@ let MessageItem = ({
       one: '# person',
       other: '# people',
     })} reacted – ${groupedReactions.map(g => g.value).join(' ')}`
-  }, [
-    reactions,
-    groupedReactions,
-    currentAccount?.did,
-    item.relatedProfiles,
-    l,
-  ])
+  }, [reactions, groupedReactions, currentAccount?.did, relatedProfiles, l])
 
   const appliedReactions = (
     <LayoutAnimationConfig skipEntering skipExiting>
@@ -390,7 +397,7 @@ let MessageItem = ({
       ) : null}
       <ReactionsDialog
         control={reactionsControl}
-        relatedProfiles={item.relatedProfiles}
+        relatedProfiles={relatedProfiles}
         message={message}
         reactions={message.reactions}
         groupedReactions={groupedReactions}

--- a/src/components/dms/SystemMessageItem.tsx
+++ b/src/components/dms/SystemMessageItem.tsx
@@ -1,4 +1,5 @@
 import {View} from 'react-native'
+import {type ChatBskyActorDefs} from '@atproto/api'
 import {useLingui} from '@lingui/react/macro'
 
 import {type ConvoItem} from '#/state/messages/convo/types'
@@ -8,13 +9,15 @@ import {Text} from '#/components/Typography'
 
 export function SystemMessageItem({
   item,
+  relatedProfiles,
 }: {
   item: ConvoItem & {type: 'system-message'}
+  relatedProfiles: Map<string, ChatBskyActorDefs.ProfileViewBasic>
 }) {
   const t = useTheme()
   const {i18n} = useLingui()
 
-  const info = getSystemMessageInfo(item.message.data, item.relatedProfiles)
+  const info = getSystemMessageInfo(item.message.data, relatedProfiles)
   if (!info) return null
 
   const {Icon, message} = info

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -25,6 +25,7 @@ import {
   type $Typed,
   type AppBskyEmbedRecord,
   AppBskyRichtextFacet,
+  ChatBskyConvoDefs,
   RichText,
 } from '@atproto/api'
 import {useScrollEdgeEffectRef} from '@bsky.app/expo-scroll-edge-effect'
@@ -84,6 +85,27 @@ function MaybeLoader({isLoading}: {isLoading: boolean}) {
 
 function keyExtractor(item: ConvoItem) {
   return item.key
+}
+
+function getNeighborMessage(
+  items: ConvoItem[],
+  index: number,
+): ChatBskyConvoDefs.MessageView | ChatBskyConvoDefs.DeletedMessageView | null {
+  const neighbor = items[index]
+  if (!neighbor) return null
+  if (
+    neighbor.type === 'message' ||
+    neighbor.type === 'pending-message' ||
+    neighbor.type === 'deleted-message'
+  ) {
+    if (
+      ChatBskyConvoDefs.isMessageView(neighbor.message) ||
+      ChatBskyConvoDefs.isDeletedMessageView(neighbor.message)
+    ) {
+      return neighbor.message
+    }
+  }
+  return null
 }
 
 function onScrollToIndexFailed() {
@@ -369,18 +391,26 @@ export function MessagesList({
     })
   }, [flatListRef])
 
-  const renderItem = ({item}: {item: ConvoItem}) => {
+  const renderItem = ({item, index}: {item: ConvoItem; index: number}) => {
     if (item.type === 'message' || item.type === 'pending-message') {
       return (
         <MessageItem
           item={item}
           isGroupChat={convoState.convo.kind === 'group'}
+          prevMessage={getNeighborMessage(convoState.items, index - 1)}
+          nextMessage={getNeighborMessage(convoState.items, index + 1)}
+          relatedProfiles={convoState.relatedProfiles}
         />
       )
     } else if (item.type === 'deleted-message') {
       return <Text>Deleted message</Text>
     } else if (item.type === 'system-message') {
-      return <SystemMessageItem item={item} />
+      return (
+        <SystemMessageItem
+          item={item}
+          relatedProfiles={convoState.relatedProfiles}
+        />
+      )
     } else if (item.type === 'error') {
       return <MessageListError item={item} />
     }

--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -536,6 +536,7 @@ export class Convo {
     this.pendingMessages = new Map()
     this.deletedMessages = new Set()
     this.relatedProfiles = new Map()
+    this.itemCache = new Map()
 
     this.pendingMessageFailure = null
     this.fetchMessageHistoryError = undefined

--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -57,6 +57,52 @@ export function isConvoItemMessage(
   )
 }
 
+/**
+ * Two ConvoItems are considered equivalent when they would render identically.
+ * Used by getItems() to preserve object identity across rebuilds, so that
+ * memoized MessageItem renders are not invalidated when an unrelated message
+ * changes (e.g. a reaction added to one message in a long thread).
+ */
+function areConvoItemsEquivalent(a: ConvoItem, b: ConvoItem): boolean {
+  if (a.type !== b.type) return false
+  switch (a.type) {
+    case 'message':
+    case 'deleted-message': {
+      const bb = b as typeof a
+      return (
+        a.message === bb.message &&
+        a.relatedProfiles === bb.relatedProfiles &&
+        a.nextMessage === bb.nextMessage &&
+        a.prevMessage === bb.prevMessage
+      )
+    }
+    case 'pending-message': {
+      const bb = b as typeof a
+      return (
+        a.message === bb.message &&
+        a.relatedProfiles === bb.relatedProfiles &&
+        a.nextMessage === bb.nextMessage &&
+        a.prevMessage === bb.prevMessage &&
+        a.failed === bb.failed &&
+        (a.retry === undefined) === (bb.retry === undefined)
+      )
+    }
+    case 'system-message': {
+      const bb = b as typeof a
+      return (
+        a.message === bb.message && a.relatedProfiles === bb.relatedProfiles
+      )
+    }
+    case 'error': {
+      const bb = b as typeof a
+      return (
+        a.code === bb.code &&
+        (a.retry === undefined) === (bb.retry === undefined)
+      )
+    }
+  }
+}
+
 function toSystemMessageView(
   ev: ChatBskyConvoGetLog.OutputSchema['logs'][number],
 ): ChatBskyConvoDefs.SystemMessageView | null {
@@ -109,6 +155,13 @@ export class Convo {
   private deletedMessages: Set<string> = new Set()
   private relatedProfiles: Map<string, ChatBskyActorDefs.ProfileViewBasic> =
     new Map()
+
+  /**
+   * Caches the last emitted ConvoItem per key. getItems() reuses an entry when
+   * the freshly-built item is equivalent, preserving object identity so that
+   * memoized MessageItems do not re-render on unrelated commits.
+   */
+  private itemCache: Map<string, ConvoItem> = new Map()
 
   private isProcessingPendingMessages = false
 
@@ -1078,7 +1131,8 @@ export class Convo {
 
       // continue queue processing
       await this.processPendingMessages()
-    } catch (e: any) {
+    } catch (err) {
+      const e = err as Error
       this.handleSendMessageFailure(e)
       this.isProcessingPendingMessages = false
     }
@@ -1177,7 +1231,8 @@ export class Convo {
       this.commit()
 
       logger.debug(`sent ${this.pendingMessages.size} pending messages`, {})
-    } catch (e: any) {
+    } catch (err) {
+      const e = err as Error
       this.handleSendMessageFailure(e)
     }
   }
@@ -1334,7 +1389,7 @@ export class Convo {
       })
     }
 
-    return items
+    const fresh = items
       .filter(item => {
         if (isConvoItemMessage(item)) {
           return !this.deletedMessages.has(item.message.id)
@@ -1381,6 +1436,27 @@ export class Convo {
 
         return item
       })
+
+    /**
+     * Preserve identity across rebuilds: Reuse the previously emitted item
+     * whenever the freshly built one is equivalent. Replace the cache with a
+     * map containing only the keys present in this round so dropped items
+     * (e.g. deleted) don't leak.
+     */
+    const nextCache = new Map<string, ConvoItem>()
+    const stabilized = new Array<ConvoItem>(fresh.length)
+    for (let i = 0; i < fresh.length; i++) {
+      const item = fresh[i]
+      const cached = this.itemCache.get(item.key)
+      const reused =
+        cached !== undefined && areConvoItemsEquivalent(cached, item)
+          ? cached
+          : item
+      nextCache.set(item.key, reused)
+      stabilized[i] = reused
+    }
+    this.itemCache = nextCache
+    return stabilized
   }
 
   /**

--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -57,52 +57,6 @@ export function isConvoItemMessage(
   )
 }
 
-/**
- * Two ConvoItems are considered equivalent when they would render identically.
- * Used by getItems() to preserve object identity across rebuilds, so that
- * memoized MessageItem renders are not invalidated when an unrelated message
- * changes (e.g. a reaction added to one message in a long thread).
- */
-function areConvoItemsEquivalent(a: ConvoItem, b: ConvoItem): boolean {
-  if (a.type !== b.type) return false
-  switch (a.type) {
-    case 'message':
-    case 'deleted-message': {
-      const bb = b as typeof a
-      return (
-        a.message === bb.message &&
-        a.relatedProfiles === bb.relatedProfiles &&
-        a.nextMessage === bb.nextMessage &&
-        a.prevMessage === bb.prevMessage
-      )
-    }
-    case 'pending-message': {
-      const bb = b as typeof a
-      return (
-        a.message === bb.message &&
-        a.relatedProfiles === bb.relatedProfiles &&
-        a.nextMessage === bb.nextMessage &&
-        a.prevMessage === bb.prevMessage &&
-        a.failed === bb.failed &&
-        (a.retry === undefined) === (bb.retry === undefined)
-      )
-    }
-    case 'system-message': {
-      const bb = b as typeof a
-      return (
-        a.message === bb.message && a.relatedProfiles === bb.relatedProfiles
-      )
-    }
-    case 'error': {
-      const bb = b as typeof a
-      return (
-        a.code === bb.code &&
-        (a.retry === undefined) === (bb.retry === undefined)
-      )
-    }
-  }
-}
-
 function toSystemMessageView(
   ev: ChatBskyConvoGetLog.OutputSchema['logs'][number],
 ): ChatBskyConvoDefs.SystemMessageView | null {
@@ -155,13 +109,6 @@ export class Convo {
   private deletedMessages: Set<string> = new Set()
   private relatedProfiles: Map<string, ChatBskyActorDefs.ProfileViewBasic> =
     new Map()
-
-  /**
-   * Caches the last emitted ConvoItem per key. getItems() reuses an entry when
-   * the freshly-built item is equivalent, preserving object identity so that
-   * memoized MessageItems do not re-render on unrelated commits.
-   */
-  private itemCache: Map<string, ConvoItem> = new Map()
 
   private isProcessingPendingMessages = false
 
@@ -269,6 +216,7 @@ export class Convo {
           status: this.status,
           items: this.getItems(),
           convo: this.convo!,
+          relatedProfiles: this.relatedProfiles,
           error: undefined,
           ...shared,
           ...methods,
@@ -279,6 +227,7 @@ export class Convo {
           status: this.status,
           items: this.getItems(),
           convo: this.convo!,
+          relatedProfiles: this.relatedProfiles,
           error: undefined,
           ...shared,
           ...methods,
@@ -289,6 +238,7 @@ export class Convo {
           status: this.status,
           items: this.getItems(),
           convo: this.convo!,
+          relatedProfiles: this.relatedProfiles,
           error: undefined,
           ...shared,
           ...methods,
@@ -299,6 +249,7 @@ export class Convo {
           status: this.status,
           items: this.getItems(),
           convo: this.convo!,
+          relatedProfiles: this.relatedProfiles,
           error: undefined,
           ...shared,
           ...methods,
@@ -536,7 +487,6 @@ export class Convo {
     this.pendingMessages = new Map()
     this.deletedMessages = new Set()
     this.relatedProfiles = new Map()
-    this.itemCache = new Map()
 
     this.pendingMessageFailure = null
     this.fetchMessageHistoryError = undefined
@@ -1287,25 +1237,18 @@ export class Convo {
           type: 'message',
           key: m.id,
           message: m,
-          relatedProfiles: this.relatedProfiles,
-          nextMessage: null,
-          prevMessage: null,
         })
       } else if (ChatBskyConvoDefs.isDeletedMessageView(m)) {
         items.unshift({
           type: 'deleted-message',
           key: m.id,
           message: m,
-          relatedProfiles: this.relatedProfiles,
-          nextMessage: null,
-          prevMessage: null,
         })
       } else if (ChatBskyConvoDefs.isSystemMessageView(m)) {
         items.unshift({
           type: 'system-message',
           key: m.id,
           message: m,
-          relatedProfiles: this.relatedProfiles,
         })
       }
     })
@@ -1327,25 +1270,18 @@ export class Convo {
           type: 'message',
           key: m.id,
           message: m,
-          relatedProfiles: this.relatedProfiles,
-          nextMessage: null,
-          prevMessage: null,
         })
       } else if (ChatBskyConvoDefs.isDeletedMessageView(m)) {
         items.push({
           type: 'deleted-message',
           key: m.id,
           message: m,
-          relatedProfiles: this.relatedProfiles,
-          nextMessage: null,
-          prevMessage: null,
         })
       } else if (ChatBskyConvoDefs.isSystemMessageView(m)) {
         items.push({
           type: 'system-message',
           key: m.id,
           message: m,
-          relatedProfiles: this.relatedProfiles,
         })
       }
     })
@@ -1366,9 +1302,6 @@ export class Convo {
             did: this.senderUserDid,
           },
         },
-        relatedProfiles: this.relatedProfiles,
-        nextMessage: null,
-        prevMessage: null,
         failed: this.pendingMessageFailure !== null,
         retry:
           this.pendingMessageFailure === 'recoverable'
@@ -1390,74 +1323,12 @@ export class Convo {
       })
     }
 
-    const fresh = items
-      .filter(item => {
-        if (isConvoItemMessage(item)) {
-          return !this.deletedMessages.has(item.message.id)
-        }
-        return true
-      })
-      .map((item, i, arr) => {
-        let nextMessage = null
-        let prevMessage = null
-        const isMessage = isConvoItemMessage(item)
-
-        if (isMessage) {
-          if (
-            ChatBskyConvoDefs.isMessageView(item.message) ||
-            ChatBskyConvoDefs.isDeletedMessageView(item.message)
-          ) {
-            const next = arr[i + 1]
-
-            if (
-              isConvoItemMessage(next) &&
-              (ChatBskyConvoDefs.isMessageView(next.message) ||
-                ChatBskyConvoDefs.isDeletedMessageView(next.message))
-            ) {
-              nextMessage = next.message
-            }
-
-            const prev = arr[i - 1]
-
-            if (
-              isConvoItemMessage(prev) &&
-              (ChatBskyConvoDefs.isMessageView(prev.message) ||
-                ChatBskyConvoDefs.isDeletedMessageView(prev.message))
-            ) {
-              prevMessage = prev.message
-            }
-          }
-
-          return {
-            ...item,
-            nextMessage,
-            prevMessage,
-          }
-        }
-
-        return item
-      })
-
-    /**
-     * Preserve identity across rebuilds: Reuse the previously emitted item
-     * whenever the freshly built one is equivalent. Replace the cache with a
-     * map containing only the keys present in this round so dropped items
-     * (e.g. deleted) don't leak.
-     */
-    const nextCache = new Map<string, ConvoItem>()
-    const stabilized = new Array<ConvoItem>(fresh.length)
-    for (let i = 0; i < fresh.length; i++) {
-      const item = fresh[i]
-      const cached = this.itemCache.get(item.key)
-      const reused =
-        cached !== undefined && areConvoItemsEquivalent(cached, item)
-          ? cached
-          : item
-      nextCache.set(item.key, reused)
-      stabilized[i] = reused
-    }
-    this.itemCache = nextCache
-    return stabilized
+    return items.filter(item => {
+      if (isConvoItemMessage(item)) {
+        return !this.deletedMessages.has(item.message.id)
+      }
+      return true
+    })
   }
 
   /**

--- a/src/state/messages/convo/types.ts
+++ b/src/state/messages/convo/types.ts
@@ -72,29 +72,11 @@ export type ConvoItem =
       type: 'message'
       key: string
       message: ChatBskyConvoDefs.MessageView
-      relatedProfiles: Map<string, ChatBskyActorDefs.ProfileViewBasic>
-      nextMessage:
-        | ChatBskyConvoDefs.MessageView
-        | ChatBskyConvoDefs.DeletedMessageView
-        | null
-      prevMessage:
-        | ChatBskyConvoDefs.MessageView
-        | ChatBskyConvoDefs.DeletedMessageView
-        | null
     }
   | {
       type: 'pending-message'
       key: string
       message: ChatBskyConvoDefs.MessageView
-      relatedProfiles: Map<string, ChatBskyActorDefs.ProfileViewBasic>
-      nextMessage:
-        | ChatBskyConvoDefs.MessageView
-        | ChatBskyConvoDefs.DeletedMessageView
-        | null
-      prevMessage:
-        | ChatBskyConvoDefs.MessageView
-        | ChatBskyConvoDefs.DeletedMessageView
-        | null
       failed: boolean
       /**
        * Retry sending the message. If present, the message is in a failed state.
@@ -105,21 +87,11 @@ export type ConvoItem =
       type: 'deleted-message'
       key: string
       message: ChatBskyConvoDefs.DeletedMessageView
-      relatedProfiles: Map<string, ChatBskyActorDefs.ProfileViewBasic>
-      nextMessage:
-        | ChatBskyConvoDefs.MessageView
-        | ChatBskyConvoDefs.DeletedMessageView
-        | null
-      prevMessage:
-        | ChatBskyConvoDefs.MessageView
-        | ChatBskyConvoDefs.DeletedMessageView
-        | null
     }
   | {
       type: 'system-message'
       key: string
       message: ChatBskyConvoDefs.SystemMessageView
-      relatedProfiles: Map<string, ChatBskyActorDefs.ProfileViewBasic>
     }
   | {
       type: 'error'
@@ -172,6 +144,7 @@ export type ConvoStateReady = {
   status: ConvoStatus.Ready
   items: ConvoItem[]
   convo: ConvoWithDetails
+  relatedProfiles: Map<string, ChatBskyActorDefs.ProfileViewBasic>
   error: undefined
   isFetchingHistory: boolean
   hasAllHistory: boolean
@@ -186,6 +159,7 @@ export type ConvoStateBackgrounded = {
   status: ConvoStatus.Backgrounded
   items: ConvoItem[]
   convo: ConvoWithDetails
+  relatedProfiles: Map<string, ChatBskyActorDefs.ProfileViewBasic>
   error: undefined
   isFetchingHistory: boolean
   hasAllHistory: boolean
@@ -200,6 +174,7 @@ export type ConvoStateSuspended = {
   status: ConvoStatus.Suspended
   items: ConvoItem[]
   convo: ConvoWithDetails
+  relatedProfiles: Map<string, ChatBskyActorDefs.ProfileViewBasic>
   error: undefined
   isFetchingHistory: boolean
   hasAllHistory: boolean
@@ -228,6 +203,7 @@ export type ConvoStateDisabled = {
   status: ConvoStatus.Disabled
   items: ConvoItem[]
   convo: ConvoWithDetails
+  relatedProfiles: Map<string, ChatBskyActorDefs.ProfileViewBasic>
   error: undefined
   isFetchingHistory: boolean
   hasAllHistory: boolean


### PR DESCRIPTION
`Convo.getItems()` in `agent.ts` was rebuilding the full `ConvoItem[]` on every state commit, and the final `map()` would spread every item. As a result, every `ConvoItem` got a brand-new object identity on every commit, even when only one message changed.

This was most evident when adding a reaction to a message. Despite none of the message content changing for the rest of the thread, every single `MessageItem` would re-render. Since `disableVirtualization` and `removeClippedSubviews` are both `true` on the `List`, this could result in hundreds of re-renders for a single reaction.

For example, in a 60-message thread this would yield 120 re-renders: Every message times two commits (optimistic and server response).

This PR removes the `map()` and gets the associated data within `renderItem` instead. With this change, there are only 6 re-renders: The reacted-to message and its immediate neighbors times the two commits.

Verified this locally by logging `MessageItem` renders in a 60-message thread on this branch vs `main`.