### PR TITLE
Enable ESLint errors and suppress existing violations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        job: [lint, prettier]
+        job: [lint, prettier, typecheck]
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
@@ -62,6 +62,8 @@ jobs:
           command: pnpm install --frozen-lockfile
           attempt_limit: 3
           attempt_delay: 2000
+      - name: Check & compile i18n
+        run: pnpm intl:build
       - name: Lint checks
         run: pnpm ${{ matrix.job }}
   # Aggregates the matrix results into a single stable check name so branch
@@ -80,28 +82,6 @@ jobs:
         run: |
           echo "linting result: $RESULT"
           test "$RESULT" = "success"
-  typechecking:
-    name: Run typecheck
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v6
-      - name: Install node
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: package.json
-          cache: pnpm
-      - name: pnpm install
-        uses: Wandalen/wretry.action@master
-        with:
-          command: pnpm install --frozen-lockfile
-          attempt_limit: 3
-          attempt_delay: 2000
-      - name: Check & compile i18n
-        run: pnpm intl:build
-      - name: Type check
-        run: pnpm typecheck
   testing:
     name: Run tests
     runs-on: ubuntu-latest

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,12 +1,72 @@
 {
+  "src/Navigation.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/Splash.android.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/Splash.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/ageAssurance/components/RedirectOverlay.tsx": {
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/ageAssurance/util.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
   "src/alf/util/flatten.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 9
+    }
+  },
+  "src/alf/util/systemUI.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    }
+  },
+  "src/alf/util/useGutters.ts": {
+    "react-hooks/immutability": {
+      "count": 5
     }
   },
   "src/analytics/PassiveAnalytics.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "react-hooks/purity": {
+      "count": 1
+    }
+  },
+  "src/analytics/features/index.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/analytics/identifiers/session.test.ts": {
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 9
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 9
     }
   },
   "src/analytics/metadata.ts": {
@@ -17,16 +77,84 @@
   "src/analytics/metrics/client.test.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 8
+    },
+    "@typescript-eslint/require-await": {
+      "count": 5
     }
   },
   "src/analytics/metrics/client.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 5
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/analytics/utils.ts": {
+    "react-hooks/immutability": {
+      "count": 1
+    }
+  },
+  "src/components/AppLanguageDropdown.tsx": {
+    "@typescript-eslint/no-unsafe-enum-comparison": {
+      "count": 1
+    }
+  },
+  "src/components/Autocomplete/Autocomplete.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/Autocomplete/useAutocomplete/index.ts": {
+    "react-hooks/immutability": {
+      "count": 1
+    }
+  },
+  "src/components/BotAccountAlert.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/Button.tsx": {
+    "react-hooks/immutability": {
+      "count": 1
     }
   },
   "src/components/Composer/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-redundant-type-constituents": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 7
+    },
+    "react-hooks/immutability": {
+      "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "src/components/DebugFieldDisplay.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
     }
   },
   "src/components/Dialog/index.tsx": {
@@ -37,10 +165,27 @@
   "src/components/Dialog/index.web.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 4
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 3
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
     }
   },
   "src/components/DraggableList/index.web.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 2
+    }
+  },
+  "src/components/EmojiPicker/preload.web.ts": {
+    "@typescript-eslint/no-floating-promises": {
       "count": 2
     }
   },
@@ -52,15 +197,52 @@
   "src/components/FocusScope/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 1
     }
   },
   "src/components/InternationalPhoneCodeSelect.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/components/KnownFollowers.tsx": {
+    "react-hooks/refs": {
+      "count": 6
+    }
+  },
+  "src/components/Lightbox/Lightbox.web.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/components/Lightbox/pager/ImageItem/ImageItem.android.tsx": {
+    "react-hooks/immutability": {
+      "count": 1
+    }
+  },
+  "src/components/Lightbox/pager/ImageItem/ImageItem.ios.tsx": {
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "src/components/LikedByList.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
     }
   },
   "src/components/Lists.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
       "count": 1
     }
   },
@@ -74,34 +256,129 @@
       "count": 1
     }
   },
+  "src/components/Post/Embed/ExternalEmbed/ExternalGif.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    }
+  },
+  "src/components/Post/Embed/ExternalEmbed/index.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
   "src/components/Post/Embed/ImageEmbed.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/Post/Embed/StandardSiteEmbed/index.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    }
+  },
+  "src/components/Post/Embed/VideoEmbed/VideoEmbedInner/VideoEmbedInnerWeb.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-enum-comparison": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    },
+    "react-hooks/immutability": {
+      "count": 1
     }
   },
   "src/components/Post/Embed/VideoEmbed/VideoEmbedInner/web-controls/utils.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 3
     }
   },
   "src/components/PostControls/BookmarkButton.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    }
+  },
+  "src/components/PostControls/DiscoverDebug.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/PostControls/ShareMenu/ShareMenuItems.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/components/PostControls/ShareMenu/ShareMenuItems.web.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    }
+  },
+  "src/components/PostControls/ShareMenu/index.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
     }
   },
   "src/components/ProfileHoverCard/index.web.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    },
+    "react-hooks/immutability": {
+      "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 2
+    }
+  },
+  "src/components/ProgressGuide/FollowDialog.tsx": {
+    "react-hooks/refs": {
+      "count": 2
+    }
+  },
+  "src/components/RichTextTag.tsx": {
+    "@typescript-eslint/no-floating-promises": {
       "count": 2
     }
   },
   "src/components/Select/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 4
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
     }
   },
   "src/components/Select/index.web.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
     }
   },
   "src/components/Select/types.ts": {
@@ -109,8 +386,43 @@
       "count": 3
     }
   },
+  "src/components/SendErrorReportDialog.tsx": {
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/components/StarterPack/Main/ProfilesList.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
   "src/components/StarterPack/ProfileStarterPacks.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    }
+  },
+  "src/components/StarterPack/QrCodeDialog.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 5
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/require-await": {
+      "count": 4
+    }
+  },
+  "src/components/StarterPack/ShareDialog.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/require-await": {
       "count": 1
     }
   },
@@ -119,9 +431,109 @@
       "count": 1
     }
   },
+  "src/components/Tooltip/index.tsx": {
+    "@typescript-eslint/no-base-to-string": {
+      "count": 1
+    }
+  },
+  "src/components/Tooltip/index.web.tsx": {
+    "@typescript-eslint/no-base-to-string": {
+      "count": 1
+    }
+  },
+  "src/components/WhoCanReply.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "src/components/ageAssurance/AgeAssuranceErrors.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/components/ageAssurance/AgeAssuranceInitDialog.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "react-hooks/purity": {
+      "count": 1
+    }
+  },
+  "src/components/ageAssurance/AgeAssuranceRedirectDialog.tsx": {
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/components/contacts/components/OTPInput.tsx": {
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "src/components/contacts/screens/GetContacts.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/contacts/screens/VerifyNumber.tsx": {
+    "@typescript-eslint/require-await": {
+      "count": 1
+    },
+    "react-hooks/purity": {
+      "count": 1
+    }
+  },
+  "src/components/contacts/screens/ViewMatches.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
   "src/components/dialogs/DeviceLocationRequestDialog.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "src/components/dialogs/EmailDialog/components/ResendEmailText.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/dialogs/EmailDialog/data/useAccountEmailState.ts": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/components/dialogs/EmailDialog/screens/Manage2FA/Disable.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    }
+  },
+  "src/components/dialogs/EmailDialog/screens/Manage2FA/Enable.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/components/dialogs/EmailDialog/screens/Update.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    }
+  },
+  "src/components/dialogs/EmailDialog/screens/Verify.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    }
+  },
+  "src/components/dialogs/InAppBrowserConsent.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
     }
   },
   "src/components/dialogs/LanguageSelectDialog.tsx": {
@@ -129,8 +541,25 @@
       "count": 1
     }
   },
+  "src/components/dialogs/LinkWarning.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    }
+  },
   "src/components/dialogs/MutedWords.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    },
+    "@typescript-eslint/require-await": {
       "count": 1
     }
   },
@@ -138,22 +567,91 @@
     "@typescript-eslint/no-explicit-any": {
       "count": 2
     },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    },
     "react-hooks/preserve-manual-memoization": {
       "count": 1
+    }
+  },
+  "src/components/dialogs/ServerInput.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/dialogs/StarterPackDialog.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/components/dialogs/SwitchAccount.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/dialogs/lists/CreateListFromStarterPackDialog.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
     }
   },
   "src/components/dialogs/lists/CreateOrEditListDialog.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/components/dialogs/nuxs/FindContactsAnnouncement.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/dialogs/nuxs/index.tsx": {
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    },
+    "react-hooks/immutability": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/components/dms/MessageItem.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
     }
   },
   "src/components/forms/DateField/index.web.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "src/components/forms/SearchInput.tsx": {
