### PR TITLE
Fix stale display name for renamed pinned lists

### DIFF
--- a/src/state/queries/feed.ts
+++ b/src/state/queries/feed.ts
@@ -413,12 +413,14 @@ const PWI_DISCOVER_FEED_STUB: SavedFeedSourceInfo = {
   contentMode: undefined,
 }
 
+export const FEED_INFO_RQKEY_ROOT = 'feed-info'
+
 const createPinnedFeedInfosQueryKey = (
   kind: 'pinned' | 'saved',
   feedUris: string[],
 ) =>
   createQueryKey(
-    'feed-info',
+    FEED_INFO_RQKEY_ROOT,
     {
       kind,
       feedUris,

--- a/src/state/queries/list.ts
+++ b/src/state/queries/list.ts
@@ -17,6 +17,7 @@ import {until} from '#/lib/async/until'
 import {type ImageMeta} from '#/state/gallery'
 import {STALE} from '#/state/queries'
 import {useAgent, useSession} from '#/state/session'
+import {FEED_INFO_RQKEY_ROOT} from './feed'
 import {invalidate as invalidateMyLists} from './my-lists'
 import {RQKEY as PROFILE_LISTS_RQKEY} from './profile-lists'
 
@@ -180,6 +181,9 @@ export function useListMetadataMutation() {
       })
       queryClient.invalidateQueries({
         queryKey: RQKEY(variables.uri),
+      })
+      queryClient.invalidateQueries({
+        queryKey: [FEED_INFO_RQKEY_ROOT],
       })
     },
   })


### PR DESCRIPTION
### **Summary**
When a pinned list's name is changed, the updated name wasn't reflected in the pinned feeds sidebar/tab bar until the app was restarted.

usePinnedFeedsInfos and useSavedFeeds both cache list metadata with staleTime: INFINITY, keyed only by the list URIs. Since renaming a list doesn't change its URI, the cache was never invalidated on edit — leaving the old name displayed indefinitely.

Fix: invalidate the feed-info query cache in useListEditMutation.onSuccess, so pinned and saved feed display names refresh immediately after a list is renamed.

### **Test plan**

- Pin a list
- Rename the list
- Confirm the new name appears in the pinned feeds sidebar (desktop) and tab bar (mobile) without restarting