### PR TITLE
Follow empty likes pages to reach older likes

### DIFF
--- a/src/lib/api/feed/likes.ts
+++ b/src/lib/api/feed/likes.ts
@@ -6,9 +6,12 @@ import {
 
 import {type FeedAPI, type FeedAPIResponse} from './types'
 
+const MAX_CONSECUTIVE_EMPTY_PAGES = 5
+
 export class LikesFeedAPI implements FeedAPI {
   agent: BskyAgent
   params: GetActorLikes.QueryParams
+  consecutiveEmptyPages = 0
 
   constructor({
     agent,
@@ -41,16 +44,31 @@ export class LikesFeedAPI implements FeedAPI {
       cursor,
       limit,
     })
-    if (res.success) {
-      // HACKFIX: the API incorrectly returns a cursor when there are no items -sfn
-      const isEmptyPage = res.data.feed.length === 0
+
+    if (!res.success) {
       return {
-        cursor: isEmptyPage ? undefined : res.data.cursor,
-        feed: res.data.feed,
+        feed: [],
       }
     }
+
+    /*
+     * getActorLikes may return empty pages with cursors for no-like gaps. Keep
+     * following them to reach older likes, but stop after 5 consecutive empty
+     * pages; that covers roughly a one-year gap and avoids infinite pagination
+     * past the oldest like (atproto issue #3087).
+     */
+    if (res.data.feed.length === 0) {
+      this.consecutiveEmptyPages++
+    } else {
+      this.consecutiveEmptyPages = 0
+    }
+
     return {
-      feed: [],
+      cursor:
+        this.consecutiveEmptyPages >= MAX_CONSECUTIVE_EMPTY_PAGES
+          ? undefined
+          : res.data.cursor,
+      feed: res.data.feed,
     }
   }
 }


### PR DESCRIPTION
This may also fix #8651 and #9843.                                                                  
                                                            
I also looked into the following related issues but couldn't reproduce them. I'll leave them for the maintainers to triage.
                                                                                                      
- https://github.com/bluesky-social/social-app/issues/6299

https://github.com/bluesky-social/atproto/issues/3087  may be related issue.