+    "react-hooks/refs": {
+      "count": 1
     }
   },
   "src/components/forms/SegmentedControl.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    }
+  },
+  "src/components/forms/TextField.tsx": {
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 3
+    },
+    "react-hooks/refs": {
       "count": 1
     }
   },
@@ -165,6 +663,37 @@
   "src/components/hooks/useFollowMethods.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "src/components/hooks/useFullscreen.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/components/hooks/useLandingEntry.native.ts": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/components/hooks/useLandingEntry.ts": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/components/hooks/useRefreshOnFocus.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/hooks/useRichText.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
     }
   },
   "src/components/images/AutoSizedImage.tsx": {
@@ -175,6 +704,15 @@
   "src/components/images/Gallery/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 5
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 4
+    },
+    "react-hooks/refs": {
+      "count": 1
     }
   },
   "src/components/images/Gallery/useKeyboardHandlers.ts": {
@@ -197,6 +735,51 @@
       "count": 2
     }
   },
+  "src/components/intents/VerifyEmailIntentDialog.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/components/interstitials/TrendingVideos.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/moderation/ContentHider.tsx": {
+    "react-hooks/immutability": {
+      "count": 1
+    }
+  },
+  "src/components/moderation/LabelsOnMeDialog.tsx": {
+    "react-hooks/purity": {
+      "count": 1
+    }
+  },
+  "src/components/moderation/ModerationDetailsDialog.tsx": {
+    "react-hooks/purity": {
+      "count": 1
+    }
+  },
+  "src/components/verification/VerificationCreatePrompt.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/components/verification/VerificationRemovePrompt.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/features/liveEvents/preferences.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/features/liveNow/components/LiveStatusDialog.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
   "src/features/liveNow/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 3
@@ -205,6 +788,12 @@
   "src/geolocation/service.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
     }
   },
   "src/lib/ScrollContext.tsx": {
@@ -212,9 +801,22 @@
       "count": 3
     }
   },
+  "src/lib/api/feed/demo.ts": {
+    "@typescript-eslint/require-await": {
+      "count": 2
+    }
+  },
+  "src/lib/api/feed/posts.ts": {
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
   "src/lib/api/index.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 5
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 3
     }
   },
   "src/lib/async/retry.ts": {
@@ -232,9 +834,20 @@
       "count": 1
     }
   },
+  "src/lib/custom-animations/CountWheel.web.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
   "src/lib/functions.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 6
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 25
     }
   },
   "src/lib/getUserDisplayName.ts": {
@@ -242,19 +855,80 @@
       "count": 1
     }
   },
+  "src/lib/haptics.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
   "src/lib/hooks/useAccountSwitcher.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/lib/hooks/useAnimatedValue.ts": {
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "src/lib/hooks/useDraggableScrollView.ts": {
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "src/lib/hooks/useIntentHandler.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
     }
   },
   "src/lib/hooks/useNonReactiveCallback.ts": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    }
+  },
+  "src/lib/hooks/useNotificationHandler.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 16
+    },
+    "@typescript-eslint/require-await": {
       "count": 1
     }
   },
   "src/lib/hooks/useOTAUpdates.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 4
+    }
+  },
+  "src/lib/hooks/useOpenLink.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/lib/hooks/usePermissions.ts": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-enum-comparison": {
+      "count": 5
+    }
+  },
+  "src/lib/hooks/usePermissions.web.ts": {
+    "@typescript-eslint/require-await": {
+      "count": 3
     }
   },
   "src/lib/hooks/useRequireEmailVerification.tsx": {
@@ -262,14 +936,33 @@
       "count": 2
     }
   },
+  "src/lib/hooks/useTLDs.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/lib/hooks/useTabFocusEffect.ts": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
   "src/lib/hooks/useToggleMutationQueue.ts": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
       "count": 2
     }
   },
   "src/lib/hooks/useWebScrollRestoration.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "react-hooks/immutability": {
+      "count": 1
     }
   },
   "src/lib/international-telephone-codes.ts": {
@@ -277,9 +970,30 @@
       "count": 1
     }
   },
+  "src/lib/link-meta/link-meta.ts": {
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 9
+    }
+  },
   "src/lib/media/manip.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 5
+    }
+  },
+  "src/lib/media/manip.web.ts": {
+    "@typescript-eslint/prefer-promise-reject-errors": {
+      "count": 1
+    },
+    "@typescript-eslint/require-await": {
+      "count": 3
+    }
+  },
+  "src/lib/media/picker.web.tsx": {
+    "@typescript-eslint/require-await": {
+      "count": 2
     }
   },
   "src/lib/media/save-image.ios.ts": {
@@ -297,8 +1011,33 @@
       "count": 1
     }
   },
+  "src/lib/notifications/notifications.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 5
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-enum-comparison": {
+      "count": 2
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
   "src/lib/react-query.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "src/lib/routes/links.ts": {
+    "@typescript-eslint/no-redundant-type-constituents": {
       "count": 1
     }
   },
@@ -312,82 +1051,298 @@
       "count": 1
     }
   },
+  "src/lib/sharing.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
   "src/lib/strings/errors.ts": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 14
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 14
+    }
+  },
+  "src/lib/translation/index.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/lib/useGetEmojis/getEmojis.ts": {
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/logger/transports/sentry.ts": {
+    "@typescript-eslint/no-unsafe-enum-comparison": {
+      "count": 3
+    }
+  },
+  "src/logger/types.ts": {
+    "@typescript-eslint/no-redundant-type-constituents": {
       "count": 1
     }
   },
   "src/screens/Bookmarks/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
     }
   },
   "src/screens/Deactivated.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/screens/E2E/SharedPreferencesTesterScreen.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 6
+    },
+    "@typescript-eslint/require-await": {
+      "count": 6
+    }
+  },
+  "src/screens/Feeds/NoFollowingFeed.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Feeds/NoSavedFeedsOfAnyType.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Hashtag.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Home/NoFeedsPinned.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/List/ListHiddenScreen.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Log.tsx": {
+    "@typescript-eslint/no-unsafe-enum-comparison": {
+      "count": 2
     }
   },
   "src/screens/Login/ChooseAccountForm.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
       "count": 1
     }
   },
   "src/screens/Login/ForgotPasswordForm.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
     }
   },
   "src/screens/Login/LoginForm.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 4
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 4
+    },
+    "react-hooks/refs": {
       "count": 1
     }
   },
   "src/screens/Login/SetNewPasswordForm.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/screens/Login/index.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "react-hooks/purity": {
+      "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/screens/Messages/ChatList.tsx": {
+    "react-hooks/immutability": {
+      "count": 1
     }
   },
   "src/screens/Moderation/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
       "count": 2
     }
   },
   "src/screens/ModerationInteractionSettings/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/screens/Onboarding/StepFinished/ValuePropositionPager.tsx": {
+    "react-hooks/refs": {
+      "count": 4
     }
   },
   "src/screens/Onboarding/StepFinished/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
       "count": 1
     }
   },
   "src/screens/Onboarding/StepInterests/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/screens/Onboarding/StepProfile/index.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Onboarding/StepSuggestedStarterpacks/StarterPackCard.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Onboarding/StepSuggestedStarterpacks/index.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
     }
   },
   "src/screens/PostThread/components/ThreadItemAnchorFollowButton.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 4
     }
   },
   "src/screens/PostThread/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
     },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 3
+    },
     "react-hooks/preserve-manual-memoization": {
       "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 4
     }
   },
   "src/screens/Profile/Header/EditProfileDialog.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 3
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
     }
   },
   "src/screens/Profile/Header/ProfileHeaderLabeler.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 3
     }
   },
   "src/screens/Profile/Header/Shell.tsx": {
@@ -395,28 +1350,163 @@
       "count": 1
     }
   },
+  "src/screens/Profile/KnownFollowers.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    }
+  },
   "src/screens/Profile/Sections/Feed.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
       "count": 1
     }
   },
   "src/screens/Profile/components/GermButton.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/screens/Profile/components/ProfileFeedHeader.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 5
