### PR TITLE
Remove KLIPY from external media settings

### DIFF
--- a/src/components/Post/Embed/ExternalEmbed/index.tsx
+++ b/src/components/Post/Embed/ExternalEmbed/index.tsx
@@ -8,7 +8,10 @@ import {useLingui} from '@lingui/react'
 import {parseAltFromGIFDescription} from '#/lib/gif-alt-text'
 import {useHaptics} from '#/lib/haptics'
 import {shareUrl} from '#/lib/sharing'
-import {parseEmbedPlayerFromUrl} from '#/lib/strings/embed-player'
+import {
+  exemptExternalEmbedSources,
+  parseEmbedPlayerFromUrl,
+} from '#/lib/strings/embed-player'
 import {toNiceDomain} from '#/lib/strings/url-helpers'
 import {useExternalEmbedsPrefs} from '#/state/preferences'
 import {atoms as a, useTheme} from '#/alf'
@@ -40,8 +43,9 @@ export const ExternalEmbed = ({
   const imageUri = link.thumb
   const embedPlayerParams = useMemo(() => {
     const params = parseEmbedPlayerFromUrl(link.uri)
-
-    if (params && externalEmbedPrefs?.[params.source] !== 'hide') {
+    if (!params) return
+    const canShow = externalEmbedPrefs?.[params.source] !== 'hide'
+    if (canShow || exemptExternalEmbedSources.has(params.source)) {
       return params
     }
   }, [link.uri, externalEmbedPrefs])

--- a/src/lib/strings/embed-player.ts
+++ b/src/lib/strings/embed-player.ts
@@ -65,6 +65,15 @@ export const externalEmbedLabels: Record<EmbedPlayerSource, string> = {
   bandcamp: 'Bandcamp',
 }
 
+/**
+ * These sources are proxied through our CDN and do not leak any user data,
+ * thus are safe to embed without a warning.
+ */
+export const exemptExternalEmbedSources = new Set<EmbedPlayerSource>([
+  'tenor',
+  'klipy',
+])
+
 export interface EmbedPlayerParams {
   type: EmbedPlayerType
   playerUri: string

--- a/src/screens/Settings/ExternalMediaPreferences.tsx
+++ b/src/screens/Settings/ExternalMediaPreferences.tsx
@@ -8,6 +8,7 @@ import {
 } from '#/lib/routes/types'
 import {
   type EmbedPlayerSource,
+  exemptExternalEmbedSources,
   externalEmbedLabels,
 } from '#/lib/strings/embed-player'
 import {
@@ -54,8 +55,10 @@ export function ExternalMediaPreferencesScreen({}: Props) {
             <View style={[a.mt_sm, a.w_full]}>
               {native(<SettingsList.Divider style={[a.my_0]} />)}
               {Object.entries(externalEmbedLabels)
-                // TODO: Remove special case when we disable the old integration.
-                .filter(([key]) => key !== 'tenor')
+                .filter(
+                  ([key]) =>
+                    !exemptExternalEmbedSources.has(key as EmbedPlayerSource),
+                )
                 .map(([key, label]) => (
                   <Fragment key={key}>
                     <PrefSelector


### PR DESCRIPTION
We missed that adding a new external embed source automatically added a settings toggle. Because we proxy KLIPY through our CDN, we aren't leaking PII and can remove this from the consent flow. We did the same thing for Tenor back in #3652.

This ensures that all users see GIFs from KLIPY presented using the default player instead of a static link card. Autoplay controls still apply.