### PR TITLE
[APP-2170] Render GIFs through ConstrainedImage

### DIFF
--- a/src/components/Post/Embed/ExternalEmbed/Gif.tsx
+++ b/src/components/Post/Embed/ExternalEmbed/Gif.tsx
@@ -1,13 +1,13 @@
 import {useRef, useState} from 'react'
-import {type StyleProp, View, type ViewStyle} from 'react-native'
+import {View} from 'react-native'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 
-import {clamp} from '#/lib/numbers'
 import {type EmbedPlayerParams} from '#/lib/strings/embed-player'
 import {useAutoplayDisabled} from '#/state/preferences'
 import {atoms as a, useTheme} from '#/alf'
 import {Fill} from '#/components/Fill'
+import {ConstrainedImage} from '#/components/images/AutoSizedImage'
 import {MediaInsetBorder} from '#/components/MediaInsetBorder'
 import {GifView} from '../../../../../modules/expo-bluesky-gif-view'
 import {type GifViewStateChangeEvent} from '../../../../../modules/expo-bluesky-gif-view/src/GifView.types'
@@ -19,14 +19,12 @@ export function GifEmbed({
   altText,
   isPreferredAltText,
   hideAlt,
-  style = {width: '100%'},
 }: {
   params: EmbedPlayerParams
   thumb: string | undefined
   altText: string
   isPreferredAltText: boolean
   hideAlt?: boolean
-  style?: StyleProp<ViewStyle>
 }) {
   const t = useTheme()
   const {_} = useLingui()
@@ -53,60 +51,64 @@ export function GifEmbed({
   let aspectRatio = 1
   if (params.dimensions) {
     const ratio = params.dimensions.width / params.dimensions.height
-    aspectRatio = clamp(ratio, 0.75, 4)
+    if (!Number.isNaN(ratio)) {
+      aspectRatio = ratio
+    }
   }
+  const constrained = Math.max(aspectRatio, 1 / 2)
 
   return (
-    <View
-      style={[
-        a.rounded_md,
-        a.overflow_hidden,
-        {backgroundColor: t.palette.black},
-        {aspectRatio},
-        style,
-      ]}>
+    <ConstrainedImage aspectRatio={constrained} minMobileAspectRatio={14 / 9}>
       <View
         style={[
-          a.absolute,
-          /*
-           * Aspect ratio was being clipped weirdly on web -esb
-           */
-          {
-            top: -2,
-            bottom: -2,
-            left: -2,
-            right: -2,
-          },
+          a.flex_1,
+          a.rounded_md,
+          a.overflow_hidden,
+          {backgroundColor: t.palette.black},
         ]}>
-        <MediaInsetBorder />
-        <GifPresentationControls
-          onPress={onPress}
-          isPlaying={playerState.isPlaying}
-          isLoading={!playerState.isLoaded}
-          altText={!hideAlt && isPreferredAltText ? altText : undefined}
-        />
-        <GifView
-          source={params.playerUri}
-          sources={params.playerSources}
-          placeholderSource={thumb}
-          style={[a.flex_1]}
-          autoplay={!autoplayDisabled}
-          onPlayerStateChange={onPlayerStateChange}
-          ref={playerRef}
-          accessibilityHint={_(msg`Animated GIF`)}
-          accessibilityLabel={altText}
-        />
-        {!playerState.isPlaying && (
-          <Fill
-            style={[
-              t.name === 'light' ? t.atoms.bg_contrast_975 : t.atoms.bg,
-              {
-                opacity: 0.3,
-              },
-            ]}
+        <View
+          style={[
+            a.absolute,
+            /*
+             * Aspect ratio was being clipped weirdly on web -esb
+             */
+            {
+              top: -2,
+              bottom: -2,
+              left: -2,
+              right: -2,
+            },
+          ]}>
+          <MediaInsetBorder />
+          <GifPresentationControls
+            onPress={onPress}
+            isPlaying={playerState.isPlaying}
+            isLoading={!playerState.isLoaded}
+            altText={!hideAlt && isPreferredAltText ? altText : undefined}
           />
-        )}
+          <GifView
+            source={params.playerUri}
+            sources={params.playerSources}
+            placeholderSource={thumb}
+            style={[a.flex_1]}
+            autoplay={!autoplayDisabled}
+            onPlayerStateChange={onPlayerStateChange}
+            ref={playerRef}
+            accessibilityHint={_(msg`Animated GIF`)}
+            accessibilityLabel={altText}
+          />
+          {!playerState.isPlaying && (
+            <Fill
+              style={[
+                t.name === 'light' ? t.atoms.bg_contrast_975 : t.atoms.bg,
+                {
+                  opacity: 0.3,
+                },
+              ]}
+            />
+          )}
+        </View>
       </View>
-    </View>
+    </ConstrainedImage>
   )
 }

--- a/src/view/com/composer/GifAltText.tsx
+++ b/src/view/com/composer/GifAltText.tsx
@@ -216,16 +216,13 @@ function AltTextInner({
             style={[a.text_2xl, a.font_semi_bold, a.leading_tight, a.pb_sm]}>
             <Trans>Add alt text</Trans>
           </Text>
-          <View style={[a.align_center]}>
-            <GifEmbed
-              thumb={thumb}
-              altText={altText}
-              isPreferredAltText={true}
-              params={params}
-              hideAlt
-              style={[{height: 225}]}
-            />
-          </View>
+          <GifEmbed
+            thumb={thumb}
+            altText={altText}
+            isPreferredAltText={true}
+            params={params}
+            hideAlt
+          />
         </View>
       </View>
       <Dialog.Close />


### PR DESCRIPTION
Tall GIFs were being squished because the previous outer View clamped the aspect ratio to [0.75, 4] and forced width: 100%. A 9:16 GIF got clamped to 0.75 and stretched to feed width.

Use the ConstrainedImage component instead, with the same parameters videos use (1:2 minimum aspect ratio in feeds, 14:9 native bounding box). Tall GIFs now render narrower with preserved aspect, matching how videos and images render today.

Removes the unused style prop from GifEmbed and the fixed height: 225 on the composer alt-text preview, which is now handled by ConstrainedImage.

before:
<img width="2352" height="1790" alt="image" src="https://github.com/user-attachments/assets/55815755-1656-4156-bfbb-39e1a8935d2c" />

after:
<img width="895" height="819" alt="CleanShot 2026-05-11 at 15 00 22" src="https://github.com/user-attachments/assets/8ccb3940-6340-45f8-ac80-b223d5781385" />