+    }
+  },
+  "src/screens/ProfileList/FeedSection.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/ProfileList/components/Header.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    }
+  },
+  "src/screens/ProfileList/components/MoreOptionsMenu.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 5
+    }
+  },
+  "src/screens/ProfileList/components/SubscribeMenu.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    }
+  },
+  "src/screens/ProfileList/index.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/SavedFeeds.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    }
+  },
+  "src/screens/Search/Shell.tsx": {
+    "react-hooks/refs": {
+      "count": 4
+    }
+  },
+  "src/screens/Search/modules/ExploreSuggestedAccounts.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Search/modules/ExploreTrendingTopics.tsx": {
+    "react-hooks/purity": {
+      "count": 2
+    }
+  },
+  "src/screens/Search/modules/ExploreTrendingVideos.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Settings/AboutSettings.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Settings/AppPasswords.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Settings/AutomationLabelSettings.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
     }
   },
   "src/screens/Settings/FindContactsSettings.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/screens/Settings/InterestsSettings.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/screens/Settings/components/ChangeHandleDialog.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 4
+    },
+    "@typescript-eslint/no-misused-promises": {
       "count": 1
     }
   },
   "src/screens/Settings/components/ChangePasswordDialog.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "src/screens/Settings/components/CopyButton.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
     }
   },
   "src/screens/Settings/components/DeactivateAccountDialog.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
       "count": 1
     }
   },
@@ -425,14 +1515,114 @@
       "count": 2
     }
   },
+  "src/screens/Settings/components/DisableEmail2FADialog.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 4
+    }
+  },
+  "src/screens/Settings/components/OTAInfo.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Signup/StepCaptcha/CaptchaWebView.tsx": {
+    "react-hooks/purity": {
+      "count": 1
+    }
+  },
+  "src/screens/Signup/StepHandle/index.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
   "src/screens/Signup/StepInfo/Policies.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
     }
   },
+  "src/screens/Signup/StepInfo/index.tsx": {
+    "react-hooks/refs": {
+      "count": 3
+    }
+  },
   "src/screens/SignupQueued.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/screens/StarterPack/StarterPackLandingScreen.tsx": {
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/screens/StarterPack/StarterPackScreen.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/screens/StarterPack/Wizard/StepFeeds.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/StarterPack/Wizard/StepProfiles.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/StarterPack/Wizard/index.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/screens/Topic.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/state/a11y.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/cache/profile-shadow.ts": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/state/cache/thread-mutes.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
     }
   },
   "src/state/cache/types.ts": {
@@ -443,31 +1633,213 @@
   "src/state/feed-feedback.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 3
+    },
+    "react-hooks/refs": {
+      "count": 2
+    }
+  },
+  "src/state/gallery.ts": {
+    "@typescript-eslint/prefer-promise-reject-errors": {
+      "count": 1
     }
   },
   "src/state/messages/events/agent.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 4
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "src/state/messages/message-drafts.tsx": {
+    "react-hooks/refs": {
+      "count": 1
     }
   },
   "src/state/persisted/index.ts": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
       "count": 1
     }
   },
   "src/state/persisted/index.web.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 4
     }
   },
   "src/state/persisted/util.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/alt-text-required.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/autoplay.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/disable-haptics.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/external-embeds-prefs.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/hidden-posts.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/in-app-browser.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/kawaii.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/languages.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/large-alt-badge.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/subtitles.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/trending.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/used-starter-packs.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/queries/activity-subscriptions.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/queries/actor-autocomplete.ts": {
+    "react-hooks/immutability": {
+      "count": 2
+    }
+  },
+  "src/state/queries/app-passwords.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    }
+  },
+  "src/state/queries/bookmarks/useBookmarkMutation.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    }
+  },
+  "src/state/queries/bookmarks/useBookmarksQuery.ts": {
+    "@typescript-eslint/require-await": {
+      "count": 2
+    }
+  },
+  "src/state/queries/explore-feed-previews.tsx": {
+    "react-hooks/refs": {
+      "count": 4
+    }
+  },
+  "src/state/queries/feed.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/queries/handle.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/queries/list-memberships.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    }
+  },
+  "src/state/queries/list.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 7
+    }
+  },
+  "src/state/queries/messages/accept-conversation.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    }
+  },
+  "src/state/queries/messages/update-all-read.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    }
+  },
+  "src/state/queries/my-lists.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
     }
   },
   "src/state/queries/notifications/feed.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "src/state/queries/notifications/unread.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 4
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 4
+    },
+    "react-hooks/refs": {
+      "count": 1
     }
   },
   "src/state/queries/nuxs/definitions.ts": {
@@ -478,108 +1850,385 @@
   "src/state/queries/pinned-post.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
     }
   },
   "src/state/queries/post-feed.ts": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 3
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
       "count": 3
     }
   },
   "src/state/queries/postgate/index.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 3
+    },
+    "@typescript-eslint/require-await": {
+      "count": 2
+    }
+  },
+  "src/state/queries/preferences/index.ts": {
+    "react-hooks/immutability": {
+      "count": 1
+    }
+  },
+  "src/state/queries/preferences/useThreadPreferences.ts": {
+    "react-hooks/refs": {
+      "count": 2
     }
   },
   "src/state/queries/search-posts.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "src/state/queries/starter-packs.ts": {
+    "@typescript-eslint/require-await": {
+      "count": 1
+    },
+    "react-hooks/immutability": {
+      "count": 1
+    }
+  },
+  "src/state/queries/suggested-follows.ts": {
+    "@typescript-eslint/no-unused-vars": {
+      "count": 1
     }
   },
   "src/state/queries/threadgate/index.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    },
+    "@typescript-eslint/require-await": {
+      "count": 3
     }
   },
   "src/state/queries/util.ts": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
       "count": 1
     }
   },
   "src/state/session/agent.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/state/shell/color-mode.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    }
+  },
+  "src/state/shell/composer/index.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/shell/onboarding.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 5
     }
   },
   "src/state/shell/progress-guide.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 4
+    }
+  },
+  "src/state/shell/reminders.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/shell/tick-every-minute.tsx": {
+    "react-hooks/purity": {
+      "count": 1
+    }
+  },
+  "src/storage/archive/index.ts": {
+    "@typescript-eslint/no-unsafe-member-access": {
       "count": 1
     }
   },
   "src/storage/index.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 8
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/view/com/auth/SplashScreen.web.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
     }
   },
   "src/view/com/composer/Composer.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
     },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 4
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    },
+    "react-hooks/immutability": {
+      "count": 2
+    },
     "react-hooks/preserve-manual-memoization": {
       "count": 3
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/view/com/composer/SelectMediaButton.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/view/com/composer/drafts/DraftsButton.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
     }
   },
   "src/view/com/composer/drafts/state/queries.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "src/view/com/composer/drafts/state/storage.ts": {
+    "@typescript-eslint/require-await": {
+      "count": 3
+    }
+  },
+  "src/view/com/composer/photos/EditImageDialog.web.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/view/com/composer/photos/Gallery.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
     }
   },
   "src/view/com/composer/photos/OpenCameraBtn.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/view/com/composer/select-language/SuggestedLanguage.tsx": {
+    "react-hooks/refs": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/view/com/composer/text-input/TextInput.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/view/com/composer/text-input/TextInput.web.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "src/view/com/composer/text-input/web/Autocomplete.tsx": {
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/view/com/composer/videos/pickVideo.web.ts": {
+    "@typescript-eslint/no-misused-promises": {
       "count": 1
     }
   },
   "src/view/com/feeds/ComposerPrompt.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    }
+  },
+  "src/view/com/feeds/FeedPage.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
     }
   },
   "src/view/com/feeds/ProfileFeedgens.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 3
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
     }
   },
   "src/view/com/lists/ListMembers.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 3
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
     }
   },
   "src/view/com/lists/MyLists.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 6
     }
   },
   "src/view/com/lists/ProfileLists.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 3
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "src/view/com/modals/Modal.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 1
     }
   },
   "src/view/com/notifications/NotificationFeed.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 6
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
     }
   },
   "src/view/com/notifications/NotificationFeedItem.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 3
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
     }
   },
   "src/view/com/pager/Pager.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 4
+    },
+    "react-hooks/refs": {
+      "count": 1
     }
   },
   "src/view/com/pager/Pager.web.tsx": {
+    "react-hooks/immutability": {
+      "count": 1
+    },
     "react-hooks/preserve-manual-memoization": {
+      "count": 1
+    },
+    "react-hooks/refs": {
       "count": 1
     }
   },
@@ -593,13 +2242,45 @@
       "count": 2
     }
   },
+  "src/view/com/pager/TabBar.tsx": {
+    "react-hooks/immutability": {
+      "count": 1
+    }
+  },
   "src/view/com/pager/TabBar.web.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 4
+    }
+  },
+  "src/view/com/post-thread/PostLikedBy.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    }
+  },
+  "src/view/com/post-thread/PostQuotes.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/view/com/post-thread/PostRepostedBy.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
     }
   },
   "src/view/com/posts/FeedShutdownMsg.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
       "count": 2
     }
   },
