### PR TITLE
Align composer video preview with in-feed embed

### DIFF
--- a/src/view/com/composer/videos/VideoPreview.tsx
+++ b/src/view/com/composer/videos/VideoPreview.tsx
@@ -5,10 +5,10 @@ import {type ImagePickerAsset} from 'expo-image-picker'
 import {BlueskyVideoView} from '@bsky.app/video'
 
 import {type CompressedVideo} from '#/lib/media/video/types'
-import {clamp} from '#/lib/numbers'
 import {useAutoplayDisabled} from '#/state/preferences'
 import {ExternalEmbedRemoveBtn} from '#/view/com/composer/ExternalEmbedRemoveBtn'
-import {atoms as a, useTheme} from '#/alf'
+import {atoms as a} from '#/alf'
+import {ConstrainedImage} from '#/components/images/AutoSizedImage'
 import {PlayButtonIcon} from '#/components/video/PlayButtonIcon'
 import {VideoTranscodeBackdrop} from './VideoTranscodeBackdrop'
 
@@ -23,58 +23,63 @@ export function VideoPreview({
   isActivePost: boolean
   clear: () => void
 }) {
-  const t = useTheme()
   const playerRef = useRef<BlueskyVideoView>(null)
   const autoplayDisabled = useAutoplayDisabled()
-  let aspectRatio = asset.width / asset.height
 
-  if (isNaN(aspectRatio)) {
-    aspectRatio = 16 / 9
+  let aspectRatio: number | undefined
+  if (asset.width && asset.height) {
+    const raw = asset.width / asset.height
+    if (!Number.isNaN(raw)) {
+      aspectRatio = raw
+    }
   }
 
-  aspectRatio = clamp(aspectRatio, 1 / 1, 3 / 1)
+  let constrained: number | undefined
+  if (aspectRatio !== undefined) {
+    const ratio = 1 / 2 // max of 1:2 ratio in feeds
+    constrained = Math.max(aspectRatio, ratio)
+  }
 
   return (
-    <View
-      style={[
-        a.w_full,
-        a.rounded_sm,
-        {aspectRatio},
-        a.overflow_hidden,
-        a.border,
-        t.atoms.border_contrast_low,
-        {backgroundColor: 'black'},
-      ]}>
-      <View style={[a.absolute, a.inset_0]}>
-        <VideoTranscodeBackdrop uri={asset.uri} />
-      </View>
-      {isActivePost && (
-        <>
-          {video.mimeType === 'image/gif' ? (
-            <Image
-              style={[a.flex_1]}
-              autoplay={!autoplayDisabled}
-              source={{uri: video.uri}}
-              accessibilityIgnoresInvertColors
-              cachePolicy="none"
-            />
-          ) : (
-            <BlueskyVideoView
-              url={video.uri}
-              autoplay={!autoplayDisabled}
-              beginMuted={true}
-              forceTakeover={true}
-              ref={playerRef}
-            />
+    <View style={[a.pt_xs]}>
+      <ConstrainedImage
+        aspectRatio={constrained || 1}
+        minMobileAspectRatio={14 / 9}>
+        <View style={[a.flex_1, {backgroundColor: 'black'}]}>
+          <View style={[a.absolute, a.inset_0]}>
+            <VideoTranscodeBackdrop uri={asset.uri} />
+          </View>
+          {isActivePost && (
+            <>
+              {video.mimeType === 'image/gif' ? (
+                <Image
+                  style={[a.flex_1]}
+                  autoplay={!autoplayDisabled}
+                  source={{uri: video.uri}}
+                  accessibilityIgnoresInvertColors
+                  cachePolicy="none"
+                  contentFit="contain"
+                />
+              ) : (
+                <BlueskyVideoView
+                  url={video.uri}
+                  autoplay={!autoplayDisabled}
+                  beginMuted={true}
+                  forceTakeover={true}
+                  ref={playerRef}
+                />
+              )}
+            </>
           )}
-        </>
-      )}
-      <ExternalEmbedRemoveBtn onRemove={clear} />
-      {autoplayDisabled && (
-        <View style={[a.absolute, a.inset_0, a.justify_center, a.align_center]}>
-          <PlayButtonIcon />
+          <ExternalEmbedRemoveBtn onRemove={clear} />
+          {autoplayDisabled && (
+            <View
+              style={[a.absolute, a.inset_0, a.justify_center, a.align_center]}>
+              <PlayButtonIcon />
+            </View>
+          )}
         </View>
-      )}
+      </ConstrainedImage>
     </View>
   )
 }

--- a/src/view/com/composer/videos/VideoPreview.web.tsx
+++ b/src/view/com/composer/videos/VideoPreview.web.tsx
@@ -4,22 +4,21 @@ import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 
 import {type CompressedVideo} from '#/lib/media/video/types'
-import {clamp} from '#/lib/numbers'
 import {useAutoplayDisabled} from '#/state/preferences'
 import {ExternalEmbedRemoveBtn} from '#/view/com/composer/ExternalEmbedRemoveBtn'
 import {atoms as a} from '#/alf'
+import {ConstrainedImage} from '#/components/images/AutoSizedImage'
 import * as Toast from '#/components/Toast'
 import {PlayButtonIcon} from '#/components/video/PlayButtonIcon'
 
 export function VideoPreview({
   asset,
   video,
-
   clear,
 }: {
   asset: ImagePickerAsset
   video: CompressedVideo
-
+  isActivePost: boolean
   clear: () => void
 }) {
   const {_} = useLingui()
@@ -27,56 +26,65 @@ export function VideoPreview({
   // it's not possible using an img tag -sfn
   const autoplayDisabled = useAutoplayDisabled()
 
-  let aspectRatio = asset.width / asset.height
-
-  if (isNaN(aspectRatio)) {
-    aspectRatio = 16 / 9
+  let aspectRatio: number | undefined
+  if (asset.width && asset.height) {
+    const raw = asset.width / asset.height
+    if (!Number.isNaN(raw)) {
+      aspectRatio = raw
+    }
   }
 
-  aspectRatio = clamp(aspectRatio, 1 / 1, 3 / 1)
+  let constrained: number | undefined
+  if (aspectRatio !== undefined) {
+    const ratio = 1 / 2 // max of 1:2 ratio in feeds
+    constrained = Math.max(aspectRatio, ratio)
+  }
 
   return (
-    <View
-      style={[
-        a.w_full,
-        a.rounded_sm,
-        {aspectRatio},
-        a.overflow_hidden,
-        {backgroundColor: 'black'},
-        a.relative,
-      ]}>
-      <ExternalEmbedRemoveBtn onRemove={clear} />
-      {video.mimeType === 'image/gif' ? (
-        <img
-          src={video.uri}
-          style={{width: '100%', height: '100%', objectFit: 'cover'}}
-          alt="GIF"
-        />
-      ) : (
-        <>
-          <video
-            src={video.uri}
-            style={{width: '100%', height: '100%', objectFit: 'cover'}}
-            autoPlay={!autoplayDisabled}
-            loop
-            muted
-            playsInline
-            onError={err => {
-              console.error('Error loading video', err)
-              Toast.show(_(msg`Could not process your video`), {
-                type: 'error',
-              })
-              clear()
-            }}
-          />
-          {autoplayDisabled && (
-            <View
-              style={[a.absolute, a.inset_0, a.justify_center, a.align_center]}>
-              <PlayButtonIcon />
-            </View>
+    <View style={[a.pt_xs]}>
+      <ConstrainedImage
+        aspectRatio={constrained || 1}
+        minMobileAspectRatio={14 / 9}>
+        <View style={[a.flex_1, {backgroundColor: 'black'}]}>
+          {video.mimeType === 'image/gif' ? (
+            <img
+              src={video.uri}
+              style={{width: '100%', height: '100%', objectFit: 'contain'}}
+              alt="GIF"
+            />
+          ) : (
+            <>
+              <video
+                src={video.uri}
+                style={{width: '100%', height: '100%', objectFit: 'contain'}}
+                autoPlay={!autoplayDisabled}
+                loop
+                muted
+                playsInline
+                onError={err => {
+                  console.error('Error loading video', err)
+                  Toast.show(_(msg`Could not process your video`), {
+                    type: 'error',
+                  })
+                  clear()
+                }}
+              />
+              {autoplayDisabled && (
+                <View
+                  style={[
+                    a.absolute,
+                    a.inset_0,
+                    a.justify_center,
+                    a.align_center,
+                  ]}>
+                  <PlayButtonIcon />
+                </View>
+              )}
+            </>
           )}
-        </>
-      )}
+          <ExternalEmbedRemoveBtn onRemove={clear} />
+        </View>
+      </ConstrainedImage>
     </View>
   )
 }

--- a/src/view/com/composer/videos/VideoTranscodeProgress.tsx
+++ b/src/view/com/composer/videos/VideoTranscodeProgress.tsx
@@ -3,8 +3,8 @@ import {View} from 'react-native'
 import ProgressPie from 'react-native-progress/Pie'
 import {type ImagePickerAsset} from 'expo-image-picker'
 
-import {clamp} from '#/lib/numbers'
 import {atoms as a, useTheme} from '#/alf'
+import {ConstrainedImage} from '#/components/images/AutoSizedImage'
 import {IS_WEB} from '#/env'
 import {ExternalEmbedRemoveBtn} from '../ExternalEmbedRemoveBtn'
 import {VideoTranscodeBackdrop} from './VideoTranscodeBackdrop'
@@ -22,42 +22,53 @@ export function VideoTranscodeProgress({
 
   if (IS_WEB) return null
 
-  let aspectRatio = asset.width / asset.height
-
-  if (isNaN(aspectRatio)) {
-    aspectRatio = 16 / 9
+  let aspectRatio: number | undefined
+  if (asset.width && asset.height) {
+    const raw = asset.width / asset.height
+    if (!Number.isNaN(raw)) {
+      aspectRatio = raw
+    }
   }
 
-  aspectRatio = clamp(aspectRatio, 1 / 1, 3 / 1)
+  let constrained: number | undefined
+  if (aspectRatio !== undefined) {
+    const ratio = 1 / 2 // max of 1:2 ratio in feeds
+    constrained = Math.max(aspectRatio, ratio)
+  }
 
   return (
-    <View
-      style={[
-        a.w_full,
-        t.atoms.bg_contrast_50,
-        a.rounded_md,
-        a.overflow_hidden,
-        {aspectRatio},
-      ]}>
-      <VideoTranscodeBackdrop uri={asset.uri} />
-      <View
-        style={[
-          a.flex_1,
-          a.align_center,
-          a.justify_center,
-          a.gap_lg,
-          a.absolute,
-          a.inset_0,
-        ]}>
-        <ProgressPie
-          size={48}
-          borderWidth={3}
-          borderColor={t.atoms.text.color}
-          color={t.atoms.text.color}
-          progress={progress}
-        />
-      </View>
-      <ExternalEmbedRemoveBtn onRemove={clear} />
+    <View style={[a.pt_xs]}>
+      <ConstrainedImage
+        aspectRatio={constrained || 1}
+        minMobileAspectRatio={14 / 9}>
+        <View
+          style={[
+            a.flex_1,
+            t.atoms.bg_contrast_50,
+            a.rounded_md,
+            a.overflow_hidden,
+          ]}>
+          <VideoTranscodeBackdrop uri={asset.uri} />
+          <View
+            style={[
+              a.flex_1,
+              a.align_center,
+              a.justify_center,
+              a.gap_lg,
+              a.absolute,
+              a.inset_0,
+            ]}>
+            <ProgressPie
+              size={48}
+              borderWidth={3}
+              borderColor={t.atoms.text.color}
+              color={t.atoms.text.color}
+              progress={progress}
+            />
+          </View>
+          <ExternalEmbedRemoveBtn onRemove={clear} />
+        </View>
+      </ConstrainedImage>
     </View>
   )
 }


### PR DESCRIPTION
## Summary

The composer's video preview and transcode-progress placeholder used a different aspect-ratio/cropping rule than the in-feed video embed, so WYSIWYG broke for portrait and very wide videos. This aligns the composer toward the feed (not the other way around — live posts are unaffected):

- Swap `clamp(ratio, 1/1, 3/1)` for the feed's `Math.max(ratio, 1/2)` with an `undefined` NaN fallback (default 1:1 via `ConstrainedImage`).
- Wrap both the preview and the transcode-progress view in `ConstrainedImage` with `minMobileAspectRatio={14 / 9}`, matching `VideoEmbed`.
- Web: switch `<video>` and GIF `<img>` `objectFit` from `cover` to `contain`.
- Native: no change to `BlueskyVideoView` resize — it already letterboxes inside `ConstrainedImage`.

## Before / after

<table>
  <thead>
    <tr>
      <th></th>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Web</td>
      <td><img src="https://github.com/user-attachments/assets/8b010593-3b91-4003-9881-e3b3a7ad4e38" alt="web before" width="360" /></td>
      <td><img src="https://github.com/user-attachments/assets/0ddcf6f5-a0ff-4ccf-aa36-b4e270462b5d" alt="web after" width="360" /></td>
    </tr>
    <tr>
      <td>Native</td>
      <td><img src="https://github.com/user-attachments/assets/ac567298-698a-4256-926f-e844264004f9" alt="native before" width="360" /></td>
      <td><img src="https://github.com/user-attachments/assets/a77f081f-21eb-49e3-9ada-abbeefbefa9b" alt="native after" width="360" /></td>
    </tr>
  </tbody>
</table>






## Test plan

- [x] Attach a portrait (9:16) video — preview letterboxes with bars on the sides and matches the published post.
- [x] Attach a landscape (16:9) video — preview matches the feed (no side-cropping).
- [x] Attach an ultra-wide (~21:9) video — previously clamped to 3:1 and cropped; now shows full width with letterbox.
- [x] Attach a GIF — cropping matches feed behavior.
- [x] Watch the transcode progress on native — frame doesn't jump when compression finishes and the player takes over.
- [x] Remove (X) button is still tappable and positioned correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)