### PR TITLE
Stop writing associatedRecord to embeds, may need to adjust schema

### DIFF
--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -422,7 +422,6 @@ async function resolveMedia(
           title: resolvedLink.title,
           description: resolvedLink.description,
           thumb: blob,
-          associatedRecord: resolvedLink.associatedRecord,
         },
       }
     }


### PR DESCRIPTION
I merged this prematurely. No sense is putting out records with data that we may not want in the future. The overall codepaths are correct though, so will leave them be for the moment.