@@ -611,16 +2292,47 @@
   "src/view/com/posts/PostFeedErrorMessage.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 8
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 9
+    }
+  },
+  "src/view/com/profile/ProfileFollowers.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    }
+  },
+  "src/view/com/profile/ProfileFollows.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
     }
   },
   "src/view/com/profile/ProfileMenu.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 6
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 4
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 6
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 12
     }
   },
   "src/view/com/testing/TestCtrls.e2e.tsx": {
     "@typescript-eslint/no-explicit-any": {
-      "count": 2
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 9
     }
   },
   "src/view/com/util/EmptyState.tsx": {
@@ -631,16 +2343,36 @@
   "src/view/com/util/ErrorBoundary.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
     }
   },
   "src/view/com/util/EventStopper.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
       "count": 1
     }
   },
   "src/view/com/util/Link.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    }
+  },
+  "src/view/com/util/LoadingPlaceholder.tsx": {
+    "react-hooks/purity": {
+      "count": 1
     }
   },
   "src/view/com/util/MainScrollProvider.tsx": {
@@ -648,9 +2380,22 @@
       "count": 2
     }
   },
+  "src/view/com/util/UserAvatar.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    }
+  },
+  "src/view/com/util/UserBanner.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    }
+  },
   "src/view/com/util/ViewSelector.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 6
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
     }
   },
   "src/view/com/util/Views.tsx": {
@@ -658,13 +2403,100 @@
       "count": 1
     }
   },
+  "src/view/com/util/Views.web.tsx": {
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/view/com/util/forms/Button.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
   "src/view/screens/Debug.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 4
+    }
+  },
+  "src/view/screens/Feeds.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/view/screens/Home.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/view/screens/ModerationBlockedAccounts.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    }
+  },
+  "src/view/screens/ModerationMutedAccounts.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/view/screens/Notifications.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    }
+  },
+  "src/view/screens/Storybook/ListContained.tsx": {
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "src/view/screens/Storybook/Storybook.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/view/shell/Drawer.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
     }
   },
   "src/view/shell/createNativeStackNavigatorWithAuth.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 13
+    }
+  },
+  "src/view/shell/desktop/Search.tsx": {
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 3
+    },
+    "react-hooks/refs": {
+      "count": 3
+    }
+  },
+  "src/view/shell/index.web.tsx": {
+    "react-hooks/set-state-in-effect": {
       "count": 1
     }
   }

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,12 +1,72 @@
 {
+  "src/Navigation.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 5
+    }
+  },
+  "src/Splash.android.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/Splash.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/ageAssurance/components/RedirectOverlay.tsx": {
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/ageAssurance/util.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
   "src/alf/util/flatten.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 9
+    }
+  },
+  "src/alf/util/systemUI.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    }
+  },
+  "src/alf/util/useGutters.ts": {
+    "react-hooks/immutability": {
+      "count": 5
     }
   },
   "src/analytics/PassiveAnalytics.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "react-hooks/purity": {
+      "count": 1
+    }
+  },
+  "src/analytics/features/index.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/analytics/identifiers/session.test.ts": {
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 9
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 9
     }
   },
   "src/analytics/metadata.ts": {
@@ -17,16 +77,84 @@
   "src/analytics/metrics/client.test.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 8
+    },
+    "@typescript-eslint/require-await": {
+      "count": 5
     }
   },
   "src/analytics/metrics/client.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 5
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/analytics/utils.ts": {
+    "react-hooks/immutability": {
+      "count": 1
+    }
+  },
+  "src/components/AppLanguageDropdown.tsx": {
+    "@typescript-eslint/no-unsafe-enum-comparison": {
+      "count": 1
+    }
+  },
+  "src/components/Autocomplete/Autocomplete.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/Autocomplete/useAutocomplete/index.ts": {
+    "react-hooks/immutability": {
+      "count": 1
+    }
+  },
+  "src/components/BotAccountAlert.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/Button.tsx": {
+    "react-hooks/immutability": {
+      "count": 1
     }
   },
   "src/components/Composer/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-redundant-type-constituents": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 7
+    },
+    "react-hooks/immutability": {
+      "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "src/components/DebugFieldDisplay.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
     }
   },
   "src/components/Dialog/index.tsx": {
@@ -37,10 +165,27 @@
   "src/components/Dialog/index.web.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 4
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 3
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
     }
   },
   "src/components/DraggableList/index.web.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 2
+    }
+  },
+  "src/components/EmojiPicker/preload.web.ts": {
+    "@typescript-eslint/no-floating-promises": {
       "count": 2
     }
   },
@@ -52,15 +197,57 @@
   "src/components/FocusScope/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 1
     }
   },
   "src/components/InternationalPhoneCodeSelect.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/components/KnownFollowers.tsx": {
+    "react-hooks/refs": {
+      "count": 6
+    }
+  },
+  "src/components/Lightbox/Lightbox.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    }
+  },
+  "src/components/Lightbox/Lightbox.web.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/components/Lightbox/pager/ImageItem/ImageItem.android.tsx": {
+    "react-hooks/immutability": {
+      "count": 1
+    }
+  },
+  "src/components/Lightbox/pager/ImageItem/ImageItem.ios.tsx": {
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "src/components/LikedByList.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
     }
   },
   "src/components/Lists.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
       "count": 1
     }
   },
@@ -74,34 +261,124 @@
       "count": 1
     }
   },
+  "src/components/Post/Embed/ExternalEmbed/ExternalGif.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    }
+  },
+  "src/components/Post/Embed/ExternalEmbed/index.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
   "src/components/Post/Embed/ImageEmbed.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/Post/Embed/VideoEmbed/VideoEmbedInner/VideoEmbedInnerWeb.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-enum-comparison": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    },
+    "react-hooks/immutability": {
       "count": 1
     }
   },
   "src/components/Post/Embed/VideoEmbed/VideoEmbedInner/web-controls/utils.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 3
     }
   },
   "src/components/PostControls/BookmarkButton.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    }
+  },
+  "src/components/PostControls/DiscoverDebug.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/PostControls/ShareMenu/ShareMenuItems.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/components/PostControls/ShareMenu/ShareMenuItems.web.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    }
+  },
+  "src/components/PostControls/ShareMenu/index.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
     }
   },
   "src/components/ProfileHoverCard/index.web.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    },
+    "react-hooks/immutability": {
+      "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 2
+    }
+  },
+  "src/components/ProgressGuide/FollowDialog.tsx": {
+    "react-hooks/refs": {
+      "count": 2
+    }
+  },
+  "src/components/RichTextTag.tsx": {
+    "@typescript-eslint/no-floating-promises": {
       "count": 2
     }
   },
   "src/components/Select/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 4
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
     }
   },
   "src/components/Select/index.web.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
     }
   },
   "src/components/Select/types.ts": {
@@ -109,8 +386,43 @@
       "count": 3
     }
   },
+  "src/components/SendErrorReportDialog.tsx": {
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/components/StarterPack/Main/ProfilesList.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
   "src/components/StarterPack/ProfileStarterPacks.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    }
+  },
+  "src/components/StarterPack/QrCodeDialog.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 5
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/require-await": {
+      "count": 4
+    }
+  },
+  "src/components/StarterPack/ShareDialog.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/require-await": {
       "count": 1
     }
   },
@@ -119,14 +431,112 @@
       "count": 1
     }
   },
+  "src/components/Tooltip/index.tsx": {
+    "@typescript-eslint/no-base-to-string": {
+      "count": 1
+    }
+  },
+  "src/components/Tooltip/index.web.tsx": {
+    "@typescript-eslint/no-base-to-string": {
+      "count": 1
+    }
+  },
+  "src/components/WhoCanReply.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "src/components/ageAssurance/AgeAssuranceErrors.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/components/ageAssurance/AgeAssuranceInitDialog.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "react-hooks/purity": {
+      "count": 1
+    }
+  },
+  "src/components/ageAssurance/AgeAssuranceRedirectDialog.tsx": {
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/components/contacts/components/OTPInput.tsx": {
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "src/components/contacts/screens/GetContacts.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/contacts/screens/VerifyNumber.tsx": {
+    "@typescript-eslint/require-await": {
+      "count": 1
+    },
+    "react-hooks/purity": {
+      "count": 1
+    }
+  },
+  "src/components/contacts/screens/ViewMatches.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
   "src/components/dialogs/DeviceLocationRequestDialog.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
     }
   },
   "src/components/dialogs/EmailDialog/components/ResendEmailText.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/dialogs/EmailDialog/data/useAccountEmailState.ts": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/components/dialogs/EmailDialog/screens/Manage2FA/Disable.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    }
