### PR TITLE
Render chat skeleton instead of loading spinner

### DIFF
--- a/src/components/dms/ChatEmptyPill.tsx
+++ b/src/components/dms/ChatEmptyPill.tsx
@@ -6,8 +6,7 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated'
-import {msg} from '@lingui/core/macro'
-import {useLingui} from '@lingui/react'
+import {useLingui} from '@lingui/react/macro'
 
 import {ScaleAndFadeIn} from '#/lib/custom-animations/ScaleAndFade'
 import {ShrinkAndPop} from '#/lib/custom-animations/ShrinkAndPop'
@@ -22,7 +21,7 @@ let lastIndex = 0
 
 export function ChatEmptyPill() {
   const t = useTheme()
-  const {_} = useLingui()
+  const {t: l} = useLingui()
   const playHaptic = useHaptics()
   const [promptIndex, setPromptIndex] = useState(lastIndex)
 
@@ -30,15 +29,15 @@ export function ChatEmptyPill() {
 
   const prompts = useMemo(() => {
     return [
-      _(msg`Say hello!`),
-      _(msg`Share your favorite feed!`),
-      _(msg`Tell a joke!`),
-      _(msg`Share a fun fact!`),
-      _(msg`Share a cool story!`),
-      _(msg`Send a neat website!`),
-      _(msg`Clip 🐴 clop 🐴`),
+      l`Say hello!`,
+      l`Share your favorite feed!`,
+      l`Tell a joke!`,
+      l`Share a fun fact!`,
+      l`Share a cool story!`,
+      l`Send a neat website!`,
+      l`Clip 🐴 clop 🐴`,
     ]
-  }, [_])
+  }, [l])
 
   const onPressIn = useCallback(() => {
     if (IS_WEB) return

--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -5,7 +5,6 @@ import {
   type StyleProp,
   type TextStyle,
   View,
-  type ViewStyle,
 } from 'react-native'
 import Animated, {
   FadeIn,
@@ -42,16 +41,19 @@ import {InlineLinkText, Link} from '#/components/Link'
 import * as ProfileCard from '#/components/ProfileCard'
 import {RichText} from '#/components/RichText'
 import {Text} from '#/components/Typography'
+import {getBubbleColor, getMessageInset} from './bubbleStyles'
 import {DateDivider} from './DateDivider'
 import {MessageItemEmbed} from './MessageItemEmbed'
 import {ReactionsDialog} from './ReactionsDialog'
-import {CLUSTERED_MESSAGE_THRESHOLD_MS, MESSAGE_GAP_THRESHOLD_MS} from './util'
-
-const AVATAR_SIZE = 28
-const CLUSTERED_MESSAGE_GAP = 2
-const BORDER_RADIUS = 18
-const SQUARED_BORDER_RADIUS = 4
-const DISPLAY_NAME_INSET = 22
+import {
+  AVATAR_SIZE,
+  BUBBLE_GAP,
+  BUBBLE_RADIUS,
+  BUBBLE_RADIUS_SHARP,
+  CLUSTERED_MESSAGE_THRESHOLD_MS,
+  DISPLAY_NAME_INSET,
+  MESSAGE_GAP_THRESHOLD_MS,
+} from './util'
 
 function isWithinClusterBoundary({
   isPending,
@@ -174,18 +176,16 @@ let MessageItem = ({
     isInCluster &&
     (isInMiddleOfCluster || isLastInCluster)
 
-  const pendingColor = t.palette.primary_300
-
   const rt = new RichTextAPI({text: message.text, facets: message.facets})
 
   const hasEmbedAndText =
     AppBskyEmbedRecord.isView(message.embed) && rt.text.length > 0
 
   const targetBottomRadius = squaredBottomCorner
-    ? SQUARED_BORDER_RADIUS
-    : BORDER_RADIUS
+    ? BUBBLE_RADIUS_SHARP
+    : BUBBLE_RADIUS
   const targetTopRadius =
-    squaredTopCorner || hasEmbedAndText ? SQUARED_BORDER_RADIUS : BORDER_RADIUS
+    squaredTopCorner || hasEmbedAndText ? BUBBLE_RADIUS_SHARP : BUBBLE_RADIUS
 
   const bottomRadiusSV = useSharedValue(targetBottomRadius)
   const topRadiusSV = useSharedValue(targetTopRadius)
@@ -381,10 +381,9 @@ let MessageItem = ({
     </LayoutAnimationConfig>
   )
 
-  const messageInset = platform<ViewStyle | undefined>({
-    ios: isFromSelf ? a.mr_md : isGroupChat ? a.ml_md : a.ml_sm,
-    android: isFromSelf ? a.mr_sm : isGroupChat ? a.ml_sm : undefined,
-    web: isFromSelf ? a.mr_sm : isGroupChat ? a.ml_sm : undefined,
+  const messageInset = getMessageInset({
+    isIncoming: !isFromSelf,
+    isGroupChat,
   })
 
   return (
@@ -450,18 +449,15 @@ let MessageItem = ({
                     ...(isOnlyEmoji(message.text)
                       ? []
                       : [
-                          a.rounded_xl,
                           a.py_sm,
                           a.px_md,
                           {
-                            marginTop: isFirstInCluster
-                              ? 0
-                              : CLUSTERED_MESSAGE_GAP,
-                            backgroundColor: isFromSelf
-                              ? isPending
-                                ? pendingColor
-                                : t.palette.primary_500
-                              : t.palette.contrast_50,
+                            borderRadius: BUBBLE_RADIUS,
+                            marginTop: isFirstInCluster ? 0 : BUBBLE_GAP,
+                            backgroundColor: getBubbleColor(t, {
+                              isIncoming: !isFromSelf,
+                              isPending,
+                            }),
                           },
                           isFromSelf ? a.self_end : a.self_start,
                           borderRadiusStyle,

--- a/src/components/dms/MessageItemEmbed.tsx
+++ b/src/components/dms/MessageItemEmbed.tsx
@@ -5,10 +5,7 @@ import {type $Typed, type AppBskyEmbedRecord} from '@atproto/api'
 import {atoms as a, native, useTheme, web} from '#/alf'
 import {Embed, PostEmbedViewContext} from '#/components/Post/Embed'
 import {MessageContextProvider} from './MessageContext'
-
-const CLUSTERED_MESSAGE_GAP = 2
-const BORDER_RADIUS = 20
-const SQUARED_BORDER_RADIUS = 4
+import {BUBBLE_GAP, BUBBLE_RADIUS, BUBBLE_RADIUS_SHARP} from './util'
 
 let MessageItemEmbed = ({
   embed,
@@ -39,7 +36,7 @@ let MessageItemEmbed = ({
             maxWidth: 360,
           }),
           {
-            marginTop: CLUSTERED_MESSAGE_GAP,
+            marginBottom: BUBBLE_GAP,
           },
         ]}>
         <View style={{marginTop: -8}}>
@@ -55,20 +52,20 @@ let MessageItemEmbed = ({
                 ? {
                     backgroundColor: t.palette.primary_50,
                     borderBottomRightRadius: squaredBottomCorner
-                      ? SQUARED_BORDER_RADIUS
-                      : BORDER_RADIUS,
+                      ? BUBBLE_RADIUS_SHARP
+                      : BUBBLE_RADIUS,
                     borderTopRightRadius: squaredTopCorner
-                      ? SQUARED_BORDER_RADIUS
-                      : BORDER_RADIUS,
+                      ? BUBBLE_RADIUS_SHARP
+                      : BUBBLE_RADIUS,
                   }
                 : {
                     backgroundColor: t.palette.contrast_50,
                     borderBottomLeftRadius: squaredBottomCorner
-                      ? SQUARED_BORDER_RADIUS
-                      : BORDER_RADIUS,
+                      ? BUBBLE_RADIUS_SHARP
+                      : BUBBLE_RADIUS,
                     borderTopLeftRadius: squaredTopCorner
-                      ? SQUARED_BORDER_RADIUS
-                      : BORDER_RADIUS,
+                      ? BUBBLE_RADIUS_SHARP
+                      : BUBBLE_RADIUS,
                   },
             ]}
           />

--- a/src/components/dms/bubbleStyles.ts
+++ b/src/components/dms/bubbleStyles.ts
@@ -1,0 +1,88 @@
+import {type ViewStyle} from 'react-native'
+
+import {type Theme} from '#/alf'
+import {atoms as a, platform} from '#/alf'
+import {BUBBLE_RADIUS, BUBBLE_RADIUS_SHARP} from './util'
+
+/**
+ * Calculates border radius for message bubbles based on cluster position.
+ * Sharpens the corners on the sender's side when messages are clustered.
+ */
+export function getBubbleRadii({
+  isIncoming,
+  isFirstInCluster,
+  isLastInCluster,
+  hasEmbedAndText = false,
+}: {
+  isIncoming: boolean
+  isFirstInCluster: boolean
+  isLastInCluster: boolean
+  hasEmbedAndText?: boolean
+}): ViewStyle {
+  const sharpTop = !isFirstInCluster || hasEmbedAndText
+  const sharpBottom = !isLastInCluster
+
+  return isIncoming
+    ? {
+        borderTopLeftRadius: sharpTop ? BUBBLE_RADIUS_SHARP : BUBBLE_RADIUS,
+        borderBottomLeftRadius: sharpBottom
+          ? BUBBLE_RADIUS_SHARP
+          : BUBBLE_RADIUS,
+        borderTopRightRadius: BUBBLE_RADIUS,
+        borderBottomRightRadius: BUBBLE_RADIUS,
+      }
+    : {
+        borderTopLeftRadius: BUBBLE_RADIUS,
+        borderBottomLeftRadius: BUBBLE_RADIUS,
+        borderTopRightRadius: sharpTop ? BUBBLE_RADIUS_SHARP : BUBBLE_RADIUS,
+        borderBottomRightRadius: sharpBottom
+          ? BUBBLE_RADIUS_SHARP
+          : BUBBLE_RADIUS,
+      }
+}
+
+/**
+ * Platform-specific outer margin for message bubbles.
+ * Keeps bubbles aligned properly across different platforms.
+ */
+export function getMessageInset({
+  isIncoming,
+  isGroupChat,
+}: {
+  isIncoming: boolean
+  isGroupChat: boolean
+}): ViewStyle | undefined {
+  return platform<ViewStyle | undefined>({
+    ios: !isIncoming ? a.mr_md : isGroupChat ? a.ml_md : a.ml_sm,
+    android: !isIncoming ? a.mr_sm : isGroupChat ? a.ml_sm : undefined,
+    web: !isIncoming ? a.mr_sm : isGroupChat ? a.ml_sm : undefined,
+  })
+}
+
+/**
+ * Determines bubble background color based on message state.
+ * Real messages use primary/contrast colors; skeleton placeholders use lighter shades.
+ */
+export function getBubbleColor(
+  t: Theme,
+  {
+    isIncoming,
+    isPending = false,
+    isRealMessage = true,
+  }: {
+    isIncoming: boolean
+    isPending?: boolean
+    isRealMessage?: boolean
+  },
+): string {
+  if (isRealMessage) {
+    return isIncoming
+      ? t.palette.contrast_50
+      : isPending
+        ? t.palette.primary_300
+        : t.palette.primary_500
+  }
+
+  // Skeleton/placeholder colors
+  return isIncoming ? t.palette.contrast_50 : t.palette.primary_100
+}

--- a/src/components/dms/util.ts
+++ b/src/components/dms/util.ts
@@ -2,10 +2,21 @@ import {type $Typed, ChatBskyActorDefs, ChatBskyConvoDefs} from '@atproto/api'
 
 import {EMOJI_REACTION_LIMIT} from '#/lib/constants'
 import {logger} from '#/logger'
+import {IS_NATIVE, IS_WEB} from '#/env'
 import * as bsky from '#/types/bsky'
+
+// The extra two items account for the header and the footer components
+export const INITIAL_NUMBER_TO_RENDER = IS_NATIVE ? 32 : 62
+export const MAX_TO_RENDER_PER_BATCH = IS_WEB ? 32 : 62
 
 export const MESSAGE_GAP_THRESHOLD_MS = 60 * 60 * 1000
 export const CLUSTERED_MESSAGE_THRESHOLD_MS = 5 * 60 * 1000
+
+export const AVATAR_SIZE = 28
+export const BUBBLE_GAP = 2
+export const BUBBLE_RADIUS = 20
+export const BUBBLE_RADIUS_SHARP = 4
+export const DISPLAY_NAME_INSET = 22
 
 export function canBeMessaged(profile: bsky.profile.AnyProfileView) {
   switch (profile.associated?.chat?.allowIncoming) {

--- a/src/screens/Messages/Conversation.tsx
+++ b/src/screens/Messages/Conversation.tsx
@@ -1,11 +1,9 @@
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {useCallback, useEffect, useId, useRef, useState} from 'react'
 import {type LayoutChangeEvent, View} from 'react-native'
+import {KeyboardGestureArea} from 'react-native-keyboard-controller'
+import Animated, {FadeOut} from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
-import {moderateProfile} from '@atproto/api'
-import {
-  ScrollEdgeEffect,
-  ScrollEdgeEffectProvider,
-} from '@bsky.app/expo-scroll-edge-effect'
+import {ScrollEdgeEffectProvider} from '@bsky.app/expo-scroll-edge-effect'
 import {Trans, useLingui} from '@lingui/react/macro'
 import {
   type RouteProp,
@@ -17,42 +15,47 @@ import {
 import {type NativeStackScreenProps} from '@react-navigation/native-stack'
 import {RemoveScrollBar} from 'react-remove-scroll-bar'
 
-import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {useViewportZoomLock} from '#/lib/hooks/useViewportZoomLock'
 import {
   type CommonNavigatorParams,
   type NavigationProp,
 } from '#/lib/routes/types'
-import {useMaybeProfileShadow} from '#/state/cache/profile-shadow'
-import {useEmail} from '#/state/email-verification'
 import {ConvoProvider, isConvoActive, useConvo} from '#/state/messages/convo'
-import {ConvoStatus} from '#/state/messages/convo/types'
+import {type ConvoState, ConvoStatus} from '#/state/messages/convo/types'
 import {useCurrentConvoId} from '#/state/messages/current-convo-id'
-import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useConvoQuery} from '#/state/queries/messages/conversation'
 import {useSession} from '#/state/session'
-import {MessagesList} from '#/screens/Messages/components/MessagesList'
-import {atoms as a, useTheme, web} from '#/alf'
+import {ChatSkeleton} from '#/screens/Messages/components/ChatSkeleton'
+import {MessageComposer} from '#/screens/Messages/components/MessageComposer'
+import {MessageInput} from '#/screens/Messages/components/MessageInput'
+import {
+  getChatBottomReservation,
+  MessagesList,
+} from '#/screens/Messages/components/MessagesList'
+import {useBlockForEmailVerification} from '#/screens/Messages/hooks/useBlockForEmailVerification'
+import {useChatFooterOverride} from '#/screens/Messages/hooks/useChatFooterOverride'
+import {useInputHeight} from '#/screens/Messages/hooks/useInputHeight'
+import {useSendChatMessage} from '#/screens/Messages/hooks/useSendChatMessage'
+import {atoms as a, platform, tokens, useTheme, web} from '#/alf'
 import {AgeRestrictedScreen} from '#/components/ageAssurance/AgeRestrictedScreen'
 import {useAgeAssuranceCopy} from '#/components/ageAssurance/useAgeAssuranceCopy'
 import * as Dialog from '#/components/Dialog'
-import {
-  EmailDialogScreenID,
-  useEmailDialogControl,
-} from '#/components/dialogs/EmailDialog'
-import {MessagesListBlockedFooter} from '#/components/dms/MessagesListBlockedFooter'
-import {MessagesListHeader} from '#/components/dms/MessagesListHeader'
+import {ChatEmptyPill} from '#/components/dms/ChatEmptyPill'
 import {type ConvoWithDetails, parseConvoView} from '#/components/dms/util'
 import {Error} from '#/components/Error'
 import * as Layout from '#/components/Layout'
-import {Loader} from '#/components/Loader'
 import * as Prompt from '#/components/Prompt'
 import {Text} from '#/components/Typography'
 import {useAnalytics} from '#/analytics'
 import {IS_INTERNAL, IS_LIQUID_GLASS, IS_WEB} from '#/env'
-import {ChatDisabled} from './components/ChatDisabled'
-import {ChatEnded} from './components/ChatEnded'
-import {ChatLocked} from './components/ChatLocked'
+import {ChatStatusInfo} from './components/ChatStatusInfo'
+import {ConvoHeader} from './components/ConvoHeader'
+import {InviteLinkDialogProvider} from './components/InviteLinkDialogProvider'
+import {
+  MessageInputEmbed,
+  useMessageEmbed,
+} from './components/MessageInputEmbed'
+import {KeyboardStickyView} from './components/vendor/KeyboardStickyView'
 
 type Props = NativeStackScreenProps<
   CommonNavigatorParams,
@@ -101,12 +104,10 @@ export function MessagesConversationScreenInner({route}: Props) {
 }
 
 function Inner({convoId}: {convoId: string}) {
-  const t = useTheme()
   const convoState = useConvo()
   const {t: l} = useLingui()
   const {currentAccount} = useSession()
   const isFocused = useIsFocused()
-  const {top: topInset} = useSafeAreaInsets()
   const {data: convoData} = useConvoQuery({convoId})
 
   useViewportZoomLock({enabled: isFocused})
@@ -138,9 +139,8 @@ function Inner({convoId}: {convoId: string}) {
   if (convoState.status === ConvoStatus.Error) {
     return (
       <>
-        <Layout.Center
-          style={[a.w_full, IS_LIQUID_GLASS && {paddingTop: topInset}]}>
-          <MessagesListHeader convo={convo} />
+        <Layout.Center style={[a.w_full]}>
+          <ConvoHeader convo={convo} />
         </Layout.Center>
         <Error
           title={l`Something went wrong`}
@@ -156,159 +156,192 @@ function Inner({convoId}: {convoId: string}) {
     <Layout.Center style={[a.flex_1]}>
       {/* MessagesList does not use the body scroll */}
       {isFocused && IS_WEB && <RemoveScrollBar />}
-      {!readyToShow && (
-        <View style={IS_LIQUID_GLASS && {paddingTop: topInset}}>
-          <MessagesListHeader convo={convo} />
-        </View>
-      )}
-      <View style={[a.flex_1]}>
-        <InnerReady
-          convo={convo}
-          hasScrolled={hasScrolled}
-          setHasScrolled={setHasScrolled}
-          isActive={isConvoActive(convoState)}
-          isDisabled={convoState.status === ConvoStatus.Disabled}
-          hasMessages={isConvoActive(convoState) && convoState.items.length > 0}
-        />
-        {!readyToShow && (
-          <View
-            style={[
-              a.absolute,
-              a.z_10,
-              a.w_full,
-              a.h_full,
-              a.justify_center,
-              a.align_center,
-              t.atoms.bg,
-            ]}>
-            <View style={[{marginBottom: 75}]}>
-              <Loader size="xl" />
-            </View>
-          </View>
-        )}
-      </View>
+      <ChatBody
+        convo={convo}
+        convoState={convoState}
+        hasScrolled={hasScrolled}
+        setHasScrolled={setHasScrolled}
+        readyToShow={readyToShow}
+      />
     </Layout.Center>
   )
 }
 
-function InnerReady({
+/**
+ * Owns the keyboard/composer area. To keep the composer from jumping around,
+ * it's mounted once and always occupies the same real estate, regardless of
+ * whether we're showing the `MessagesList` or the `ChatSkeleton` above it.
+ */
+function ChatBody({
+  convo,
+  convoState,
   hasScrolled,
   setHasScrolled,
-  convo,
-  isActive,
-  isDisabled,
-  hasMessages,
+  readyToShow,
 }: {
+  convo: ConvoWithDetails | null
+  convoState: ConvoState
   hasScrolled: boolean
   setHasScrolled: React.Dispatch<React.SetStateAction<boolean>>
-  convo: ConvoWithDetails | null
-  isActive: boolean
-  isDisabled: boolean
-  hasMessages: boolean
+  readyToShow: boolean
 }) {
-  const navigation = useNavigation<NavigationProp>()
-  const {top: topInset} = useSafeAreaInsets()
+  const t = useTheme()
+  const ax = useAnalytics()
+  const {bottom: bottomInset} = useSafeAreaInsets()
+  const {params} =
+    useRoute<RouteProp<CommonNavigatorParams, 'MessagesConversation'>>()
+  const {embedUri, setEmbed} = useMessageEmbed()
+
+  const isActive = isConvoActive(convoState)
+  const isDisabled = convoState.status === ConvoStatus.Disabled
+  const hasMessages = isActive && convoState.items.length > 0
+
+  const textInputId = `chat-input-${useId()}`
+  const {inputHeightUI, inputHeightJS, onInputLayout} = useInputHeight()
+
   const [headerHeight, setHeaderHeight] = useState(0)
   const onHeaderLayout = (e: LayoutChangeEvent) => {
     setHeaderHeight(e.nativeEvent.layout.height)
   }
-  const {params} =
-    useRoute<RouteProp<CommonNavigatorParams, 'MessagesConversation'>>()
-  const {needsEmailVerification} = useEmail()
-  const emailDialogControl = useEmailDialogControl()
 
-  /**
-   * Must be non-reactive, otherwise the update to open the global dialog will
-   * cause a re-render loop.
-   */
-  const maybeBlockForEmailVerification = useNonReactiveCallback(() => {
-    if (needsEmailVerification) {
-      /*
-       * HACKFIX
-       *
-       * Load bearing timeout, to bump this state update until the after the
-       * `navigator.addListener('state')` handler closes elements from
-       * `shell/index.*.tsx`  - sfn & esb
-       */
-      setTimeout(() =>
-        emailDialogControl.open({
-          id: EmailDialogScreenID.Verify,
-          instructions: [
-            <Trans key="pre-compose">
-              Before you can message another user, you must first verify your
-              email.
-            </Trans>,
-          ],
-          onCloseWithoutVerifying: () => {
-            if (navigation.canGoBack()) {
-              navigation.goBack()
-            } else {
-              navigation.navigate('Messages', {animation: 'pop'})
-            }
-          },
-        }),
-      )
-    }
-  })
-
-  useEffect(() => {
-    maybeBlockForEmailVerification()
-  }, [maybeBlockForEmailVerification])
-
-  const primaryMember = useMaybeProfileShadow(convo?.primaryMember)
-  const moderationOpts = useModerationOpts()
-  const primaryMemberModeration = useMemo(() => {
-    if (!primaryMember || !moderationOpts) return null
-    return moderateProfile(primaryMember, moderationOpts)
-  }, [primaryMember, moderationOpts])
-
-  const header = <MessagesListHeader convo={convo} />
-
-  let footer: React.ReactNode = null
-  if (isDisabled) {
-    footer = <ChatDisabled />
-  } else if (convo && primaryMember && primaryMemberModeration?.blocked) {
-    footer = (
-      <MessagesListBlockedFooter
-        recipient={primaryMember}
-        convoId={convo.view.id}
-        hasMessages={hasMessages}
-        moderation={primaryMemberModeration}
-      />
-    )
-  } else if (convo?.kind === 'group') {
-    if (convo.details.lockStatus === 'locked') {
-      footer = <ChatLocked convo={convo} />
-    } else if (convo.details.lockStatus === 'locked-permanently') {
-      footer = <ChatEnded convo={convo} />
-    }
+  const [footerHeight, setFooterHeight] = useState(0)
+  const onFooterLayout = (e: LayoutChangeEvent) => {
+    setFooterHeight(e.nativeEvent.layout.height)
   }
 
-  return (
-    <>
-      {IS_LIQUID_GLASS ? (
-        <ScrollEdgeEffect
-          edge="top"
-          style={[a.absolute, a.w_full, a.z_10, {paddingTop: topInset}]}
-          onLayout={onHeaderLayout}>
-          {header}
-        </ScrollEdgeEffect>
-      ) : (
-        header
-      )}
-      {isActive && (
-        <MessagesList
-          hasScrolled={hasScrolled}
-          setHasScrolled={setHasScrolled}
-          hasAcceptOverride={!!params.accept}
-          transparentHeaderHeight={IS_LIQUID_GLASS ? headerHeight : 0}
-          footer={footer}
-        />
-      )}
+  useBlockForEmailVerification()
 
+  const footerOverride = useChatFooterOverride({convo, isDisabled, hasMessages})
+
+  const onSendMessage = useSendChatMessage({
+    convoState,
+    embedUri,
+    hasScrolled,
+    setHasScrolled,
+  })
+
+  return (
+    <InviteLinkDialogProvider convo={convo}>
+      <ConvoHeader convo={convo} onLayout={onHeaderLayout} />
+      <KeyboardGestureArea
+        interpolator="ios"
+        // HACKFIX: https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1419
+        offset={Math.round(inputHeightJS)}
+        // TODO slightly too buggy unfortunately, enable when possible
+        // textInputNativeID={textInputId}
+        style={[a.flex_1]}>
+        <View style={[a.flex_1]}>
+          {isActive && (
+            <MessagesList
+              hasScrolled={hasScrolled}
+              setHasScrolled={setHasScrolled}
+              transparentHeaderHeight={IS_LIQUID_GLASS ? headerHeight : 0}
+              inputHeightUI={inputHeightUI}
+              inputHeightJS={inputHeightJS}
+            />
+          )}
+          {!readyToShow && (
+            <Animated.View
+              exiting={FadeOut.duration(200)}
+              style={[
+                a.absolute,
+                web(a.px_md),
+                {top: 0, left: 0, right: 0, bottom: 0},
+                t.atoms.bg,
+              ]}>
+              <ChatSkeleton
+                convo={convo}
+                transparentHeaderHeight={IS_LIQUID_GLASS ? headerHeight : 0}
+                bottomPadding={getChatBottomReservation({
+                  inputHeight: footerOverride ? footerHeight : inputHeightJS,
+                  bottomInset,
+                })}
+              />
+            </Animated.View>
+          )}
+        </View>
+        <KeyboardStickyView
+          style={[a.absolute, a.bottom_0, a.left_0, a.right_0]}
+          onLayout={footerOverride ? onFooterLayout : onInputLayout}
+          minimumOffset={bottomInset}
+          offset={{
+            closed: platform({
+              ios: tokens.space.lg, // hide bottom padding when closed
+              default: 0,
+            }),
+            opened: 0,
+          }}>
+          {footerOverride ?? (
+            <ConversationFooter
+              convoState={convoState}
+              hasAcceptOverride={!!params.accept}>
+              {ax.features.enabled(ax.features.DmsNewMessageComposerEnable) ? (
+                <MessageComposer
+                  textInputId={textInputId}
+                  onSendMessage={(message: string) =>
+                    void onSendMessage(message)
+                  }
+                  hasEmbed={!!embedUri}
+                  setEmbed={setEmbed}
+                  loading={!readyToShow}>
+                  <MessageInputEmbed embedUri={embedUri} setEmbed={setEmbed} />
+                </MessageComposer>
+              ) : (
+                <MessageInput
+                  textInputId={textInputId}
+                  onSendMessage={onSendMessage}
+                  hasEmbed={!!embedUri}
+                  setEmbed={setEmbed}
+                  disabled={!readyToShow}>
+                  <MessageInputEmbed embedUri={embedUri} setEmbed={setEmbed} />
+                </MessageInput>
+              )}
+            </ConversationFooter>
+          )}
+        </KeyboardStickyView>
+      </KeyboardGestureArea>
       {!IS_INTERNAL && convo?.kind === 'group' && <GroupChatGate />}
-    </>
+    </InviteLinkDialogProvider>
   )
+}
+
+/**
+ * Wraps the composer with optional decorations or replaces it entirely for
+ * convo states where the user can't send a message. The composer stays mounted
+ * in every other case - including during history fetch - so its height is
+ * stable for the skeleton above.
+ */
+function ConversationFooter({
+  convoState,
+  hasAcceptOverride,
+  children,
+}: {
+  convoState: ConvoState
+  hasAcceptOverride?: boolean
+  children?: React.ReactNode // message input
+}) {
+  if (!isConvoActive(convoState)) {
+    return children
+  }
+
+  const hasItems = convoState.items.length > 0
+  const isRequest =
+    convoState.convo.view.status === 'request' && !hasAcceptOverride
+
+  if (hasItems && isRequest) {
+    return <ChatStatusInfo convoState={convoState} />
+  }
+
+  if (!hasItems && !convoState.isFetchingHistory) {
+    return (
+      <>
+        <ChatEmptyPill />
+        {children}
+      </>
+    )
+  }
+
+  return children
 }
 
 function GroupChatGate() {

--- a/src/screens/Messages/components/ChatSkeleton.tsx
+++ b/src/screens/Messages/components/ChatSkeleton.tsx
@@ -1,0 +1,235 @@
+import {useCallback, useMemo, useRef} from 'react'
+import {ScrollView, View} from 'react-native'
+import {useSafeAreaInsets} from 'react-native-safe-area-context'
+import {ChatBskyConvoDefs} from '@atproto/api'
+import {useScrollEdgeEffectRef} from '@bsky.app/expo-scroll-edge-effect'
+
+import {useSession} from '#/state/session'
+import {atoms as a, useTheme} from '#/alf'
+import {
+  getBubbleColor,
+  getBubbleRadii,
+  getMessageInset,
+} from '#/components/dms/bubbleStyles'
+import {
+  AVATAR_SIZE,
+  BUBBLE_GAP,
+  type ConvoWithDetails,
+  INITIAL_NUMBER_TO_RENDER,
+} from '#/components/dms/util'
+import {Text} from '#/components/Typography'
+import {IS_LIQUID_GLASS} from '#/env'
+
+type Side = 'incoming' | 'outgoing'
+
+type SkeletonBubble =
+  | {side: Side; widthPct: number; height: number; text?: undefined}
+  | {side: Side; text: string}
+
+/**
+ * Pre-seeded pattern that approximates a busy chat. Cluster boundaries are
+ * derived from adjacent bubbles' `side` values.
+ */
+const SKELETON_PATTERN: SkeletonBubble[] = [
+  {side: 'outgoing', widthPct: 55, height: 36},
+  {side: 'outgoing', widthPct: 40, height: 36},
+  {side: 'incoming', widthPct: 60, height: 36},
+  {side: 'outgoing', widthPct: 35, height: 36},
+  {side: 'incoming', widthPct: 45, height: 36},
+  {side: 'outgoing', widthPct: 70, height: 56},
+  {side: 'outgoing', widthPct: 50, height: 36},
+  {side: 'incoming', widthPct: 55, height: 36},
+  {side: 'outgoing', widthPct: 65, height: 36},
+  {side: 'incoming', widthPct: 50, height: 36},
+  {side: 'outgoing', widthPct: 45, height: 36},
+  {side: 'incoming', widthPct: 40, height: 36},
+  {side: 'outgoing', widthPct: 55, height: 36},
+  {side: 'outgoing', widthPct: 60, height: 36},
+  {side: 'incoming', widthPct: 50, height: 36},
+]
+
+export function ChatSkeleton({
+  convo,
+  bottomPadding = 0,
+  transparentHeaderHeight = 0,
+}: {
+  convo: ConvoWithDetails | null
+  /**
+   * Reserved space at the bottom for the composer area. The skeleton lives in
+   * the same flex slot as the real list, with the composer overlaying its
+   * bottom region, so the bottommost bubble needs to clear that overlap.
+   */
+  bottomPadding?: number
+  /**
+   * On Liquid Glass, the floating header overlays the top of this view.
+   * Mirrors `MessagesList`'s prop so the skeleton's scroll view also drives
+   * the header's top edge-effect blur while the real list isn't mounted yet.
+   */
+  transparentHeaderHeight?: number
+}) {
+  const t = useTheme()
+  const {currentAccount} = useSession()
+  const {bottom: bottomInset} = useSafeAreaInsets()
+  const isGroup = convo?.kind === 'group'
+
+  // Under Liquid Glass the scroll view's frame reaches past the bottom safe
+  // area, and iOS's default `contentInsetAdjustmentBehavior` is timing-
+  // dependent about whether it adds `bottomInset` to `contentInset.bottom`.
+  // We force `"always"` below for a deterministic ~bottomInset of implicit
+  // inset, then subtract it from the caller's reservation here so the
+  // bottommost bubble lines up with the first rendered message.
+  const adjustedPaddingBottom = IS_LIQUID_GLASS
+    ? bottomPadding - bottomInset
+    : bottomPadding
+
+  // Register this scroll view as the source for the header's top edge-effect
+  // blur (Liquid Glass) on mount, but skip the unregistration on unmount.
+  // `MessagesList` registers its own scroll view shortly after, and we don't
+  // want this view's FadeOut to clear that registration when it finally
+  // unmounts. No-op on platforms where `useScrollEdgeEffectRef` returns
+  // undefined.
+  const scrollEdgeRef = useScrollEdgeEffectRef()
+  const scrollViewRef = useRef<ScrollView | null>(null)
+  const setScrollViewRef = useCallback(
+    (node: ScrollView | null) => {
+      scrollViewRef.current = node
+      if (node && scrollEdgeRef) {
+        scrollEdgeRef(node)
+      }
+    },
+    [scrollEdgeRef],
+  )
+
+  // Placeholders with the real `lastMessage` appended at the bottom if it's a
+  // regular message - deleted and system messages are skipped.
+  const bubbles = useMemo<SkeletonBubble[]>(() => {
+    const list: SkeletonBubble[] = Array.from(
+      {length: INITIAL_NUMBER_TO_RENDER},
+      (_, i) => SKELETON_PATTERN[i % SKELETON_PATTERN.length],
+    )
+    const lastMessage = convo?.view.lastMessage
+    if (lastMessage && ChatBskyConvoDefs.isMessageView(lastMessage)) {
+      list.push({
+        side:
+          lastMessage.sender.did === currentAccount?.did
+            ? 'outgoing'
+            : 'incoming',
+        text: lastMessage.text,
+      })
+    }
+    return list
+  }, [convo, currentAccount?.did])
+
+  return (
+    <ScrollView
+      ref={setScrollViewRef}
+      scrollEnabled={false}
+      showsVerticalScrollIndicator={false}
+      style={[a.flex_1]}
+      contentInset={{top: transparentHeaderHeight}}
+      contentInsetAdjustmentBehavior="always"
+      contentContainerStyle={[
+        a.justify_end,
+        {flexGrow: 1, paddingBottom: adjustedPaddingBottom},
+      ]}
+      onContentSizeChange={() => {
+        scrollViewRef.current?.scrollToEnd({animated: false})
+      }}>
+      <View>
+        {bubbles.map((bubble, i) => {
+          const prev = bubbles[i - 1]
+          const next = bubbles[i + 1]
+          const isFirstInCluster = !prev || prev.side !== bubble.side
+          const isLastInCluster = !next || next.side !== bubble.side
+          const isIncoming = bubble.side === 'incoming'
+          const showAvatar = isGroup && isIncoming && isLastInCluster
+          const isRealMessage = bubble.text !== undefined
+
+          const radii = getBubbleRadii({
+            isIncoming,
+            isFirstInCluster,
+            isLastInCluster,
+          })
+
+          const bubbleColor = getBubbleColor(t, {
+            isIncoming,
+            isRealMessage,
+          })
+
+          const rowInset = getMessageInset({
+            isIncoming,
+            isGroupChat: isGroup,
+          })
+
+          return (
+            <View
+              key={i}
+              style={[
+                a.flex_row,
+                a.align_end,
+                isIncoming ? a.justify_start : a.justify_end,
+                rowInset,
+                isFirstInCluster ? a.mt_md : {marginTop: BUBBLE_GAP},
+              ]}>
+              {isGroup && isIncoming ? (
+                <View
+                  style={[
+                    a.rounded_full,
+                    {
+                      width: AVATAR_SIZE,
+                      height: AVATAR_SIZE,
+                      opacity: showAvatar ? 1 : 0,
+                      backgroundColor: t.palette.contrast_50,
+                    },
+                  ]}
+                />
+              ) : null}
+              {bubble.text !== undefined ? (
+                <View
+                  style={[
+                    isIncoming && a.ml_sm,
+                    radii,
+                    a.py_sm,
+                    a.px_md,
+                    {backgroundColor: bubbleColor},
+                  ]}>
+                  <Text
+                    emoji
+                    style={[
+                      a.text_md,
+                      a.leading_snug,
+                      !isIncoming && {color: t.palette.white},
+                    ]}>
+                    {bubble.text}
+                  </Text>
+                </View>
+              ) : (
+                <View
+                  style={[
+                    isIncoming && a.ml_sm,
+                    radii,
+                    a.py_sm,
+                    a.px_md,
+                    {
+                      width: `${bubble.widthPct}%`,
+                      backgroundColor: bubbleColor,
+                    },
+                  ]}>
+                  <Text
+                    emoji
+                    style={[
+                      a.text_md,
+                      a.leading_snug,
+                      !isIncoming && {color: t.palette.white},
+                    ]}>
+                    &nbsp;
+                  </Text>
+                </View>
+              )}
+            </View>
+          )
+        })}
+      </View>
+    </ScrollView>
+  )
+}

--- a/src/screens/Messages/components/ConvoHeader.tsx
+++ b/src/screens/Messages/components/ConvoHeader.tsx
@@ -1,0 +1,49 @@
+import {type LayoutChangeEvent, View} from 'react-native'
+import {useSafeAreaInsets} from 'react-native-safe-area-context'
+import {ScrollEdgeEffect} from '@bsky.app/expo-scroll-edge-effect'
+
+import {atoms as a} from '#/alf'
+import {MessagesListHeader} from '#/components/dms/MessagesListHeader'
+import {type ConvoWithDetails} from '#/components/dms/util'
+import {IS_LIQUID_GLASS} from '#/env'
+
+/**
+ * Without `onLayout`, this is a plain in-flow header used for static surfaces
+ * (e.g. the error screen). With `onLayout`, it becomes the floating variant
+ * that overlays the scrollable list with a Liquid Glass material; the caller
+ * uses the measured height to compensate via `contentInset.top` on the list.
+ *
+ * On non-Liquid Glass platforms the floating variant collapses back to an
+ * in-flow header (the top inset is handled by `Layout.Screen` there), and
+ * `onLayout` is therefore not attached.
+ */
+export function ConvoHeader({
+  convo,
+  onLayout,
+}: {
+  convo: ConvoWithDetails | null
+  onLayout?: (e: LayoutChangeEvent) => void
+}) {
+  const {top: topInset} = useSafeAreaInsets()
+
+  if (onLayout && IS_LIQUID_GLASS) {
+    return (
+      <ScrollEdgeEffect
+        edge="top"
+        style={[a.absolute, a.w_full, a.z_10, {paddingTop: topInset}]}
+        onLayout={onLayout}>
+        <MessagesListHeader convo={convo} />
+      </ScrollEdgeEffect>
+    )
+  }
+
+  if (onLayout) {
+    return <MessagesListHeader convo={convo} />
+  }
+
+  return (
+    <View style={IS_LIQUID_GLASS && {paddingTop: topInset}}>
+      <MessagesListHeader convo={convo} />
+    </View>
+  )
+}

--- a/src/screens/Messages/components/InviteLinkDialogProvider.tsx
+++ b/src/screens/Messages/components/InviteLinkDialogProvider.tsx
@@ -16,7 +16,7 @@ export function InviteLinkDialogProvider({
   convo,
   children,
 }: {
-  convo: ConvoWithDetails | undefined
+  convo: ConvoWithDetails | null
   children: React.ReactNode
 }) {
   if (convo?.kind !== 'group') {

--- a/src/screens/Messages/components/MessageComposer.tsx
+++ b/src/screens/Messages/components/MessageComposer.tsx
@@ -32,6 +32,7 @@ import * as EmojiPicker from '#/components/EmojiPicker'
 import {GlassView} from '#/components/GlassView'
 import {EmojiArc_Stroke2_Corner0_Rounded as EmojiSmileIcon} from '#/components/icons/Emoji'
 import {PaperPlaneVertical_Filled_Stroke2_Corner1_Rounded as PaperPlaneIcon} from '#/components/icons/PaperPlane'
+import {Loader} from '#/components/Loader'
 import * as Toast from '#/components/Toast'
 import {IS_ANDROID, IS_IOS, IS_LIQUID_GLASS, IS_NATIVE, IS_WEB} from '#/env'
 
@@ -42,19 +43,21 @@ export function MessageComposer({
   onSendMessage,
   hasEmbed,
   setEmbed,
+  loading = false,
   children,
 }: {
   textInputId?: string
   onSendMessage: (message: string) => void
   hasEmbed: boolean
   setEmbed: (embedUrl: string | undefined) => void
+  loading?: boolean
   children?: React.ReactNode
 }) {
   const t = useTheme()
   const {t: l} = useLingui()
   const playHaptic = useHaptics()
   const {needsEmailVerification} = useEmail()
-  const editable = !needsEmailVerification
+  const editable = !needsEmailVerification && !loading
   const {getDraft, clearDraft} = useMessageDraft()
   const composerInternalApiRef = useComposerInternalApiRef()
 
@@ -209,7 +212,7 @@ export function MessageComposer({
             <Composer
               nativeID={textInputId}
               label={l`Message input field`}
-              placeholder={l`Message`}
+              placeholder={loading ? l`Loading chat…` : l`Message`}
               autocompletePlacement="top-start"
               internalApiRef={composerInternalApiRef}
               defaultValue={text}
@@ -237,7 +240,11 @@ export function MessageComposer({
               }}
             />
           </GlassView>
-          <SubmitButton onPress={handleSubmit} disabled={submitDisabled} />
+          <SubmitButton
+            onPress={handleSubmit}
+            disabled={submitDisabled}
+            loading={loading}
+          />
         </GlassContainer>
       </View>
     </ComposerContainer>
@@ -247,9 +254,11 @@ export function MessageComposer({
 function SubmitButton({
   onPress,
   disabled,
+  loading,
 }: {
   onPress: () => void
   disabled: boolean
+  loading: boolean
 }) {
   const {t: l} = useLingui()
   const t = useTheme()
@@ -278,7 +287,11 @@ function SubmitButton({
         ]}
         onPress={onPress}
         disabled={disabled}>
-        <PaperPlaneIcon size="md" fill={t.palette.white} style={[a.mb_2xs]} />
+        {loading ? (
+          <Loader size="md" fill={t.palette.white} style={[a.mb_2xs]} />
+        ) : (
+          <PaperPlaneIcon size="md" fill={t.palette.white} style={[a.mb_2xs]} />
+        )}
       </Pressable>
     </GlassView>
   )

--- a/src/screens/Messages/components/MessageInput.tsx
+++ b/src/screens/Messages/components/MessageInput.tsx
@@ -42,12 +42,14 @@ export function MessageInput({
   onSendMessage,
   hasEmbed,
   setEmbed,
+  disabled = false,
   children,
 }: {
   textInputId?: string
   onSendMessage: (message: string) => Promise<void> | void
   hasEmbed: boolean
   setEmbed: (embedUrl: string | undefined) => void
+  disabled?: boolean
   children?: React.ReactNode
 }) {
   const {t: l} = useLingui()
@@ -67,12 +69,13 @@ export function MessageInput({
   const [shouldEnforceClear, setShouldEnforceClear] = useState(false)
 
   const {needsEmailVerification} = useEmail()
+  const editable = !needsEmailVerification && !disabled
 
   useSaveMessageDraft(message)
   useExtractEmbedFromFacets(message, setEmbed)
 
   const onSubmit = useCallback(() => {
-    if (needsEmailVerification) {
+    if (!editable) {
       return
     }
     if (!hasEmbed && message.trim() === '') {
@@ -103,7 +106,7 @@ export function MessageInput({
       void onSendMessage(message)
     })
   }, [
-    needsEmailVerification,
+    editable,
     hasEmbed,
     message,
     clearDraft,
@@ -139,8 +142,7 @@ export function MessageInput({
     scrollEnabled: isInputScrollable.get(),
   }))
 
-  const submitDisabled =
-    needsEmailVerification || (!hasEmbed && message.trim().length === 0)
+  const submitDisabled = !editable || (!hasEmbed && message.trim().length === 0)
 
   const blur = useCallback(() => {
     inputRef.current?.blur()
@@ -209,7 +211,7 @@ export function MessageInput({
             ref={inputRef}
             hitSlop={HITSLOP_10}
             animatedProps={animatedProps}
-            editable={!needsEmailVerification}
+            editable={editable}
           />
         </GlassView>
         <GlassView

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -1,17 +1,6 @@
-import {
-  useCallback,
-  useEffect,
-  useId,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react'
-import {type LayoutChangeEvent, type ScrollViewProps, View} from 'react-native'
-import {
-  KeyboardChatScrollView,
-  type KeyboardChatScrollViewProps,
-  KeyboardGestureArea,
-} from 'react-native-keyboard-controller'
+import {useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react'
+import {type ScrollViewProps, View} from 'react-native'
+import {KeyboardChatScrollView} from 'react-native-keyboard-controller'
 import {
   runOnJS,
   type ScrollEvent,
@@ -21,52 +10,88 @@ import {
   useSharedValue,
 } from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
-import {
-  type $Typed,
-  type AppBskyEmbedRecord,
-  AppBskyRichtextFacet,
-  ChatBskyConvoDefs,
-  RichText,
-} from '@atproto/api'
+import {ChatBskyConvoDefs} from '@atproto/api'
 import {useScrollEdgeEffectRef} from '@bsky.app/expo-scroll-edge-effect'
 
 import {mergeRefs} from '#/lib/merge-refs'
 import {ScrollProvider} from '#/lib/ScrollContext'
-import {shortenLinks, stripInvalidMentions} from '#/lib/strings/rich-text-manip'
-import {
-  convertBskyAppUrlIfNeeded,
-  isBskyPostUrl,
-} from '#/lib/strings/url-helpers'
-import {logger} from '#/logger'
-import {
-  type ActiveConvoStates,
-  isConvoActive,
-  useConvoActive,
-} from '#/state/messages/convo'
-import {type ConvoState, ConvoStatus} from '#/state/messages/convo/types'
-import {useGetPost} from '#/state/queries/post'
-import {useAgent} from '#/state/session'
+import {useConvoActive} from '#/state/messages/convo'
+import {ConvoStatus} from '#/state/messages/convo/types'
 import {List, type ListMethods} from '#/view/com/util/List'
-import {MessageComposer} from '#/screens/Messages/components/MessageComposer'
-import {MessageInput} from '#/screens/Messages/components/MessageInput'
 import {MessageListError} from '#/screens/Messages/components/MessageListError'
-import {atoms as a, platform, tokens, useTheme, web} from '#/alf'
-import {ChatEmptyPill} from '#/components/dms/ChatEmptyPill'
+import {platform, tokens, useTheme, web} from '#/alf'
 import {DateDivider} from '#/components/dms/DateDivider'
 import {MessageItem} from '#/components/dms/MessageItem'
 import {NewMessagesPill} from '#/components/dms/NewMessagesPill'
 import {SystemMessageGroup} from '#/components/dms/SystemMessageGroup'
 import {SystemMessageItem} from '#/components/dms/SystemMessageItem'
+import {
+  INITIAL_NUMBER_TO_RENDER,
+  MAX_TO_RENDER_PER_BATCH,
+} from '#/components/dms/util'
 import {Loader} from '#/components/Loader'
 import {Text} from '#/components/Typography'
-import {useAnalytics} from '#/analytics'
-import {IS_ANDROID, IS_NATIVE, IS_WEB} from '#/env'
-import {ChatStatusInfo} from './ChatStatusInfo'
+import {IS_ANDROID, IS_WEB} from '#/env'
 import {groupSystemMessages, type RenderItem} from './groupSystemMessages'
-import {InviteLinkDialogProvider} from './InviteLinkDialogProvider'
-import {MessageInputEmbed, useMessageEmbed} from './MessageInputEmbed'
 import {MessagesListInfoPanel} from './MessagesListInfoPanel'
-import {KeyboardStickyView} from './vendor/KeyboardStickyView'
+
+/**
+ * The static portion of the bottom reservation. Lives inside the scroll
+ * view's content via `contentContainerStyle.paddingBottom`.
+ */
+const LIST_CONTENT_PADDING_BOTTOM = platform({
+  ios: tokens.space.lg,
+  android: tokens.space.md,
+  default: 0, // web uses ListFooterComponent height for the static slot too
+})
+
+/**
+ * The non-input portion of the dynamic bottom padding, i.e., everything
+ * `getChatBottomDynamicPadding` adds on top of `inputHeight`. Split out as a
+ * plain JS function so the native path can resolve it on the JS thread (via
+ * `platform()`, which is not worklet-safe) and then close over the result
+ * when entering `useDerivedValue`.
+ */
+function getChatBottomDynamicOffset(bottomInset: number): number {
+  return platform({
+    ios: bottomInset - tokens.space.lg,
+    android: bottomInset,
+    web: tokens.space.md,
+    default: 0,
+  })
+}
+
+/**
+ * The dynamic, composer-height-dependent portion of the bottom reservation.
+ *
+ * On native this value is fed back into the scroll view. On web it's the height
+ * of `ListFooterComponent`. Both paths sit above `LIST_CONTENT_PADDING_BOTTOM`
+ * to make up the total reservation.
+ */
+function getChatBottomDynamicPadding({
+  inputHeight,
+  bottomInset,
+}: {
+  inputHeight: number
+  bottomInset: number
+}): number {
+  return inputHeight + getChatBottomDynamicOffset(bottomInset)
+}
+
+/**
+ * The chat skeleton needs to match this vertical space so the skeleton-to-list
+ * handoff doesn't visibly jump.
+ *
+ * Single source of truth: Every internal call site is derived from
+ * `LIST_CONTENT_PADDING_BOTTOM` plus `getChatBottomDynamicPadding`, so they
+ * can't drift out of sync.
+ */
+export function getChatBottomReservation(args: {
+  inputHeight: number
+  bottomInset: number
+}): number {
+  return LIST_CONTENT_PADDING_BOTTOM + getChatBottomDynamicPadding(args)
+}
 
 function MaybeLoader({isLoading}: {isLoading: boolean}) {
   return (
@@ -114,24 +139,20 @@ function onScrollToIndexFailed() {
 export function MessagesList({
   hasScrolled,
   setHasScrolled,
-  footer,
-  hasAcceptOverride,
   transparentHeaderHeight,
+  inputHeightUI,
+  inputHeightJS,
 }: {
   hasScrolled: boolean
   setHasScrolled: React.Dispatch<React.SetStateAction<boolean>>
-  footer?: React.ReactNode
-  hasAcceptOverride?: boolean
   transparentHeaderHeight?: number
+  inputHeightUI: SharedValue<number>
+  inputHeightJS: number
 }) {
-  const ax = useAnalytics()
   const convoState = useConvoActive()
-  const agent = useAgent()
-  const getPost = useGetPost()
-  const {embedUri, setEmbed} = useMessageEmbed()
   const t = useTheme()
+  const {bottom: bottomInset} = useSafeAreaInsets()
 
-  const textInputId = 'chat-input-' + useId()
   const flatListRef = useAnimatedRef<ListMethods>()
 
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
@@ -155,18 +176,6 @@ export function MessagesList({
     show: false,
     startContentOffset: 0,
   })
-
-  const inputHeightUI = useSharedValue(0)
-  const [inputHeightJS, setInputHeightJS] = useState(0)
-
-  const onInputLayout = useCallback(
-    (event: LayoutChangeEvent) => {
-      const inputHeight = event.nativeEvent.layout.height
-      inputHeightUI.set(inputHeight)
-      setInputHeightJS(inputHeight)
-    },
-    [inputHeightUI],
-  )
 
   // We need to keep track of when the scroll offset is at the bottom of the list to know when to scroll as new items
   // are added to the list. For example, if the user is scrolled up to 1iew older messages, we don't want to scroll to
@@ -279,7 +288,6 @@ export function MessagesList({
       setHasScrolled,
       convoState.isFetchingHistory,
       renderItems.length,
-      // these are stable
       flatListRef,
       isAtTop,
       isAtBottom,
@@ -314,90 +322,6 @@ export function MessagesList({
       }
     },
     [layoutHeight, newMessagesPill, isAtBottom, isAtTop],
-  )
-
-  // -- Keyboard animation handling
-
-  const {bottom: bottomInset} = useSafeAreaInsets()
-
-  // -- Message sending
-  const onSendMessage = useCallback(
-    async (text: string) => {
-      let rt = new RichText({text: text.trimEnd()}, {cleanNewlines: true})
-
-      // detect facets without resolution first - this is used to see if there's
-      // any post links in the text that we can embed. We do this first because
-      // we want to remove the post link from the text, re-trim, then detect facets
-      rt.detectFacetsWithoutResolution()
-
-      let embed: $Typed<AppBskyEmbedRecord.Main> | undefined
-
-      if (embedUri) {
-        try {
-          const post = await getPost({uri: embedUri})
-          if (post) {
-            embed = {
-              $type: 'app.bsky.embed.record',
-              record: {
-                uri: post.uri,
-                cid: post.cid,
-              },
-            }
-
-            // look for the embed uri in the facets, so we can remove it from the text
-            const postLinkFacet = rt.facets?.find(facet => {
-              return facet.features.find(feature => {
-                if (AppBskyRichtextFacet.isLink(feature)) {
-                  if (isBskyPostUrl(feature.uri)) {
-                    const url = convertBskyAppUrlIfNeeded(feature.uri)
-                    const [_0, _1, _2, rkey] = url.split('/').filter(Boolean)
-
-                    // this might have a handle instead of a DID
-                    // so just compare the rkey - not particularly dangerous
-                    return post.uri.endsWith(rkey)
-                  }
-                }
-                return false
-              })
-            })
-
-            if (postLinkFacet) {
-              const isAtStart = postLinkFacet.index.byteStart === 0
-              const isAtEnd =
-                postLinkFacet.index.byteEnd === rt.unicodeText.graphemeLength
-
-              // remove the post link from the text
-              if (isAtStart || isAtEnd) {
-                rt.delete(
-                  postLinkFacet.index.byteStart,
-                  postLinkFacet.index.byteEnd,
-                )
-              }
-
-              rt = new RichText({text: rt.text.trim()}, {cleanNewlines: true})
-            }
-          }
-        } catch (error) {
-          logger.error('Failed to get post as quote for DM', {error})
-        }
-      }
-
-      await rt.detectFacets(agent)
-
-      rt = shortenLinks(rt)
-      rt = stripInvalidMentions(rt)
-
-      if (!hasScrolled) {
-        setHasScrolled(true)
-      }
-
-      convoState.sendMessage({
-        text: rt.text,
-        facets: rt.facets,
-        embed,
-      })
-    },
-    [agent, convoState, embedUri, getPost, hasScrolled, setHasScrolled],
   )
 
   const scrollToEndOnPress = useCallback(() => {
@@ -461,117 +385,75 @@ export function MessagesList({
 
   const renderScrollComponent = useCallback(
     (props: ScrollViewProps) => (
-      <ChatScrollComponent {...props} inputHeight={inputHeightUI} />
+      <ChatScrollComponent
+        {...props}
+        inputHeight={inputHeightUI}
+        attachScrollEdgeEffect={hasScrolled}
+      />
     ),
-    [inputHeightUI],
+    [inputHeightUI, hasScrolled],
   )
 
   return (
-    <InviteLinkDialogProvider convo={convoState.convo}>
-      <KeyboardGestureArea
-        interpolator="ios"
-        // HACKFIX: https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1419
-        offset={Math.round(inputHeightJS)}
-        // slightly too buggy unfortunately, enable when possible
-        // textInputNativeID={textInputId}
-        style={[a.flex_1]}>
-        {/* Custom scroll provider so that we can use the `onScroll` event in our custom List implementation */}
-        <ScrollProvider onScroll={onScroll}>
-          <List
-            ref={flatListRef}
-            data={renderItems}
-            renderItem={renderItem}
-            keyExtractor={keyExtractor}
-            disableFullWindowScroll={true}
-            disableVirtualization={true}
-            // The extra two items account for the header and the footer components
-            initialNumToRender={IS_NATIVE ? 32 : 62}
-            maxToRenderPerBatch={IS_WEB ? 32 : 62}
-            keyboardDismissMode="interactive"
-            keyboardShouldPersistTaps="handled"
-            maintainVisibleContentPosition={{minIndexForVisible: 0}}
-            removeClippedSubviews={false}
-            sideBorders={false}
-            onContentSizeChange={onContentSizeChange}
-            onStartReached={onStartReached}
-            onScrollToIndexFailed={onScrollToIndexFailed}
-            showsVerticalScrollIndicator={!IS_ANDROID}
-            scrollEventThrottle={100}
-            ListHeaderComponent={
-              <>
-                <MaybeLoader isLoading={convoState.isFetchingHistory} />
-                {convoState.convo?.kind === 'group' &&
-                convoState.hasAllHistory ? (
-                  <MessagesListInfoPanel convo={convoState.convo} />
-                ) : null}
-              </>
-            }
-            // native only (prop is not supported on web)
-            renderScrollComponent={renderScrollComponent}
-            contentContainerStyle={{
-              paddingBottom: platform({
-                // ios is slightly larger as the input has no top padding
-                ios: tokens.space.lg,
-                android: tokens.space.md,
-                web: 0, // web uses ListFooterComponent instead for scroll reasons
-              }),
-            }}
-            ListFooterComponent={
-              <View
-                style={web({height: tokens.space.md + inputHeightJS})}
-                onLayout={onFooterLayout}
-              />
-            }
-            style={web({
-              scrollbarWidth: 'thin',
-              scrollbarColor: `${t.palette.contrast_100} transparent`,
-              scrollbarGutter: 'stable both-edges',
-            })}
-            contentInset={{top: transparentHeaderHeight}}
-            scrollIndicatorInsets={{top: transparentHeaderHeight}}
-          />
-        </ScrollProvider>
-        <KeyboardStickyView
-          style={[a.absolute, a.bottom_0, a.left_0, a.right_0]}
-          onLayout={onInputLayout}
-          minimumOffset={bottomInset}
-          offset={{
-            closed: platform({
-              ios: tokens.space.lg, // hide bottom padding when closed
-              default: 0,
-            }),
-            opened: 0,
-          }}>
-          {footer ?? (
-            <ConversationFooter
-              convoState={convoState}
-              hasAcceptOverride={hasAcceptOverride}>
-              {ax.features.enabled(ax.features.DmsNewMessageComposerEnable) ? (
-                <MessageComposer
-                  textInputId={textInputId}
-                  onSendMessage={(message: string) =>
-                    void onSendMessage(message)
-                  }
-                  hasEmbed={!!embedUri}
-                  setEmbed={setEmbed}>
-                  <MessageInputEmbed embedUri={embedUri} setEmbed={setEmbed} />
-                </MessageComposer>
-              ) : (
-                <MessageInput
-                  textInputId={textInputId}
-                  onSendMessage={onSendMessage}
-                  hasEmbed={!!embedUri}
-                  setEmbed={setEmbed}>
-                  <MessageInputEmbed embedUri={embedUri} setEmbed={setEmbed} />
-                </MessageInput>
-              )}
-            </ConversationFooter>
-          )}
-        </KeyboardStickyView>
-      </KeyboardGestureArea>
-
+    <>
+      {/* Custom scroll provider so that we can use the `onScroll` event in our custom List implementation */}
+      <ScrollProvider onScroll={onScroll}>
+        <List
+          ref={flatListRef}
+          data={renderItems}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          disableFullWindowScroll={true}
+          disableVirtualization={true}
+          // The extra two items account for the header and the footer components
+          initialNumToRender={INITIAL_NUMBER_TO_RENDER}
+          maxToRenderPerBatch={MAX_TO_RENDER_PER_BATCH}
+          keyboardDismissMode="interactive"
+          keyboardShouldPersistTaps="handled"
+          maintainVisibleContentPosition={{minIndexForVisible: 0}}
+          removeClippedSubviews={false}
+          sideBorders={false}
+          onContentSizeChange={onContentSizeChange}
+          onStartReached={onStartReached}
+          onScrollToIndexFailed={onScrollToIndexFailed}
+          showsVerticalScrollIndicator={!IS_ANDROID}
+          scrollEventThrottle={100}
+          ListHeaderComponent={
+            <>
+              <MaybeLoader isLoading={convoState.isFetchingHistory} />
+              {convoState.convo?.kind === 'group' &&
+              convoState.hasAllHistory ? (
+                <MessagesListInfoPanel convo={convoState.convo} />
+              ) : null}
+            </>
+          }
+          // native only (prop is not supported on web)
+          renderScrollComponent={renderScrollComponent}
+          contentContainerStyle={{
+            paddingBottom: LIST_CONTENT_PADDING_BOTTOM,
+          }}
+          ListFooterComponent={
+            <View
+              style={web({
+                height: getChatBottomDynamicPadding({
+                  inputHeight: inputHeightJS,
+                  bottomInset,
+                }),
+              })}
+              onLayout={onFooterLayout}
+            />
+          }
+          style={web({
+            scrollbarWidth: 'thin',
+            scrollbarColor: `${t.palette.contrast_100} transparent`,
+            scrollbarGutter: 'stable both-edges',
+          })}
+          contentInset={{top: transparentHeaderHeight}}
+          scrollIndicatorInsets={{top: transparentHeaderHeight}}
+        />
+      </ScrollProvider>
       {newMessagesPill.show && <NewMessagesPill onPress={scrollToEndOnPress} />}
-    </InviteLinkDialogProvider>
+    </>
   )
 }
 
@@ -579,92 +461,58 @@ export function MessagesList({
 function ChatScrollComponent({
   ref,
   inputHeight,
+  attachScrollEdgeEffect,
   ...props
 }: ScrollViewProps & {
-  ref?: React.RefObject<KeyboardChatScrollViewProps>
+  ref?: React.RefObject<React.ComponentRef<
+    typeof KeyboardChatScrollView
+  > | null>
   inputHeight: SharedValue<number>
+  /**
+   * Whether to register this scroll view as the source for the header's top
+   * edge-effect blur (Liquid Glass). Held off until after the initial
+   * scroll-to-end so the `ChatSkeleton` - which is visually on top and has
+   * already registered its own scroll view - stays the active source while
+   * it's still on screen. Without this gate, MessagesList would override the
+   * skeleton's registration on mount and the header would try to blur an
+   * empty, off-screen scroll view.
+   */
+  attachScrollEdgeEffect: boolean
 }) {
   const scrollEdgeRef = useScrollEdgeEffectRef()
   const {bottom: bottomInset} = useSafeAreaInsets()
+  const nodeRef =
+    useRef<React.ComponentRef<typeof KeyboardChatScrollView>>(null)
 
-  const offset = platform({
-    ios: bottomInset - tokens.space.lg,
-    android: bottomInset,
-    default: 0,
-  })
-
-  const inputOffset = platform({
-    ios: bottomInset - tokens.space.lg,
-    android: bottomInset,
-    default: 0,
-  })
+  // Resolved on the JS thread; the worklet below just adds inputHeight.
+  const inputOffset = getChatBottomDynamicOffset(bottomInset)
 
   const extraContentPadding = useDerivedValue(
     () => inputHeight.get() + inputOffset,
   )
 
+  useLayoutEffect(() => {
+    if (!attachScrollEdgeEffect || !scrollEdgeRef) return
+    if (nodeRef.current) {
+      scrollEdgeRef(nodeRef.current)
+    }
+    return () => {
+      scrollEdgeRef(null)
+    }
+  }, [attachScrollEdgeEffect, scrollEdgeRef])
+
   return (
     <KeyboardChatScrollView
-      ref={mergeRefs([scrollEdgeRef, ref])}
+      ref={mergeRefs([nodeRef, ref])}
       automaticallyAdjustContentInsets={false}
       keyboardDismissMode="interactive"
       keyboardLiftBehavior="always"
       extraContentPadding={extraContentPadding}
-      offset={offset}
+      // Same value as `extraContentPadding` minus `inputHeight`: this is the
+      // vertical gap the keyboard controller needs to account for between the
+      // scroll content's bottom and where the input actually sits.
+      offset={inputOffset}
       {...props}
     />
   )
-}
-
-type FooterState = 'loading' | 'new-chat' | 'request' | 'standard'
-
-function getFooterState(
-  convoState: ActiveConvoStates,
-  hasAcceptOverride?: boolean,
-): FooterState {
-  if (convoState.items.length === 0) {
-    if (convoState.isFetchingHistory) {
-      return 'loading'
-    } else {
-      return 'new-chat'
-    }
-  }
-
-  if (convoState.convo.view.status === 'request' && !hasAcceptOverride) {
-    return 'request'
-  }
-
-  return 'standard'
-}
-
-function ConversationFooter({
-  convoState,
-  hasAcceptOverride,
-  children,
-}: {
-  convoState: ConvoState
-  hasAcceptOverride?: boolean
-  children?: React.ReactNode // message input
-}) {
-  if (!isConvoActive(convoState)) {
-    return null
-  }
-
-  const footerState = getFooterState(convoState, hasAcceptOverride)
-
-  switch (footerState) {
-    case 'loading':
-      return null
-    case 'new-chat':
-      return (
-        <>
-          <ChatEmptyPill />
-          {children}
-        </>
-      )
-    case 'request':
-      return <ChatStatusInfo convoState={convoState} />
-    case 'standard':
-      return children
-  }
 }

--- a/src/screens/Messages/hooks/useBlockForEmailVerification.tsx
+++ b/src/screens/Messages/hooks/useBlockForEmailVerification.tsx
@@ -1,0 +1,58 @@
+import {useEffect} from 'react'
+import {Trans} from '@lingui/react/macro'
+import {useNavigation} from '@react-navigation/native'
+
+import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
+import {type NavigationProp} from '#/lib/routes/types'
+import {useEmail} from '#/state/email-verification'
+import {
+  EmailDialogScreenID,
+  useEmailDialogControl,
+} from '#/components/dialogs/EmailDialog'
+
+/**
+ * On mount, opens the email-verification dialog if the user hasn't verified
+ * their email yet. Closing without verifying pops back out of the conversation.
+ */
+export function useBlockForEmailVerification() {
+  const navigation = useNavigation<NavigationProp>()
+  const {needsEmailVerification} = useEmail()
+  const emailDialogControl = useEmailDialogControl()
+
+  /**
+   * Must be non-reactive, otherwise the update to open the global dialog will
+   * cause a re-render loop.
+   */
+  const maybeBlockForEmailVerification = useNonReactiveCallback(() => {
+    if (!needsEmailVerification) return
+    /*
+     * HACKFIX
+     *
+     * Load bearing timeout, to bump this state update until the after the
+     * `navigator.addListener('state')` handler closes elements from
+     * `shell/index.*.tsx`  - sfn & esb
+     */
+    setTimeout(() =>
+      emailDialogControl.open({
+        id: EmailDialogScreenID.Verify,
+        instructions: [
+          <Trans key="pre-compose">
+            Before you can message another user, you must first verify your
+            email.
+          </Trans>,
+        ],
+        onCloseWithoutVerifying: () => {
+          if (navigation.canGoBack()) {
+            navigation.goBack()
+          } else {
+            navigation.navigate('Messages', {animation: 'pop'})
+          }
+        },
+      }),
+    )
+  })
+
+  useEffect(() => {
+    maybeBlockForEmailVerification()
+  }, [maybeBlockForEmailVerification])
+}

--- a/src/screens/Messages/hooks/useChatFooterOverride.tsx
+++ b/src/screens/Messages/hooks/useChatFooterOverride.tsx
@@ -1,0 +1,55 @@
+import {useMemo} from 'react'
+import {moderateProfile} from '@atproto/api'
+
+import {useMaybeProfileShadow} from '#/state/cache/profile-shadow'
+import {useModerationOpts} from '#/state/preferences/moderation-opts'
+import {ChatDisabled} from '#/screens/Messages/components/ChatDisabled'
+import {ChatEnded} from '#/screens/Messages/components/ChatEnded'
+import {ChatLocked} from '#/screens/Messages/components/ChatLocked'
+import {MessagesListBlockedFooter} from '#/components/dms/MessagesListBlockedFooter'
+import {type ConvoWithDetails} from '#/components/dms/util'
+
+/**
+ * Returns a footer node to render in place of the composer when the chat
+ * can't accept new messages (disabled, blocked, locked, ended) — or `null` to
+ * let the composer render normally.
+ */
+export function useChatFooterOverride({
+  convo,
+  isDisabled,
+  hasMessages,
+}: {
+  convo: ConvoWithDetails | null
+  isDisabled: boolean
+  hasMessages: boolean
+}): React.ReactNode {
+  const primaryMember = useMaybeProfileShadow(convo?.primaryMember)
+  const moderationOpts = useModerationOpts()
+  const primaryMemberModeration = useMemo(() => {
+    if (!primaryMember || !moderationOpts) return null
+    return moderateProfile(primaryMember, moderationOpts)
+  }, [primaryMember, moderationOpts])
+
+  if (isDisabled) {
+    return <ChatDisabled />
+  }
+  if (convo && primaryMember && primaryMemberModeration?.blocked) {
+    return (
+      <MessagesListBlockedFooter
+        recipient={primaryMember}
+        convoId={convo.view.id}
+        hasMessages={hasMessages}
+        moderation={primaryMemberModeration}
+      />
+    )
+  }
+  if (convo?.kind === 'group') {
+    if (convo.details.lockStatus === 'locked') {
+      return <ChatLocked convo={convo} />
+    }
+    if (convo.details.lockStatus === 'locked-permanently') {
+      return <ChatEnded convo={convo} />
+    }
+  }
+  return null
+}

--- a/src/screens/Messages/hooks/useInputHeight.ts
+++ b/src/screens/Messages/hooks/useInputHeight.ts
@@ -1,0 +1,24 @@
+import {useCallback, useState} from 'react'
+import {type LayoutChangeEvent} from 'react-native'
+import {useSharedValue} from 'react-native-reanimated'
+
+/**
+ * Tracks the composer's measured height in two parallel forms.
+ *
+ * The Reanimated shared value and the React state value exist as separate
+ * fields rather than one source of truth because crossing the JS/UI thread
+ * boundary on every render is what reanimated explicitly avoids.
+ */
+export function useInputHeight() {
+  const inputHeightUI = useSharedValue(0)
+  const [inputHeightJS, setInputHeightJS] = useState(0)
+  const onInputLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const {height} = event.nativeEvent.layout
+      inputHeightUI.set(height)
+      setInputHeightJS(height)
+    },
+    [inputHeightUI],
+  )
+  return {inputHeightUI, inputHeightJS, onInputLayout}
+}

--- a/src/screens/Messages/hooks/useSendChatMessage.ts
+++ b/src/screens/Messages/hooks/useSendChatMessage.ts
@@ -1,0 +1,123 @@
+import {useCallback} from 'react'
+import {
+  type $Typed,
+  type AppBskyEmbedRecord,
+  AppBskyRichtextFacet,
+  RichText,
+} from '@atproto/api'
+
+import {shortenLinks, stripInvalidMentions} from '#/lib/strings/rich-text-manip'
+import {
+  convertBskyAppUrlIfNeeded,
+  isBskyPostUrl,
+} from '#/lib/strings/url-helpers'
+import {logger} from '#/logger'
+import {isConvoActive} from '#/state/messages/convo'
+import {type ConvoState} from '#/state/messages/convo/types'
+import {useGetPost} from '#/state/queries/post'
+import {useAgent} from '#/state/session'
+
+/**
+ * Returns a `sendMessage(text)` callback that performs the DM send pipeline:
+ * facet detection, optional quote-post embed extraction, link/mention cleanup,
+ * and finally `convoState.sendMessage`.
+ *
+ * The composer is disabled at the UI level when the convo isn't active, so
+ * the early `isConvoActive` return below is just a type guard for narrowing
+ * `convoState.sendMessage` from `undefined` to a callable.
+ */
+export function useSendChatMessage({
+  convoState,
+  embedUri,
+  hasScrolled,
+  setHasScrolled,
+}: {
+  convoState: ConvoState
+  embedUri: string | undefined
+  hasScrolled: boolean
+  setHasScrolled: React.Dispatch<React.SetStateAction<boolean>>
+}) {
+  const agent = useAgent()
+  const getPost = useGetPost()
+
+  return useCallback(
+    async (text: string) => {
+      if (!isConvoActive(convoState)) return
+
+      let rt = new RichText({text: text.trimEnd()}, {cleanNewlines: true})
+
+      // detect facets without resolution first - this is used to see if there's
+      // any post links in the text that we can embed. We do this first because
+      // we want to remove the post link from the text, re-trim, then detect facets
+      rt.detectFacetsWithoutResolution()
+
+      let embed: $Typed<AppBskyEmbedRecord.Main> | undefined
+
+      if (embedUri) {
+        try {
+          const post = await getPost({uri: embedUri})
+          if (post) {
+            embed = {
+              $type: 'app.bsky.embed.record',
+              record: {
+                uri: post.uri,
+                cid: post.cid,
+              },
+            }
+
+            // look for the embed uri in the facets, so we can remove it from the text
+            const postLinkFacet = rt.facets?.find(facet => {
+              return facet.features.find(feature => {
+                if (AppBskyRichtextFacet.isLink(feature)) {
+                  if (isBskyPostUrl(feature.uri)) {
+                    const url = convertBskyAppUrlIfNeeded(feature.uri)
+                    const [_0, _1, _2, rkey] = url.split('/').filter(Boolean)
+
+                    // this might have a handle instead of a DID
+                    // so just compare the rkey - not particularly dangerous
+                    return post.uri.endsWith(rkey)
+                  }
+                }
+                return false
+              })
+            })
+
+            if (postLinkFacet) {
+              const isAtStart = postLinkFacet.index.byteStart === 0
+              const isAtEnd =
+                postLinkFacet.index.byteEnd === rt.unicodeText.graphemeLength
+
+              // remove the post link from the text
+              if (isAtStart || isAtEnd) {
+                rt.delete(
+                  postLinkFacet.index.byteStart,
+                  postLinkFacet.index.byteEnd,
+                )
+              }
+
+              rt = new RichText({text: rt.text.trim()}, {cleanNewlines: true})
+            }
+          }
+        } catch (error) {
+          logger.error('Failed to get post as quote for DM', {error})
+        }
+      }
+
+      await rt.detectFacets(agent)
+
+      rt = shortenLinks(rt)
+      rt = stripInvalidMentions(rt)
+
+      if (!hasScrolled) {
+        setHasScrolled(true)
+      }
+
+      convoState.sendMessage({
+        text: rt.text,
+        facets: rt.facets,
+        embed,
+      })
+    },
+    [agent, convoState, embedUri, getPost, hasScrolled, setHasScrolled],
+  )
+}


### PR DESCRIPTION
Adds a chat skeleton that appears immediately and fades into the conversation once the latter is ready.

To facilitate this, I moved the composer/chat footer to avoid duplicating it or creating a separate placeholder (both of which could get out of sync). Once I pulled that thread, I moved a few more things out as well. Most of this was to reduce the scope of `ChatBody`; now its sole function is to render the layout.

Note that there’s some logic specific to Liquid Glass, both for positioning the last message in the skeleton and for ensuring the top blur is applied there as well.

**Android**

https://github.com/user-attachments/assets/2aea4e67-7ed0-4a18-ba12-26224d0e17ce

**iOS**

https://github.com/user-attachments/assets/028d4edc-9549-4334-a014-16b1bfcc2aee

**Web**

https://github.com/user-attachments/assets/41e9ebdf-f7be-447e-8ea2-0a6645eb33a6