### PR TITLE
ci: build link image on push to main

### DIFF
--- a/.github/workflows/build-and-push-link-aws.yaml
+++ b/.github/workflows/build-and-push-link-aws.yaml
@@ -1,11 +1,9 @@
 name: build-and-push-link-aws
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - "bskylink/**"
-      - "Dockerfile.bskylink"
-      - ".github/workflows/build-and-push-link-aws.yaml"
+  push:
+    branches:
+      - main
 
 env:
   REGISTRY: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_REGISTRY }}


### PR DESCRIPTION
## Summary

Same fix as #10469 (bskyogcard), for bskylink. The workflow only triggered on `pull_request`, so merges to main never produced a fresh ECR image. Matches `build-and-push-bskyweb-aws.yaml`: push on main + workflow_dispatch.

## Test plan

- [ ] Next merge to main triggers the workflow and pushes a `bskylink:<main-sha>` image

🤖 Generated with [Claude Code](https://claude.com/claude-code)