+  },
+  "src/components/dialogs/EmailDialog/screens/Manage2FA/Enable.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/components/dialogs/EmailDialog/screens/Update.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    }
+  },
+  "src/components/dialogs/EmailDialog/screens/Verify.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    }
+  },
+  "src/components/dialogs/InAppBrowserConsent.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
     }
   },
   "src/components/dialogs/LanguageSelectDialog.tsx": {
@@ -134,8 +544,25 @@
       "count": 1
     }
   },
+  "src/components/dialogs/LinkWarning.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    }
+  },
   "src/components/dialogs/MutedWords.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    },
+    "@typescript-eslint/require-await": {
       "count": 1
     }
   },
@@ -143,22 +570,96 @@
     "@typescript-eslint/no-explicit-any": {
       "count": 2
     },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    },
     "react-hooks/preserve-manual-memoization": {
       "count": 1
+    }
+  },
+  "src/components/dialogs/ServerInput.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/dialogs/StarterPackDialog.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/components/dialogs/SwitchAccount.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/dialogs/lists/CreateListFromStarterPackDialog.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
     }
   },
   "src/components/dialogs/lists/CreateOrEditListDialog.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/components/dialogs/nuxs/FindContactsAnnouncement.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/dialogs/nuxs/index.tsx": {
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    },
+    "react-hooks/immutability": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/components/dms/AfterReportDialog.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/dms/MessagesListBlockedFooter.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
     }
   },
   "src/components/forms/DateField/index.web.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "src/components/forms/SearchInput.tsx": {
+    "react-hooks/refs": {
+      "count": 1
     }
   },
   "src/components/forms/SegmentedControl.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    }
+  },
+  "src/components/forms/TextField.tsx": {
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 3
+    },
+    "react-hooks/refs": {
       "count": 1
     }
   },
@@ -170,6 +671,40 @@
   "src/components/hooks/useFollowMethods.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "src/components/hooks/useFullscreen.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/components/hooks/useRefreshOnFocus.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/hooks/useRichText.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/hooks/useStarterPackEntry.native.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/components/hooks/useStarterPackEntry.ts": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
     }
   },
   "src/components/images/AutoSizedImage.tsx": {
@@ -180,6 +715,15 @@
   "src/components/images/Gallery/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 5
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 4
+    },
+    "react-hooks/refs": {
+      "count": 1
     }
   },
   "src/components/images/Gallery/useKeyboardHandlers.ts": {
@@ -202,8 +746,56 @@
       "count": 2
     }
   },
+  "src/components/intents/VerifyEmailIntentDialog.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/components/interstitials/TrendingVideos.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/components/moderation/ContentHider.tsx": {
+    "react-hooks/immutability": {
+      "count": 1
+    }
+  },
+  "src/components/moderation/LabelsOnMeDialog.tsx": {
+    "react-hooks/purity": {
+      "count": 1
+    }
+  },
+  "src/components/moderation/ModerationDetailsDialog.tsx": {
+    "react-hooks/purity": {
+      "count": 1
+    }
+  },
   "src/components/moderation/ReportDialog/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    }
+  },
+  "src/components/verification/VerificationCreatePrompt.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/components/verification/VerificationRemovePrompt.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/features/liveEvents/preferences.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/features/liveNow/components/LiveStatusDialog.tsx": {
+    "@typescript-eslint/no-floating-promises": {
       "count": 1
     }
   },
@@ -215,6 +807,12 @@
   "src/geolocation/service.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
     }
   },
   "src/lib/ScrollContext.tsx": {
@@ -222,9 +820,22 @@
       "count": 3
     }
   },
+  "src/lib/api/feed/demo.ts": {
+    "@typescript-eslint/require-await": {
+      "count": 2
+    }
+  },
+  "src/lib/api/feed/posts.ts": {
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
   "src/lib/api/index.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 5
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 3
     }
   },
   "src/lib/async/retry.ts": {
@@ -242,9 +853,20 @@
       "count": 1
     }
   },
+  "src/lib/custom-animations/CountWheel.web.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
   "src/lib/functions.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 6
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 25
     }
   },
   "src/lib/getUserDisplayName.ts": {
@@ -252,19 +874,80 @@
       "count": 1
     }
   },
+  "src/lib/haptics.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
   "src/lib/hooks/useAccountSwitcher.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/lib/hooks/useAnimatedValue.ts": {
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "src/lib/hooks/useDraggableScrollView.ts": {
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "src/lib/hooks/useIntentHandler.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
     }
   },
   "src/lib/hooks/useNonReactiveCallback.ts": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    }
+  },
+  "src/lib/hooks/useNotificationHandler.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 16
+    },
+    "@typescript-eslint/require-await": {
       "count": 1
     }
   },
   "src/lib/hooks/useOTAUpdates.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 4
+    }
+  },
+  "src/lib/hooks/useOpenLink.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/lib/hooks/usePermissions.ts": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-enum-comparison": {
+      "count": 5
+    }
+  },
+  "src/lib/hooks/usePermissions.web.ts": {
+    "@typescript-eslint/require-await": {
+      "count": 3
     }
   },
   "src/lib/hooks/useRequireEmailVerification.tsx": {
@@ -272,14 +955,33 @@
       "count": 2
     }
   },
+  "src/lib/hooks/useTLDs.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/lib/hooks/useTabFocusEffect.ts": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
   "src/lib/hooks/useToggleMutationQueue.ts": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
       "count": 2
     }
   },
   "src/lib/hooks/useWebScrollRestoration.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "react-hooks/immutability": {
+      "count": 1
     }
   },
   "src/lib/international-telephone-codes.ts": {
@@ -287,9 +989,30 @@
       "count": 1
     }
   },
+  "src/lib/link-meta/link-meta.ts": {
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 7
+    }
+  },
   "src/lib/media/manip.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 5
+    }
+  },
+  "src/lib/media/manip.web.ts": {
+    "@typescript-eslint/prefer-promise-reject-errors": {
+      "count": 1
+    },
+    "@typescript-eslint/require-await": {
+      "count": 3
+    }
+  },
+  "src/lib/media/picker.web.tsx": {
+    "@typescript-eslint/require-await": {
+      "count": 2
     }
   },
   "src/lib/media/save-image.ios.ts": {
@@ -307,8 +1030,33 @@
       "count": 1
     }
   },
+  "src/lib/notifications/notifications.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 5
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-enum-comparison": {
+      "count": 2
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
   "src/lib/react-query.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "src/lib/routes/links.ts": {
+    "@typescript-eslint/no-redundant-type-constituents": {
       "count": 1
     }
   },
@@ -322,13 +1070,55 @@
       "count": 1
     }
   },
+  "src/lib/sharing.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
   "src/lib/strings/errors.ts": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 14
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 14
+    }
+  },
+  "src/lib/translation/index.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/lib/useGetEmojis/getEmojis.ts": {
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/locale/i18n.ts": {
+    "@typescript-eslint/no-floating-promises": {
       "count": 1
     }
   },
   "src/locale/i18n.web.ts": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/logger/transports/sentry.ts": {
+    "@typescript-eslint/no-unsafe-enum-comparison": {
+      "count": 3
+    }
+  },
+  "src/logger/types.ts": {
+    "@typescript-eslint/no-redundant-type-constituents": {
       "count": 1
     }
   },
@@ -340,74 +1130,264 @@
   "src/screens/Bookmarks/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
     }
   },
   "src/screens/Deactivated.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/screens/E2E/SharedPreferencesTesterScreen.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 6
+    },
+    "@typescript-eslint/require-await": {
+      "count": 6
+    }
+  },
+  "src/screens/Feeds/NoFollowingFeed.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Feeds/NoSavedFeedsOfAnyType.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Hashtag.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Home/NoFeedsPinned.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/List/ListHiddenScreen.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Log.tsx": {
+    "@typescript-eslint/no-unsafe-enum-comparison": {
+      "count": 2
     }
   },
   "src/screens/Login/ChooseAccountForm.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
       "count": 1
     }
   },
   "src/screens/Login/ForgotPasswordForm.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
     }
   },
   "src/screens/Login/LoginForm.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 4
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 4
+    },
+    "react-hooks/refs": {
       "count": 1
     }
   },
   "src/screens/Login/SetNewPasswordForm.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/screens/Login/index.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "react-hooks/purity": {
