### PR TITLE
ci: build ogcard image on push to main

### DIFF
--- a/.github/workflows/build-and-push-ogcard-aws.yaml
+++ b/.github/workflows/build-and-push-ogcard-aws.yaml
@@ -1,11 +1,9 @@
 name: build-and-push-ogcard-aws
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - "bskyogcard/**"
-      - "Dockerfile.bskyogcard"
-      - ".github/workflows/build-and-push-ogcard-aws.yaml"
+  push:
+    branches:
+      - main
 
 env:
   REGISTRY: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_REGISTRY }}


### PR DESCRIPTION
## Summary

`build-and-push-ogcard-aws.yaml` only triggered on `pull_request`, never on push to main. PR commits got ECR images; merges to main produced no new image. Matches `bskyweb-aws` pattern now (push to main + workflow_dispatch).

## Why

The current trigger pattern means deploy tooling pointing at a main-resolved image SHA may miss, or pick up a stale PR-commit build. bskyweb + embedr both use `push: branches: [main]` for exactly this reason.

## Context

bskylink (`build-and-push-link-aws.yaml`) has the same quirk. Leaving that for a separate conversation with whoever owns bskylink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)