### PR TITLE
Detect missing H.264/AAC codec support on web video

### DIFF
--- a/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/VideoEmbedInnerWeb.tsx
+++ b/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/VideoEmbedInnerWeb.tsx
@@ -103,6 +103,34 @@ export class HLSUnsupportedError extends Error {
   }
 }
 
+// Bluesky serves HLS as MPEG-TS with H.264 + AAC. `Hls.isSupported()` is loose
+// (true if MSE supports *any* of {H.264, AV1, VP9} OR *any* of {AAC, FLAC}),
+// so on Linux boxes missing H.264 (e.g. no ubuntu-restricted-extras, sandboxed
+// Firefox snap) it returns true and playback fails later on segment append.
+// Use Baseline 3.0 to match hls.js's own probe - it's the most universal H.264
+// profile, so if it isn't supported, no H.264 is.
+// Mirror hls.js's `getMediaSource` lookup (ManagedMediaSource on modern iOS,
+// then MediaSource, then WebKitMediaSource) so we probe the same constructor
+// it will actually use for playback.
+function canPlayBskyVideoCodecs(): boolean {
+  if (typeof self === 'undefined') return false
+  const globalSelf = self as typeof self & {
+    ManagedMediaSource?: typeof MediaSource
+    WebKitMediaSource?: typeof MediaSource
+  }
+  const mediaSource =
+    globalSelf.ManagedMediaSource ||
+    globalSelf.MediaSource ||
+    globalSelf.WebKitMediaSource
+  if (!mediaSource || typeof mediaSource.isTypeSupported !== 'function') {
+    return false
+  }
+  return (
+    mediaSource.isTypeSupported('video/mp4; codecs="avc1.42E01E"') &&
+    mediaSource.isTypeSupported('audio/mp4; codecs="mp4a.40.2"')
+  )
+}
+
 export class VideoNotFoundError extends Error {
   constructor() {
     super('Video not found')
@@ -228,7 +256,7 @@ function useHLS({
   useEffect(() => {
     if (!videoRef.current) return
     if (!Hls) return
-    if (!Hls.isSupported()) {
+    if (!Hls.isSupported() || !canPlayBskyVideoCodecs()) {
       throw new HLSUnsupportedError()
     }
 

--- a/src/components/Post/Embed/VideoEmbed/index.web.tsx
+++ b/src/components/Post/Embed/VideoEmbed/index.web.tsx
@@ -233,7 +233,7 @@ function VideoError({error, retry}: {error: unknown; retry: () => void}) {
   } else if (error instanceof HLSUnsupportedError) {
     showRetryButton = false
     text = _(
-      msg`Your browser does not support the video format. Please try a different browser.`,
+      msg`This video can’t be played on your device. Your browser or system may be missing the required video codecs (H.264/AAC).`,
     )
   } else {
     text = _(msg`An error occurred while loading the video. Please try again.`)


### PR DESCRIPTION
## Summary

- `Hls.isSupported()` passes if MSE supports **any** of `{H.264, AV1, VP9}` *or* **any** of `{AAC, FLAC}` (see `node_modules/hls.js/src/is-supported.ts`). Linux boxes without H.264 (e.g. Ubuntu without `ubuntu-restricted-extras`, sandboxed Firefox snap) often have VP9/Opus, so `isSupported()` returns true, hls.js attaches, and playback fails on the first segment append.
- The user then sees the generic "An error occurred while loading the video. Please try again." with a Retry button that does nothing.
- This PR probes `MediaSource.isTypeSupported` directly for `avc1.42E01E` (H.264 Baseline 3.0, the same string hls.js uses for its own probe) and `mp4a.40.2` (AAC-LC), which are the codecs our video service actually serves (confirmed via `ffprobe` on a 360p segment).
- Mirrors hls.js's `getMediaSource` lookup chain (`ManagedMediaSource` → `MediaSource` → `WebKitMediaSource`) so iOS Safari isn't a false negative.
- Updates the `HLSUnsupportedError` copy to point at the system layer rather than telling users to switch browsers, which is bad advice on Linux.

Reported by a user who switched from Windows 10 to Ubuntu Studio 26.04 and lost video playback across Firefox / Opera / Chrome.

## Test plan

- [ ] Verify on a normally-functioning browser (macOS / Windows Chrome, Firefox, Safari) that video playback still works.
- [ ] Verify on iOS Safari that videos still play (this is the `ManagedMediaSource` path).
- [ ] In DevTools, run `MediaSource.isTypeSupported('video/mp4; codecs="avc1.42E01E"')` and confirm `true` on a healthy machine.
- [ ] Simulate a missing-codec environment (Firefox with `media.mediasource.h264.enabled` = false in `about:config`) and confirm the new "missing codecs" message renders without a Retry button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)