+      "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/screens/Messages/ChatList.tsx": {
+    "react-hooks/immutability": {
+      "count": 1
+    }
+  },
+  "src/screens/Messages/components/InviteLinkDialog.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
     }
   },
   "src/screens/Moderation/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
       "count": 2
     }
   },
   "src/screens/ModerationInteractionSettings/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/screens/Onboarding/StepFinished/ValuePropositionPager.tsx": {
+    "react-hooks/refs": {
+      "count": 4
     }
   },
   "src/screens/Onboarding/StepFinished/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
       "count": 1
     }
   },
   "src/screens/Onboarding/StepInterests/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/screens/Onboarding/StepProfile/index.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Onboarding/StepSuggestedStarterpacks/StarterPackCard.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Onboarding/StepSuggestedStarterpacks/index.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
     }
   },
   "src/screens/PostThread/components/ThreadItemAnchorFollowButton.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 4
     }
   },
   "src/screens/PostThread/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
     },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 3
+    },
     "react-hooks/preserve-manual-memoization": {
       "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 4
     }
   },
   "src/screens/Profile/Header/EditProfileDialog.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 3
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
     }
   },
   "src/screens/Profile/Header/ProfileHeaderLabeler.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 3
     }
   },
   "src/screens/Profile/Header/Shell.tsx": {
@@ -415,28 +1395,176 @@
       "count": 1
     }
   },
+  "src/screens/Profile/KnownFollowers.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    }
+  },
   "src/screens/Profile/Sections/Feed.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
       "count": 1
     }
   },
   "src/screens/Profile/components/GermButton.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/screens/Profile/components/ProfileFeedHeader.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 5
+    }
+  },
+  "src/screens/ProfileList/FeedSection.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/ProfileList/components/Header.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    }
+  },
+  "src/screens/ProfileList/components/MoreOptionsMenu.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 5
+    }
+  },
+  "src/screens/ProfileList/components/SubscribeMenu.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    }
+  },
+  "src/screens/ProfileList/index.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/SavedFeeds.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    }
+  },
+  "src/screens/Search/Shell.tsx": {
+    "react-hooks/refs": {
+      "count": 4
+    }
+  },
+  "src/screens/Search/modules/ExploreSuggestedAccounts.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Search/modules/ExploreTrendingTopics.tsx": {
+    "react-hooks/purity": {
+      "count": 2
+    }
+  },
+  "src/screens/Search/modules/ExploreTrendingVideos.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Settings/AboutSettings.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Settings/AppPasswords.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Settings/AutomationLabelSettings.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
     }
   },
   "src/screens/Settings/FindContactsSettings.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/screens/Settings/InterestsSettings.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/screens/Settings/NotificationSettings/ActivityNotificationSettings.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Settings/NotificationSettings/index.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Settings/components/ChangeHandleDialog.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 4
+    },
+    "@typescript-eslint/no-misused-promises": {
       "count": 1
     }
   },
   "src/screens/Settings/components/ChangePasswordDialog.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "src/screens/Settings/components/CopyButton.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
     }
   },
   "src/screens/Settings/components/DeactivateAccountDialog.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
       "count": 1
     }
   },
@@ -445,14 +1573,114 @@
       "count": 2
     }
   },
+  "src/screens/Settings/components/DisableEmail2FADialog.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 4
+    }
+  },
+  "src/screens/Settings/components/OTAInfo.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/Signup/StepCaptcha/CaptchaWebView.tsx": {
+    "react-hooks/purity": {
+      "count": 1
+    }
+  },
+  "src/screens/Signup/StepHandle/index.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
   "src/screens/Signup/StepInfo/Policies.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
     }
   },
+  "src/screens/Signup/StepInfo/index.tsx": {
+    "react-hooks/refs": {
+      "count": 3
+    }
+  },
   "src/screens/SignupQueued.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/screens/StarterPack/StarterPackLandingScreen.tsx": {
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/screens/StarterPack/StarterPackScreen.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/screens/StarterPack/Wizard/StepFeeds.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/StarterPack/Wizard/StepProfiles.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/screens/StarterPack/Wizard/index.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/screens/Topic.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/state/a11y.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/cache/profile-shadow.ts": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/state/cache/thread-mutes.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
     }
   },
   "src/state/cache/types.ts": {
@@ -463,31 +1691,218 @@
   "src/state/feed-feedback.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 3
+    },
+    "react-hooks/refs": {
+      "count": 2
+    }
+  },
+  "src/state/gallery.ts": {
+    "@typescript-eslint/prefer-promise-reject-errors": {
+      "count": 1
     }
   },
   "src/state/messages/events/agent.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 4
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "src/state/messages/message-drafts.tsx": {
+    "react-hooks/refs": {
+      "count": 1
     }
   },
   "src/state/persisted/index.ts": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
       "count": 1
     }
   },
   "src/state/persisted/index.web.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 4
     }
   },
   "src/state/persisted/util.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/alt-text-required.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/autoplay.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/disable-haptics.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/external-embeds-prefs.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/hidden-posts.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/in-app-browser.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/kawaii.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/languages.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/large-alt-badge.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/subtitles.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/trending.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/preferences/used-starter-packs.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/queries/activity-subscriptions.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/queries/actor-autocomplete.ts": {
+    "react-hooks/immutability": {
+      "count": 2
+    }
+  },
+  "src/state/queries/app-passwords.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    }
+  },
+  "src/state/queries/bookmarks/useBookmarkMutation.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    }
+  },
+  "src/state/queries/bookmarks/useBookmarksQuery.ts": {
+    "@typescript-eslint/require-await": {
+      "count": 2
+    }
+  },
+  "src/state/queries/explore-feed-previews.tsx": {
+    "react-hooks/refs": {
+      "count": 4
+    }
+  },
+  "src/state/queries/feed.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/queries/handle.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/queries/list-memberships.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    }
+  },
+  "src/state/queries/list.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 7
+    }
+  },
+  "src/state/queries/messages/accept-conversation.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    }
+  },
+  "src/state/queries/messages/update-all-read.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    }
+  },
+  "src/state/queries/my-lists.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
     }
   },
   "src/state/queries/notifications/feed.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "src/state/queries/notifications/settings.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/queries/notifications/unread.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 4
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 4
+    },
+    "react-hooks/refs": {
+      "count": 1
     }
   },
   "src/state/queries/nuxs/definitions.ts": {
@@ -498,108 +1913,385 @@
   "src/state/queries/pinned-post.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
     }
   },
   "src/state/queries/post-feed.ts": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 3
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
       "count": 3
     }
   },
   "src/state/queries/postgate/index.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 3
+    },
+    "@typescript-eslint/require-await": {
+      "count": 2
+    }
+  },
+  "src/state/queries/preferences/index.ts": {
+    "react-hooks/immutability": {
+      "count": 1
+    }
+  },
+  "src/state/queries/preferences/useThreadPreferences.ts": {
+    "react-hooks/refs": {
+      "count": 2
     }
   },
   "src/state/queries/search-posts.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "src/state/queries/starter-packs.ts": {
+    "@typescript-eslint/require-await": {
+      "count": 1
+    },
+    "react-hooks/immutability": {
+      "count": 1
+    }
+  },
+  "src/state/queries/suggested-follows.ts": {
+    "@typescript-eslint/no-unused-vars": {
+      "count": 1
     }
   },
   "src/state/queries/threadgate/index.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    },
+    "@typescript-eslint/require-await": {
+      "count": 3
     }
   },
   "src/state/queries/util.ts": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
       "count": 1
     }
   },
   "src/state/session/agent.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "src/state/shell/color-mode.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    }
+  },
+  "src/state/shell/composer/index.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/shell/onboarding.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 5
     }
   },
   "src/state/shell/progress-guide.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 4
+    }
+  },
+  "src/state/shell/reminders.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/state/shell/tick-every-minute.tsx": {
+    "react-hooks/purity": {
+      "count": 1
+    }
+  },
+  "src/storage/archive/index.ts": {
+    "@typescript-eslint/no-unsafe-member-access": {
       "count": 1
     }
   },
   "src/storage/index.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 8
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/view/com/auth/SplashScreen.web.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
     }
   },
   "src/view/com/composer/Composer.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
     },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 4
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    },
+    "react-hooks/immutability": {
+      "count": 2
+    },
     "react-hooks/preserve-manual-memoization": {
       "count": 3
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/view/com/composer/SelectMediaButton.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/view/com/composer/drafts/DraftsButton.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
     }
   },
   "src/view/com/composer/drafts/state/queries.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "src/view/com/composer/drafts/state/storage.ts": {
