### PR TITLE
Update chat presentation

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -24,11 +24,6 @@
       "count": 5
     }
   },
-  "src/components/Button.tsx": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 2
-    }
-  },
   "src/components/Composer/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -86,8 +86,8 @@ export type ButtonState = {
 export type ButtonContext = VariantProps & ButtonState
 
 type NonTextElements =
-  | React.ReactElement<any>
-  | Iterable<React.ReactElement<any> | null | undefined | boolean>
+  | React.ReactElement
+  | Iterable<React.ReactElement | null | undefined | boolean>
 
 export type ButtonProps = Pick<
   PressableProps,

--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -1,9 +1,8 @@
 import {createContext, useCallback, useContext, useId, useMemo} from 'react'
 import {type GestureResponderEvent, View} from 'react-native'
-import {msg} from '@lingui/core/macro'
-import {useLingui} from '@lingui/react'
+import {useLingui} from '@lingui/react/macro'
 
-import {atoms as a, type TextStyleProp, useTheme, web} from '#/alf'
+import {atoms as a, native, type TextStyleProp, useTheme, web} from '#/alf'
 import {
   Button,
   type ButtonColor,
@@ -79,6 +78,22 @@ export function Outer({
   )
 }
 
+export function Icon({
+  icon: Icon,
+  fill,
+}: {
+  icon: React.ComponentType<SVGIconProps>
+  fill?: string
+}) {
+  const t = useTheme()
+
+  return (
+    <View style={[a.align_center, a.justify_center, native(a.pt_lg), a.mb_lg]}>
+      <Icon fill={fill || t.palette.contrast_1000} size="3xl" />
+    </View>
+  )
+}
+
 export function TitleText({
   children,
   style,
@@ -89,9 +104,9 @@ export function TitleText({
       nativeID={titleId}
       style={[
         a.flex_1,
-        a.text_2xl,
-        a.font_semi_bold,
-        a.pb_xs,
+        a.text_lg,
+        a.font_bold,
+        a.pb_sm,
         a.leading_snug,
         style,
       ]}>
@@ -111,20 +126,14 @@ export function DescriptionText({
     <Text
       nativeID={descriptionId}
       selectable={selectable}
-      style={[
-        a.text_md,
-        a.leading_snug,
-        t.atoms.text_contrast_high,
-        a.pb_lg,
-        style,
-      ]}>
+      style={[a.text_sm, a.leading_snug, t.atoms.text, a.pb_2xl, style]}>
       {children}
     </Text>
   )
 }
 
 export function Actions({children}: {children: React.ReactNode}) {
-  return <View style={[a.w_full, a.gap_sm, a.justify_end]}>{children}</View>
+  return <View style={[a.w_full, a.gap_md, a.justify_end]}>{children}</View>
 }
 
 export function Content({children}: {children: React.ReactNode}) {
@@ -139,7 +148,7 @@ export function Cancel({
    */
   cta?: string
 }) {
-  const {_} = useLingui()
+  const {t: l} = useLingui()
   const {close} = Dialog.useDialogContext()
   const onPress = useCallback(() => {
     close()
@@ -150,9 +159,9 @@ export function Cancel({
       variant="solid"
       color="secondary"
       size="large"
-      label={cta || _(msg`Cancel`)}
+      label={cta || l`Cancel`}
       onPress={onPress}>
-      <ButtonText>{cta || _(msg`Cancel`)}</ButtonText>
+      <ButtonText>{cta || l`Cancel`}</ButtonText>
     </Button>
   )
 }
@@ -191,7 +200,7 @@ export function Action({
   shouldCloseOnPress?: boolean
   testID?: string
 }) {
-  const {_} = useLingui()
+  const {t: l} = useLingui()
   const {close} = Dialog.useDialogContext()
   const handleOnPress = useCallback(
     (e: GestureResponderEvent) => {
@@ -209,10 +218,10 @@ export function Action({
       color={color}
       disabled={disabled}
       size="large"
-      label={cta || _(msg`Confirm`)}
+      label={cta || l`Confirm`}
       onPress={handleOnPress}
       testID={testID}>
-      <ButtonText>{cta || _(msg`Confirm`)}</ButtonText>
+      <ButtonText>{cta || l`Confirm`}</ButtonText>
       {icon && <ButtonIcon icon={icon} />}
     </Button>
   )
@@ -220,6 +229,7 @@ export function Action({
 
 export function Basic({
   control,
+  icon,
   title,
   description,
   cancelButtonCta,
@@ -229,6 +239,7 @@ export function Basic({
   showCancel = true,
 }: React.PropsWithChildren<{
   control: Dialog.DialogOuterProps['control']
+  icon?: React.ComponentType<SVGIconProps>
   title: string
   description?: string
   cancelButtonCta?: string
@@ -244,11 +255,27 @@ export function Basic({
   confirmButtonColor?: ButtonColor
   showCancel?: boolean
 }>) {
+  const t = useTheme()
+
   return (
     <Outer control={control} testID="confirmModal">
       <Content>
-        <TitleText>{title}</TitleText>
-        {description && <DescriptionText>{description}</DescriptionText>}
+        {icon ? (
+          <Icon
+            icon={icon}
+            fill={
+              confirmButtonColor === 'negative'
+                ? t.palette.negative_500
+                : undefined
+            }
+          />
+        ) : null}
+        <TitleText style={icon ? a.text_center : null}>{title}</TitleText>
+        {description && (
+          <DescriptionText style={icon ? a.text_center : null}>
+            {description}
+          </DescriptionText>
+        )}
       </Content>
       <Actions>
         <Action

--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -2,7 +2,7 @@ import {createContext, useCallback, useContext, useId, useMemo} from 'react'
 import {type GestureResponderEvent, View} from 'react-native'
 import {useLingui} from '@lingui/react/macro'
 
-import {atoms as a, native, type TextStyleProp, useTheme, web} from '#/alf'
+import {atoms as a, useTheme, type ViewStyleProp, web} from '#/alf'
 import {
   Button,
   type ButtonColor,
@@ -78,35 +78,19 @@ export function Outer({
   )
 }
 
-export function Icon({
-  icon: Icon,
-  fill,
-}: {
-  icon: React.ComponentType<SVGIconProps>
-  fill?: string
-}) {
-  const t = useTheme()
-
-  return (
-    <View style={[a.align_center, a.justify_center, native(a.pt_lg), a.mb_lg]}>
-      <Icon fill={fill || t.palette.contrast_1000} size="3xl" />
-    </View>
-  )
-}
-
 export function TitleText({
   children,
   style,
-}: React.PropsWithChildren<TextStyleProp>) {
+}: React.PropsWithChildren<ViewStyleProp>) {
   const {titleId} = useContext(Context)
   return (
     <Text
       nativeID={titleId}
       style={[
         a.flex_1,
-        a.text_lg,
-        a.font_bold,
-        a.pb_sm,
+        a.text_2xl,
+        a.font_semi_bold,
+        a.pb_xs,
         a.leading_snug,
         style,
       ]}>
@@ -118,22 +102,21 @@ export function TitleText({
 export function DescriptionText({
   children,
   selectable,
-  style,
-}: React.PropsWithChildren<{selectable?: boolean} & TextStyleProp>) {
+}: React.PropsWithChildren<{selectable?: boolean}>) {
   const t = useTheme()
   const {descriptionId} = useContext(Context)
   return (
     <Text
       nativeID={descriptionId}
       selectable={selectable}
-      style={[a.text_sm, a.leading_snug, t.atoms.text, a.pb_2xl, style]}>
+      style={[a.text_md, a.leading_snug, t.atoms.text_contrast_high, a.pb_lg]}>
       {children}
     </Text>
   )
 }
 
 export function Actions({children}: {children: React.ReactNode}) {
-  return <View style={[a.w_full, a.gap_md, a.justify_end]}>{children}</View>
+  return <View style={[a.w_full, a.gap_sm, a.justify_end]}>{children}</View>
 }
 
 export function Content({children}: {children: React.ReactNode}) {
@@ -229,7 +212,6 @@ export function Action({
 
 export function Basic({
   control,
-  icon,
   title,
   description,
   cancelButtonCta,
@@ -239,7 +221,6 @@ export function Basic({
   showCancel = true,
 }: React.PropsWithChildren<{
   control: Dialog.DialogOuterProps['control']
-  icon?: React.ComponentType<SVGIconProps>
   title: string
   description?: string
   cancelButtonCta?: string
@@ -255,27 +236,11 @@ export function Basic({
   confirmButtonColor?: ButtonColor
   showCancel?: boolean
 }>) {
-  const t = useTheme()
-
   return (
     <Outer control={control} testID="confirmModal">
       <Content>
-        {icon ? (
-          <Icon
-            icon={icon}
-            fill={
-              confirmButtonColor === 'negative'
-                ? t.palette.negative_500
-                : undefined
-            }
-          />
-        ) : null}
-        <TitleText style={icon ? a.text_center : null}>{title}</TitleText>
-        {description && (
-          <DescriptionText style={icon ? a.text_center : null}>
-            {description}
-          </DescriptionText>
-        )}
+        <TitleText>{title}</TitleText>
+        {description && <DescriptionText>{description}</DescriptionText>}
       </Content>
       <Actions>
         <Action

--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -2,7 +2,7 @@ import {createContext, useCallback, useContext, useId, useMemo} from 'react'
 import {type GestureResponderEvent, View} from 'react-native'
 import {useLingui} from '@lingui/react/macro'
 
-import {atoms as a, useTheme, type ViewStyleProp, web} from '#/alf'
+import {atoms as a, type TextStyleProp, useTheme, web} from '#/alf'
 import {
   Button,
   type ButtonColor,
@@ -81,7 +81,7 @@ export function Outer({
 export function TitleText({
   children,
   style,
-}: React.PropsWithChildren<ViewStyleProp>) {
+}: React.PropsWithChildren<TextStyleProp>) {
   const {titleId} = useContext(Context)
   return (
     <Text
@@ -102,14 +102,21 @@ export function TitleText({
 export function DescriptionText({
   children,
   selectable,
-}: React.PropsWithChildren<{selectable?: boolean}>) {
+  style,
+}: React.PropsWithChildren<{selectable?: boolean} & TextStyleProp>) {
   const t = useTheme()
   const {descriptionId} = useContext(Context)
   return (
     <Text
       nativeID={descriptionId}
       selectable={selectable}
-      style={[a.text_md, a.leading_snug, t.atoms.text_contrast_high, a.pb_lg]}>
+      style={[
+        a.text_md,
+        a.leading_snug,
+        t.atoms.text_contrast_high,
+        a.pb_lg,
+        style,
+      ]}>
       {children}
     </Text>
   )

--- a/src/screens/Messages/Conversation.tsx
+++ b/src/screens/Messages/Conversation.tsx
@@ -350,14 +350,14 @@ function GroupChatGate() {
             🐴
           </Text>
         </View>
-        <Prompt.TitleText style={[a.text_center]}>
+        <Prompt.TitleText>
           {hasBeenReleased ? (
             <Trans>Group chats are now available</Trans>
           ) : (
             <Trans>Group chats are not yet available</Trans>
           )}
         </Prompt.TitleText>
-        <Prompt.DescriptionText style={[a.text_center]}>
+        <Prompt.DescriptionText>
           {hasBeenReleased ? (
             <Trans>Update your app to the latest version to join in!</Trans>
           ) : (

--- a/src/screens/Messages/Conversation.tsx
+++ b/src/screens/Messages/Conversation.tsx
@@ -350,14 +350,14 @@ function GroupChatGate() {
             🐴
           </Text>
         </View>
-        <Prompt.TitleText>
+        <Prompt.TitleText style={[a.text_center]}>
           {hasBeenReleased ? (
             <Trans>Group chats are now available</Trans>
           ) : (
             <Trans>Group chats are not yet available</Trans>
           )}
         </Prompt.TitleText>
-        <Prompt.DescriptionText>
+        <Prompt.DescriptionText style={[a.text_center]}>
           {hasBeenReleased ? (
             <Trans>Update your app to the latest version to join in!</Trans>
           ) : (

--- a/src/screens/Messages/ConversationSettings/AddMembersLink.tsx
+++ b/src/screens/Messages/ConversationSettings/AddMembersLink.tsx
@@ -1,6 +1,8 @@
 import {View} from 'react-native'
+import {plural} from '@lingui/core/macro'
 import {Trans, useLingui} from '@lingui/react/macro'
 
+import {createSanitizedDisplayName} from '#/lib/moderation/create-sanitized-display-name'
 import {logger} from '#/logger'
 import {useAddGroupMembers} from '#/state/queries/messages/add-group-members'
 import {atoms as a, useTheme} from '#/alf'
@@ -30,8 +32,28 @@ export function AddMembersLink({
   const {mutate: addGroupMembers, isPending: isAddPending} = useAddGroupMembers(
     convoId,
     {
-      onSuccess: () => {
-        addMembersControl.close()
+      onSuccess: data => {
+        addMembersControl.close(() => {
+          const members = data.addedMembers ?? []
+
+          let names = null
+          if (members.length === 1) {
+            names = l`${createSanitizedDisplayName(members[0])} added to chat`
+          } else if (members.length === 2) {
+            names = l`${createSanitizedDisplayName(members[0])} and ${createSanitizedDisplayName(members[1])} added to chat`
+          } else if (members.length > 2) {
+            const memberCount = convo.details.memberCount - 2
+            names = l`${createSanitizedDisplayName(members[0])}, ${createSanitizedDisplayName(members[1])}and ${plural(
+              memberCount,
+              {
+                one: '# other',
+                other: '# others',
+              },
+            )} added to chat`
+          }
+
+          if (names) Toast.show(names)
+        })
       },
       onError: e => {
         logger.error('Failed to add group chat members', {message: e})

--- a/src/screens/Messages/ConversationSettings/Member.tsx
+++ b/src/screens/Messages/ConversationSettings/Member.tsx
@@ -51,9 +51,7 @@ export function Member({
     requireAuth(async () => {
       try {
         await queueFollow()
-        Toast.show(l`Following ${displayName}`, {
-          type: 'info',
-        })
+        Toast.show(l`Following ${displayName}`)
       } catch (err) {
         const e = err as Error
         if (e?.name !== 'AbortError') {

--- a/src/screens/Messages/ConversationSettings/MemberMenu.tsx
+++ b/src/screens/Messages/ConversationSettings/MemberMenu.tsx
@@ -182,14 +182,6 @@ export function MemberMenu({
         <Menu.Outer>
           <Menu.Group>
             <Menu.Item
-              label={l`Message ${displayName}`}
-              onPress={handleMessageMember}>
-              <Menu.ItemIcon icon={MessageIcon} />
-              <Menu.ItemText>
-                <Trans context="action">Message</Trans>
-              </Menu.ItemText>
-            </Menu.Item>
-            <Menu.Item
               label={l`View ${displayName}’s profile`}
               onPress={() => {
                 navigation.navigate('Profile', {name: profile.did})
@@ -197,6 +189,14 @@ export function MemberMenu({
               <Menu.ItemIcon icon={PersonIcon} />
               <Menu.ItemText>
                 <Trans>Go to profile</Trans>
+              </Menu.ItemText>
+            </Menu.Item>
+            <Menu.Item
+              label={l`Message ${displayName}`}
+              onPress={handleMessageMember}>
+              <Menu.ItemIcon icon={MessageIcon} />
+              <Menu.ItemText>
+                <Trans context="action">Message</Trans>
               </Menu.ItemText>
             </Menu.Item>
           </Menu.Group>

--- a/src/screens/Messages/ConversationSettings/index.tsx
+++ b/src/screens/Messages/ConversationSettings/index.tsx
@@ -176,6 +176,8 @@ function GroupSettings({
   moderationOpts: ModerationOpts
   isReady: boolean
 }) {
+  const [isPTRing, setIsPTRing] = useState(false)
+
   const initialNumToRender = useInitialNumToRender({minItemHeight: 68})
   const bottomBarOffset = useBottomBarOffset()
 
@@ -184,7 +186,7 @@ function GroupSettings({
   const primaryMember = convo.primaryMember
   const isOwner = !!primaryMember && primaryMember.did === currentAccount?.did
 
-  const {data: memberListData = []} = useListConvoMembersQuery({
+  const {data: memberListData = [], refetch} = useListConvoMembersQuery({
     convoId: convo.view.id,
     placeholderData: convo.members,
   })
@@ -269,6 +271,16 @@ function GroupSettings({
     }
   }
 
+  const onRefresh = async () => {
+    setIsPTRing(true)
+    try {
+      await refetch()
+    } catch (err) {
+      logger.error('Failed to refresh group chat members', {message: err})
+    }
+    setIsPTRing(false)
+  }
+
   return (
     <List
       data={items}
@@ -289,6 +301,8 @@ function GroupSettings({
       renderItem={renderItem}
       sideBorders={false}
       windowSize={11}
+      refreshing={isPTRing}
+      onRefresh={() => void onRefresh()}
     />
   )
 }

--- a/src/screens/Messages/ConversationSettings/prompts.tsx
+++ b/src/screens/Messages/ConversationSettings/prompts.tsx
@@ -4,6 +4,8 @@ import {Trans, useLingui} from '@lingui/react/macro'
 import {atoms as a} from '#/alf'
 import type * as Dialog from '#/components/Dialog'
 import * as TextField from '#/components/forms/TextField'
+import {ArrowBoxLeft_Stroke2_Corner0_Rounded as LeaveIcon} from '#/components/icons/ArrowBoxLeft'
+import {Lock_Stroke2_Corner0_Rounded as LockIcon} from '#/components/icons/Lock'
 import * as Prompt from '#/components/Prompt'
 
 export function EditNamePrompt({
@@ -62,6 +64,7 @@ export function LockChatPrompt({
   return (
     <Prompt.Basic
       control={control}
+      icon={LockIcon}
       title={l`Lock group chat?`}
       description={l`Members can still read chat history but can’t send new messages.`}
       confirmButtonCta={l`Lock group chat`}
@@ -85,6 +88,7 @@ export function LeaveChatPrompt({
   return (
     <Prompt.Basic
       control={control}
+      icon={LeaveIcon}
       title={l`Are you sure you want to leave ${groupName}?`}
       description={l`You won’t be able to rejoin unless you’re invited.`}
       confirmButtonCta={l`Leave group chat`}

--- a/src/screens/Messages/ConversationSettings/prompts.tsx
+++ b/src/screens/Messages/ConversationSettings/prompts.tsx
@@ -4,8 +4,6 @@ import {Trans, useLingui} from '@lingui/react/macro'
 import {atoms as a} from '#/alf'
 import type * as Dialog from '#/components/Dialog'
 import * as TextField from '#/components/forms/TextField'
-import {ArrowBoxLeft_Stroke2_Corner0_Rounded as LeaveIcon} from '#/components/icons/ArrowBoxLeft'
-import {Lock_Stroke2_Corner0_Rounded as LockIcon} from '#/components/icons/Lock'
 import * as Prompt from '#/components/Prompt'
 
 export function EditNamePrompt({
@@ -23,31 +21,33 @@ export function EditNamePrompt({
 
   return (
     <Prompt.Outer control={control}>
-      <Prompt.Content>
-        <Prompt.TitleText>
-          <Trans>Edit group name</Trans>
-        </Prompt.TitleText>
-        <View style={[a.my_sm]}>
-          <TextField.Root isInvalid={false}>
-            <TextField.Input
-              label={l`Edit group name`}
-              placeholder={l`Group name`}
-              value={value}
-              onChangeText={onChangeText}
-              returnKeyType="done"
-              autoCapitalize="none"
-              autoComplete="off"
-              autoCorrect={false}
-              autoFocus
-              onSubmitEditing={onConfirm}
-            />
-          </TextField.Root>
-        </View>
-      </Prompt.Content>
-      <Prompt.Actions>
-        <Prompt.Action cta={l`Save`} onPress={onConfirm} />
-        <Prompt.Cancel />
-      </Prompt.Actions>
+      <>
+        <Prompt.Content>
+          <Prompt.TitleText>
+            <Trans>Edit group name</Trans>
+          </Prompt.TitleText>
+          <View style={[a.my_sm]}>
+            <TextField.Root isInvalid={false}>
+              <TextField.Input
+                label={l`Edit group name`}
+                placeholder={l`Group name`}
+                value={value}
+                onChangeText={onChangeText}
+                returnKeyType="done"
+                autoCapitalize="none"
+                autoComplete="off"
+                autoCorrect={false}
+                autoFocus
+                onSubmitEditing={onConfirm}
+              />
+            </TextField.Root>
+          </View>
+        </Prompt.Content>
+        <Prompt.Actions>
+          <Prompt.Action cta={l`Save`} onPress={onConfirm} />
+          <Prompt.Cancel />
+        </Prompt.Actions>
+      </>
     </Prompt.Outer>
   )
 }
@@ -64,7 +64,6 @@ export function LockChatPrompt({
   return (
     <Prompt.Basic
       control={control}
-      icon={LockIcon}
       title={l`Lock group chat?`}
       description={l`Members can still read chat history but can’t send new messages.`}
       confirmButtonCta={l`Lock group chat`}
@@ -88,7 +87,6 @@ export function LeaveChatPrompt({
   return (
     <Prompt.Basic
       control={control}
-      icon={LeaveIcon}
       title={l`Are you sure you want to leave ${groupName}?`}
       description={l`You won’t be able to rejoin unless you’re invited.`}
       confirmButtonCta={l`Leave group chat`}

--- a/src/screens/Messages/components/ChatLocked.tsx
+++ b/src/screens/Messages/components/ChatLocked.tsx
@@ -74,9 +74,7 @@ export function ChatLocked({
                 a.text_sm,
                 a.font_semi_bold,
                 a.leading_snug,
-                {
-                  color: t.palette.negative_500,
-                },
+                t.atoms.text_contrast_high,
               ]}>
               <Trans>Unlock chat</Trans>
             </Text>

--- a/src/screens/Messages/components/InviteLinkDialog.tsx
+++ b/src/screens/Messages/components/InviteLinkDialog.tsx
@@ -38,6 +38,7 @@ enum Step {
   INFO,
   GENERATE,
   MANAGE,
+  CONFIRM_DISABLE,
 }
 
 export function InviteLinkDialog({
@@ -341,13 +342,10 @@ export function InviteLinkDialog({
               {isOwner ? (
                 <StackedButton
                   label={l`Disable`}
-                  icon={isDisabling ? Loader : ChainLinkBrokenIcon}
+                  icon={ChainLinkBrokenIcon}
                   color="negative_subtle"
                   style={[a.flex_1, a.rounded_full]}
-                  disabled={isDisabling}
-                  onPress={() => {
-                    disableJoinLink()
-                  }}>
+                  onPress={() => setStep(Step.CONFIRM_DISABLE)}>
                   <Trans>Disable</Trans>
                 </StackedButton>
               ) : null}
@@ -382,10 +380,10 @@ export function InviteLinkDialog({
           ) : (
             <View style={[a.gap_md, a.mt_lg]}>
               <Button
+                disabled={isEnabling || isDisabling}
                 label={l`Re-enable invite link`}
                 color="primary"
                 size="large"
-                disabled={isEnabling}
                 onPress={() => {
                   enableJoinLink()
                 }}>
@@ -395,6 +393,7 @@ export function InviteLinkDialog({
                 {isEnabling && <ButtonIcon icon={Loader} />}
               </Button>
               <Button
+                disabled={isEnabling || isDisabling}
                 label={l`Generate new invite link`}
                 color="secondary"
                 size="large"
@@ -409,6 +408,63 @@ export function InviteLinkDialog({
       )
       break
     }
+    case Step.CONFIRM_DISABLE:
+      content = (
+        <>
+          <View style={[a.align_center, a.justify_center, a.mb_lg]}>
+            <ChainLinkBrokenIcon fill={t.palette.negative_500} size="3xl" />
+          </View>
+          <Text
+            style={[
+              a.flex_1,
+              a.pb_sm,
+              a.text_center,
+              a.text_lg,
+              a.font_bold,
+              a.leading_snug,
+            ]}>
+            <Trans>Disable this invite link?</Trans>
+          </Text>
+          <Text
+            style={[
+              a.pb_2xl,
+              a.text_center,
+              a.text_sm,
+              a.leading_snug,
+              t.atoms.text,
+            ]}>
+            <Trans>
+              Anyone who has it will no longer be able to join or request to
+              join. You can always create a new one.
+            </Trans>
+          </Text>
+          <View style={[a.w_full, a.gap_md, a.justify_end]}>
+            <Button
+              color="negative"
+              disabled={isDisabling}
+              size="large"
+              label={l`Disable link`}
+              onPress={() => {
+                disableJoinLink()
+                setStep(Step.MANAGE)
+              }}>
+              <ButtonText>
+                <Trans>Disable link</Trans>
+              </ButtonText>
+            </Button>
+            <Button
+              color="secondary"
+              size="large"
+              label={l`Cancel`}
+              onPress={() => {
+                setStep(Step.MANAGE)
+              }}>
+              <ButtonText>{l`Cancel`}</ButtonText>
+            </Button>
+          </View>
+        </>
+      )
+      break
   }
 
   if (!isOwner && (!joinLink || joinLink.enabledStatus === 'disabled')) {

--- a/src/screens/Messages/components/MessagesListInfoPanel.tsx
+++ b/src/screens/Messages/components/MessagesListInfoPanel.tsx
@@ -1,6 +1,7 @@
 import {View} from 'react-native'
 import {Plural, Trans, useLingui} from '@lingui/react/macro'
 
+import {createSanitizedDisplayName} from '#/lib/moderation/create-sanitized-display-name'
 import {logger} from '#/logger'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useAddGroupMembers} from '#/state/queries/messages/add-group-members'
@@ -56,18 +57,22 @@ export function MessagesListInfoPanel({
 
   let names: React.ReactNode = null
   if (members.length === 1) {
-    names = <Trans>New chat with {members[0].displayName}</Trans>
+    names = (
+      <Trans>New chat with {createSanitizedDisplayName(members[0])}</Trans>
+    )
   } else if (members.length === 2) {
     names = (
       <Trans>
-        New chat with {members[0].displayName} and {members[1].displayName}
+        New chat with {createSanitizedDisplayName(members[0])} and{' '}
+        {createSanitizedDisplayName(members[1])}
       </Trans>
     )
   } else if (members.length > 2) {
     const memberCount = convo.details.memberCount - 2
     names = (
       <Trans>
-        New chat with {members[0].displayName}, {members[1].displayName}, and{' '}
+        New chat with {createSanitizedDisplayName(members[0])},{' '}
+        {createSanitizedDisplayName(members[1])}, and{' '}
         <Plural
           value={memberCount}
           one={`${memberCount} more`}

--- a/src/state/queries/messages/list-convo-members.ts
+++ b/src/state/queries/messages/list-convo-members.ts
@@ -59,7 +59,11 @@ export function useListConvoMembersQuery({
                 r => r.did === data.member.did,
               )
               if (newMember) {
-                mutateList(list => list.concat(newMember))
+                mutateList(list =>
+                  list.some(m => m.did === newMember.did)
+                    ? list
+                    : list.concat(newMember),
+                )
               }
             }
           } else if (ChatBskyConvoDefs.isLogRemoveMember(log)) {

--- a/src/state/queries/messages/remove-from-group.ts
+++ b/src/state/queries/messages/remove-from-group.ts
@@ -1,6 +1,6 @@
 import {
   type ChatBskyActorDefs,
-  type ChatBskyConvoDefs,
+  ChatBskyConvoDefs,
   type ChatBskyConvoListConvos,
   type ChatBskyGroupRemoveMembers,
 } from '@atproto/api'
@@ -56,9 +56,18 @@ export function useRemoveFromGroupChat(
         CONVO_KEY(convoId),
         prev => {
           if (!prev) return
+          const nextMembers = prev.members.filter(m => !members.includes(m.did))
+          const removed = prev.members.length - nextMembers.length
+          if (!ChatBskyConvoDefs.isGroupConvo(prev.kind)) {
+            return {...prev, members: nextMembers}
+          }
           return {
             ...prev,
-            members: prev.members.filter(m => !members.includes(m.did)),
+            members: nextMembers,
+            kind: {
+              ...prev.kind,
+              memberCount: Math.max(0, prev.kind.memberCount - removed),
+            },
           }
         },
       )
@@ -73,9 +82,20 @@ export function useRemoveFromGroupChat(
             ...page,
             convos: page.convos.map(convo => {
               if (convo.id !== convoId) return convo
+              const nextMembers = convo.members.filter(
+                m => !members.includes(m.did),
+              )
+              const removed = convo.members.length - nextMembers.length
+              if (!ChatBskyConvoDefs.isGroupConvo(convo.kind)) {
+                return {...convo, members: nextMembers}
+              }
               return {
                 ...convo,
-                members: convo.members.filter(m => !members.includes(m.did)),
+                members: nextMembers,
+                kind: {
+                  ...convo.kind,
+                  memberCount: Math.max(0, convo.kind.memberCount - removed),
+                },
               }
             }),
           })),


### PR DESCRIPTION
Implements the latest design changes and fixes a bug.

* Adds support for an icon to prompts
  * Locking a group chat has a lock icon
  * Leaving a group chat has an exit icon
* Fixes color of “Unlock chat” link on a locked chat
* Adds confirmation dialog for disabling an invite link
* Adds pull-to-refresh for the chat member list
* Fixes optimistic updates when adding or removing chat members

https://github.com/user-attachments/assets/c4acc957-1867-4ae1-b6d7-6ce3e7dee5c6

https://github.com/user-attachments/assets/f28ac642-3f3f-48a0-9976-856e7af64421

https://github.com/user-attachments/assets/36868d93-f7b7-4aae-9cc7-bfeff9f09b80

https://github.com/user-attachments/assets/90a60bc4-39d9-4242-a90e-5aeeb35d741b

https://github.com/user-attachments/assets/7426dd6b-cab9-432a-8eb9-5e84343f496b

https://github.com/user-attachments/assets/1dbd80f5-9545-41da-b01d-92e27d7d7dad

https://github.com/user-attachments/assets/6b0186d2-b9dd-493f-8c93-416675036b00