### PR TITLE
Display badges next to chat inviter's display name

### DIFF
--- a/src/screens/Messages/components/ChatStatusInfo.tsx
+++ b/src/screens/Messages/components/ChatStatusInfo.tsx
@@ -137,16 +137,22 @@ function InviterHeader({
         moderation={moderation.ui('avatar')}
       />
       <View style={[a.flex_1]}>
-        <View style={[a.flex_row, a.align_center]}>
-          <Text
-            style={[a.text_md, a.font_bold, t.atoms.text]}
-            numberOfLines={1}>
-            <Trans comment="Text identifying the person who added you to a group chat. Display name is followed by the user’s profile badges.">
-              Added by {displayName}
-            </Trans>
-          </Text>
-          <ProfileBadges profile={profile} size="md" style={[a.pl_xs]} />
-        </View>
+        <Text style={[a.flex_row, a.align_center]}>
+          <Trans comment="Text identifying the person who added you to a group chat">
+            <Text
+              style={[a.text_md, a.font_bold, t.atoms.text]}
+              numberOfLines={1}>
+              {displayName}
+            </Text>
+            <ProfileBadges profile={profile} size="md" style={[a.pl_xs]} />
+            <Text
+              style={[a.text_md, a.font_bold, t.atoms.text]}
+              numberOfLines={1}>
+              {' '}
+              added you
+            </Text>
+          </Trans>
+        </Text>
         <Text style={[web(a.pt_xs), a.text_sm, t.atoms.text_contrast_high]}>
           {sanitizeHandle(profile.handle, '@')}
         </Text>

--- a/src/screens/Messages/components/ChatStatusInfo.tsx
+++ b/src/screens/Messages/components/ChatStatusInfo.tsx
@@ -140,13 +140,23 @@ function InviterHeader({
         <Text style={[a.flex_row, a.align_center]}>
           <Trans comment="Text identifying the person who added you to a group chat">
             <Text
-              style={[a.text_md, a.font_bold, t.atoms.text]}
+              style={[
+                a.text_md,
+                a.leading_snug,
+                a.font_semi_bold,
+                t.atoms.text,
+              ]}
               numberOfLines={1}>
               {displayName}
             </Text>
-            <ProfileBadges profile={profile} size="md" style={[a.pl_xs]} />
+            <ProfileBadges profile={profile} size="sm" style={[a.pl_xs]} />
             <Text
-              style={[a.text_md, a.font_bold, t.atoms.text]}
+              style={[
+                a.text_md,
+                a.leading_snug,
+                a.font_semi_bold,
+                t.atoms.text,
+              ]}
               numberOfLines={1}>
               {' '}
               added you

--- a/src/screens/Messages/components/ChatStatusInfo.tsx
+++ b/src/screens/Messages/components/ChatStatusInfo.tsx
@@ -13,6 +13,7 @@ import {PreviewableUserAvatar} from '#/view/com/util/UserAvatar'
 import {atoms as a, useTheme, web} from '#/alf'
 import {LeaveConvoPrompt} from '#/components/dms/LeaveConvoPrompt'
 import {KnownFollowers} from '#/components/KnownFollowers'
+import {ProfileBadges} from '#/components/ProfileBadges'
 import {usePromptControl} from '#/components/Prompt'
 import {Text} from '#/components/Typography'
 import type * as bsky from '#/types/bsky'
@@ -135,10 +136,17 @@ function InviterHeader({
         size={42}
         moderation={moderation.ui('avatar')}
       />
-      <View>
-        <Text style={[a.text_md, a.font_bold, t.atoms.text]}>
-          <Trans>{displayName} added you</Trans>
-        </Text>
+      <View style={[a.flex_1]}>
+        <View style={[a.flex_row, a.align_center]}>
+          <Text
+            style={[a.text_md, a.font_bold, t.atoms.text]}
+            numberOfLines={1}>
+            <Trans comment="Text identifying the person who added you to a group chat. Display name is followed by the user’s profile badges.">
+              Added by {displayName}
+            </Trans>
+          </Text>
+          <ProfileBadges profile={profile} size="md" style={[a.pl_xs]} />
+        </View>
         <Text style={[web(a.pt_xs), a.text_sm, t.atoms.text_contrast_high]}>
           {sanitizeHandle(profile.handle, '@')}
         </Text>


### PR DESCRIPTION
~Doesn’t seem like we can inline badges in a translated string, so I made a slight copy edit to ensure the badges appear directly after the display name.~