+    "@typescript-eslint/require-await": {
+      "count": 3
+    }
+  },
+  "src/view/com/composer/photos/EditImageDialog.web.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/view/com/composer/photos/Gallery.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
     }
   },
   "src/view/com/composer/photos/OpenCameraBtn.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/view/com/composer/select-language/SuggestedLanguage.tsx": {
+    "react-hooks/refs": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/view/com/composer/text-input/TextInput.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/view/com/composer/text-input/TextInput.web.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "src/view/com/composer/text-input/web/Autocomplete.tsx": {
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/view/com/composer/videos/pickVideo.web.ts": {
+    "@typescript-eslint/no-misused-promises": {
       "count": 1
     }
   },
   "src/view/com/feeds/ComposerPrompt.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    }
+  },
+  "src/view/com/feeds/FeedPage.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
     }
   },
   "src/view/com/feeds/ProfileFeedgens.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 3
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
     }
   },
   "src/view/com/lists/ListMembers.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 3
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
     }
   },
   "src/view/com/lists/MyLists.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 6
     }
   },
   "src/view/com/lists/ProfileLists.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 3
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "src/view/com/modals/Modal.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/require-await": {
+      "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 1
     }
   },
   "src/view/com/notifications/NotificationFeed.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 6
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
     }
   },
   "src/view/com/notifications/NotificationFeedItem.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 3
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
     }
   },
   "src/view/com/pager/Pager.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 4
+    },
+    "react-hooks/refs": {
+      "count": 1
     }
   },
   "src/view/com/pager/Pager.web.tsx": {
+    "react-hooks/immutability": {
+      "count": 1
+    },
     "react-hooks/preserve-manual-memoization": {
+      "count": 1
+    },
+    "react-hooks/refs": {
       "count": 1
     }
   },
@@ -613,13 +2305,45 @@
       "count": 2
     }
   },
+  "src/view/com/pager/TabBar.tsx": {
+    "react-hooks/immutability": {
+      "count": 1
+    }
+  },
   "src/view/com/pager/TabBar.web.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 4
+    }
+  },
+  "src/view/com/post-thread/PostLikedBy.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    }
+  },
+  "src/view/com/post-thread/PostQuotes.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/view/com/post-thread/PostRepostedBy.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
     }
   },
   "src/view/com/posts/FeedShutdownMsg.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
       "count": 2
     }
   },
@@ -631,16 +2355,47 @@
   "src/view/com/posts/PostFeedErrorMessage.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 8
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 9
+    }
+  },
+  "src/view/com/profile/ProfileFollowers.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    }
+  },
+  "src/view/com/profile/ProfileFollows.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
     }
   },
   "src/view/com/profile/ProfileMenu.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 6
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 4
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 6
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 12
     }
   },
   "src/view/com/testing/TestCtrls.e2e.tsx": {
     "@typescript-eslint/no-explicit-any": {
-      "count": 2
+      "count": 1
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 9
     }
   },
   "src/view/com/util/EmptyState.tsx": {
@@ -651,16 +2406,36 @@
   "src/view/com/util/ErrorBoundary.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
     }
   },
   "src/view/com/util/EventStopper.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
       "count": 1
     }
   },
   "src/view/com/util/Link.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 2
+    }
+  },
+  "src/view/com/util/LoadingPlaceholder.tsx": {
+    "react-hooks/purity": {
+      "count": 1
     }
   },
   "src/view/com/util/MainScrollProvider.tsx": {
@@ -668,9 +2443,22 @@
       "count": 2
     }
   },
+  "src/view/com/util/UserAvatar.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    }
+  },
+  "src/view/com/util/UserBanner.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    }
+  },
   "src/view/com/util/ViewSelector.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 6
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
     }
   },
   "src/view/com/util/Views.tsx": {
@@ -678,9 +2466,22 @@
       "count": 1
     }
   },
+  "src/view/com/util/Views.web.tsx": {
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/view/com/util/forms/Button.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
   "src/view/screens/Debug.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 4
     }
   },
   "src/view/screens/DebugMod.tsx": {
@@ -688,8 +2489,82 @@
       "count": 1
     }
   },
+  "src/view/screens/Feeds.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/view/screens/Home.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/view/screens/ModerationBlockedAccounts.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    }
+  },
+  "src/view/screens/ModerationMutedAccounts.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/view/screens/Notifications.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3
+    }
+  },
+  "src/view/screens/Storybook/ListContained.tsx": {
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "src/view/screens/Storybook/Storybook.tsx": {
+    "@typescript-eslint/no-misused-promises": {
+      "count": 1
+    }
+  },
+  "src/view/shell/Drawer.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    }
+  },
   "src/view/shell/createNativeStackNavigatorWithAuth.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 13
