### PR TITLE
Fix unnecessary scrollbars on web

### DIFF
--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -340,7 +340,9 @@ function ListImpl<ItemT>(
           ref={containerRef}
           style={[
             contentContainerStyle,
-            desktopFixedHeight ? styles.minHeightViewport : null,
+            desktopFixedHeight && !disableFullWindowScroll
+              ? styles.minHeightViewport
+              : null,
           ]}>
           <Visibility
             root={disableFullWindowScroll ? nativeRef : null}


### PR DESCRIPTION
Fixes an issue where `List` components on web always displayed a vertical scrollbar, even when content didn’t require one.

I poked around a bit but this one needs some smoke testing to ensure nothing regressed.

| Before | After |
| - | - |
| <img width="1166" height="1006" alt="before" src="https://github.com/user-attachments/assets/b3e0bac9-08f4-4dd5-ad42-4995ea14d13e" /> | <img width="1177" height="1007" alt="after" src="https://github.com/user-attachments/assets/e06abd63-34ea-4cca-b164-83035a418b5d" /> |