+    }
+  },
+  "src/view/shell/desktop/Search.tsx": {
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 3
+    },
+    "react-hooks/refs": {
+      "count": 3
+    }
+  },
+  "src/view/shell/index.web.tsx": {
+    "react-hooks/set-state-in-effect": {
       "count": 1
     }
   }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -134,11 +134,10 @@ export default defineConfig(
       'react-native/no-inline-styles': 'off',
       ...reactNativeA11y.configs.all.rules,
       'react-compiler/react-compiler': 'warn',
-      // TODO: Fix these and set to error
-      'react-hooks/set-state-in-effect': 'warn',
-      'react-hooks/purity': 'warn',
-      'react-hooks/refs': 'warn',
-      'react-hooks/immutability': 'warn',
+      'react-hooks/set-state-in-effect': 'error',
+      'react-hooks/purity': 'error',
+      'react-hooks/refs': 'error',
+      'react-hooks/immutability': 'error',
 
       /**
        * Import sorting
@@ -235,9 +234,8 @@ export default defineConfig(
         },
       ],
       /**
-       * Maintain previous behavior - these are stricter in typescript-eslint
-       * v8 `warn` ones are probably worth fixing. `off` ones are a bit too
-       * nit-picky
+       * Maintain previous behavior via eslint-suppressions.json - these are
+       * stricter in typescript-eslint v8. `off` ones are a bit too nit-picky.
        */
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/ban-ts-comment': 'off',
@@ -247,18 +245,18 @@ export default defineConfig(
       '@typescript-eslint/unbound-method': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'warn',
-      '@typescript-eslint/no-unsafe-call': 'warn',
-      '@typescript-eslint/no-floating-promises': 'warn',
-      '@typescript-eslint/no-misused-promises': 'warn',
-      '@typescript-eslint/require-await': 'warn',
-      '@typescript-eslint/no-unsafe-enum-comparison': 'warn',
-      '@typescript-eslint/no-unnecessary-type-assertion': 'warn',
-      '@typescript-eslint/no-redundant-type-constituents': 'warn',
-      '@typescript-eslint/no-duplicate-type-constituents': 'warn',
-      '@typescript-eslint/no-base-to-string': 'warn',
-      '@typescript-eslint/prefer-promise-reject-errors': 'warn',
-      '@typescript-eslint/await-thenable': 'warn',
+      '@typescript-eslint/no-unsafe-member-access': 'error',
+      '@typescript-eslint/no-unsafe-call': 'error',
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/require-await': 'error',
+      '@typescript-eslint/no-unsafe-enum-comparison': 'error',
+      '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+      '@typescript-eslint/no-redundant-type-constituents': 'error',
+      '@typescript-eslint/no-duplicate-type-constituents': 'error',
+      '@typescript-eslint/no-base-to-string': 'error',
+      '@typescript-eslint/prefer-promise-reject-errors': 'error',
+      '@typescript-eslint/await-thenable': 'error',
 
       'no-restricted-imports': [
         'error',

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -8,8 +8,10 @@ import {
   type UninheritableButtonProps,
 } from '#/components/Button'
 import {CircleCheck_Stroke2_Corner0_Rounded as CircleCheck} from '#/components/icons/CircleCheck'
-import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
-import {CircleInfo_Stroke2_Corner0_Rounded as ErrorIcon} from '#/components/icons/CircleInfo'
+import {
+  CircleInfo_Stroke2_Corner0_Rounded as CircleInfo,
+  CircleInfo_Stroke2_Corner0_Rounded as ErrorIcon,
+} from '#/components/icons/CircleInfo'
 import {type Props as SVGIconProps} from '#/components/icons/common'
 import {Warning_Stroke2_Corner0_Rounded as WarningIcon} from '#/components/icons/Warning'
 import {dismiss} from '#/components/Toast/sonner'

--- a/src/lib/hooks/useTimeAgo.ts
+++ b/src/lib/hooks/useTimeAgo.ts
@@ -58,12 +58,12 @@ export function dateDiff(
   if (diffSeconds < NOW) {
     diff = {
       value: 0,
-      unit: 'now' as DateDiff['unit'],
+      unit: 'now',
     }
   } else if (diffSeconds < MINUTE) {
     diff = {
       value: diffSeconds,
-      unit: 'second' as DateDiff['unit'],
+      unit: 'second',
     }
   } else if (diffSeconds < HOUR) {
     const value =
@@ -72,7 +72,7 @@ export function dateDiff(
         : Math.floor(diffSeconds / MINUTE)
     diff = {
       value,
-      unit: 'minute' as DateDiff['unit'],
+      unit: 'minute',
     }
   } else if (diffSeconds < DAY) {
     const value =
@@ -81,7 +81,7 @@ export function dateDiff(
         : Math.floor(diffSeconds / HOUR)
     diff = {
       value,
-      unit: 'hour' as DateDiff['unit'],
+      unit: 'hour',
     }
   } else if (diffSeconds < MONTH_30) {
     const value =
@@ -90,7 +90,7 @@ export function dateDiff(
         : Math.floor(diffSeconds / DAY)
     diff = {
       value,
-      unit: 'day' as DateDiff['unit'],
+      unit: 'day',
     }
   } else {
     const value =
@@ -99,7 +99,7 @@ export function dateDiff(
         : Math.floor(diffSeconds / MONTH_30)
     diff = {
       value,
-      unit: 'month' as DateDiff['unit'],
+      unit: 'month',
     }
   }
 

--- a/src/lib/routes/links.ts
+++ b/src/lib/routes/links.ts
@@ -19,8 +19,8 @@ export function makeProfileLink(
 export function makeCustomFeedLink(
   did: string,
   rkey: string,
-  segment?: string | undefined,
-  feedCacheKey?: 'discover' | 'explore' | undefined,
+  segment?: string,
+  feedCacheKey?: 'discover' | 'explore',
 ) {
   return (
     [`/profile`, did, 'feed', rkey, ...(segment ? [segment] : [])].join('/') +

--- a/src/screens/Settings/AppIconSettings/index.tsx
+++ b/src/screens/Settings/AppIconSettings/index.tsx
@@ -129,7 +129,7 @@ function getAppIconName(icon: string | false): DynamicAppIcon.IconName {
   if (!icon || icon === 'DEFAULT') {
     return 'default_light'
   } else {
-    return icon as DynamicAppIcon.IconName
+    return icon
   }
 }
 
@@ -151,7 +151,7 @@ function Group({
       values={[value]}
       maxSelections={1}
       onChange={vals => {
-        if (vals[0]) onChange(vals[0] as DynamicAppIcon.IconName)
+        if (vals[0]) onChange(vals[0])
       }}>
       <View style={[a.flex_1, a.rounded_md, a.overflow_hidden]}>
         {children}

--- a/src/screens/VideoFeed/components/Scrubber.tsx
+++ b/src/screens/VideoFeed/components/Scrubber.tsx
@@ -23,8 +23,7 @@ import {
 import {useEventListener} from 'expo'
 import {type VideoPlayer} from 'expo-video'
 
-import {tokens} from '#/alf'
-import {atoms as a} from '#/alf'
+import {atoms as a, tokens} from '#/alf'
 import {formatTime} from '#/components/Post/Embed/VideoEmbed/VideoEmbedInner/web-controls/utils'
 import {Text} from '#/components/Typography'
 

--- a/src/state/queries/notifications/feed.ts
+++ b/src/state/queries/notifications/feed.ts
@@ -298,7 +298,7 @@ export function* findAllPostsInQueryData(
         if (AppBskyFeedDefs.isPostView(item.subject)) {
           const quotedPost = getEmbeddedPost(item.subject?.embed)
           if (quotedPost && didOrHandleUriMatches(atUri, quotedPost)) {
-            yield embedViewRecordToPostView(quotedPost!)
+            yield embedViewRecordToPostView(quotedPost)
           }
         }
       }

--- a/src/state/queries/nuxs/util.ts
+++ b/src/state/queries/nuxs/util.ts
@@ -34,7 +34,7 @@ export function parseAppNux(nux: AppBskyActorDefs.Nux): AppNux | undefined {
 
 export function serializeAppNux(nux: AppNux): AppBskyActorDefs.Nux {
   const {data, ...rest} = nux
-  const schema = NuxSchemas[nux.id as Nux]
+  const schema = NuxSchemas[nux.id]
 
   const result: AppBskyActorDefs.Nux = {
     ...rest,

--- a/src/state/queries/suggested-follows.ts
+++ b/src/state/queries/suggested-follows.ts
@@ -85,7 +85,7 @@ export function useSuggestedFollowsByActorWithDismiss({
 
   const profiles = useMemo(() => {
     return (data?.suggestions ?? []).map(profile => ({
-      actor: profile as bsky.profile.AnyProfileView,
+      actor: profile,
       recId: data?.recId,
     }))
   }, [data?.suggestions, data?.recId])

--- a/src/state/queries/usePostThread/traversal.ts
+++ b/src/state/queries/usePostThread/traversal.ts
@@ -196,7 +196,7 @@ export function sortAndAnnotateThreadItems(
                    * `repliesSeenCounter` later on, since `repliesSeenCounter`
                    * is 1-indexed and `replyIndex` is 0-indexed.
                    */
-                  childMetadata!.replyIndex =
+                  childMetadata.replyIndex =
                     childParentMetadata.repliesSeenCounter
                 }
 

--- a/src/view/com/composer/drafts/state/api.ts
+++ b/src/view/com/composer/drafts/state/api.ts
@@ -470,11 +470,11 @@ export async function draftToComposerPosts(
               height,
               mime: 'image/jpeg',
             },
-          }
+          } satisfies ComposerImage
         })
 
         const images = (await Promise.all(imagePromises)).filter(
-          (img): img is ComposerImage => img !== null,
+          (img): img is NonNullable<typeof img> => img !== null,
         )
         if (images.length > 0) {
           embed.media = {type: 'images', images}

--- a/src/view/com/composer/drafts/state/api.ts
+++ b/src/view/com/composer/drafts/state/api.ts
@@ -470,7 +470,7 @@ export async function draftToComposerPosts(
               height,
               mime: 'image/jpeg',
             },
-          } as ComposerImage
+          }
         })
 
         const images = (await Promise.all(imagePromises)).filter(
@@ -511,7 +511,7 @@ export async function draftToComposerPosts(
                   tinygif: mediaObject,
                   preview: mediaObject,
                 },
-              } as Gif,
+              },
               alt: gifData.alt,
             }
             break

--- a/src/view/com/composer/photos/Gallery.tsx
+++ b/src/view/com/composer/photos/Gallery.tsx
@@ -187,7 +187,7 @@ const GalleryItem = ({
   return (
     <View
       ref={altBtnRef}
-      style={imageStyle as ViewStyle}
+      style={imageStyle}
       // Fixes ALT and icons appearing with half opacity when the post is inactive
       renderToHardwareTextureAndroid>
       <TouchableOpacity

--- a/src/view/com/testing/TestCtrls.e2e.tsx
+++ b/src/view/com/testing/TestCtrls.e2e.tsx
@@ -55,7 +55,7 @@ export function TestCtrls() {
         accessibilityLabel="Text input field"
         accessibilityHint="Enter proxy header"
         testID="e2eProxyHeaderInput"
-        onChangeText={val => setProxyHeader(val as any)}
+        onChangeText={val => setProxyHeader(val)}
         autoComplete="off"
         autoCorrect={false}
         autoCapitalize="none"

--- a/src/view/com/util/PressableWithHover.tsx
+++ b/src/view/com/util/PressableWithHover.tsx
@@ -3,9 +3,9 @@ import {
   Pressable,
   type PressableProps,
   type StyleProp,
+  type View,
   type ViewStyle,
 } from 'react-native'
-import {type View} from 'react-native'
 
 import {addStyle} from '#/lib/styles'
 import {useInteractionState} from '#/components/hooks/useInteractionState'

--- a/src/view/shell/createNativeStackNavigatorWithAuth.tsx
+++ b/src/view/shell/createNativeStackNavigatorWithAuth.tsx
@@ -171,7 +171,7 @@ function NativeStackNavigator({
     }
 
     // Evicted screens get a lightweight placeholder instead of their full tree
-    finalDescriptors = {} as typeof descriptors
+    finalDescriptors = {}
     for (const key in descriptors) {
       if (mountSet.has(key)) {
         finalDescriptors[key] = descriptors[key]


### PR DESCRIPTION
Addresses a TODO in our ESLint configuration by flipping some rules from `warn` to `error` while suppressing existing violations so they’re non-blocking (see #10383).

1. Changed `warn` to `error`
2. Removed TODOs
3. Ran `yarn lint --fix --suppress-all`