### PR TITLE
 Fix links, mentions, and tags not rendering in composer reply-to preview

### DIFF
--- a/src/screens/PostThread/components/ThreadItemAnchor.tsx
+++ b/src/screens/PostThread/components/ThreadItemAnchor.tsx
@@ -253,6 +253,7 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
         uri: post.uri,
         cid: post.cid,
         text: record.text,
+        facets: record.facets,
         author: post.author,
         embed: post.embed,
         moderation,

--- a/src/screens/PostThread/components/ThreadItemPost.tsx
+++ b/src/screens/PostThread/components/ThreadItemPost.tsx
@@ -238,6 +238,7 @@ const ThreadItemPostInner = memo(function ThreadItemPostInner({
         uri: post.uri,
         cid: post.cid,
         text: record.text,
+        facets: record.facets,
         author: post.author,
         embed: post.embed,
         moderation,

--- a/src/screens/PostThread/components/ThreadItemTreePost.tsx
+++ b/src/screens/PostThread/components/ThreadItemTreePost.tsx
@@ -300,6 +300,7 @@ const ThreadItemTreePostInner = memo(function ThreadItemTreePostInner({
         uri: post.uri,
         cid: post.cid,
         text: record.text,
+        facets: record.facets,
         author: post.author,
         embed: post.embed,
         moderation,

--- a/src/screens/PostThread/index.tsx
+++ b/src/screens/PostThread/index.tsx
@@ -127,6 +127,7 @@ export function PostThread({uri}: {uri: string}) {
         uri: anchor.uri,
         cid: post.cid,
         text: post.record.text,
+        facets: post.record.facets,
         author: post.author,
         embed: post.embed,
         moderation: anchor.moderation,

--- a/src/screens/VideoFeed/index.tsx
+++ b/src/screens/VideoFeed/index.tsx
@@ -769,6 +769,7 @@ function Overlay({
         uri: post.uri,
         cid: post.cid,
         text: record?.text || '',
+        facets: record?.facets,
         author: post.author,
         embed: post.embed,
         langs: record?.langs,

--- a/src/state/shell/composer/index.tsx
+++ b/src/state/shell/composer/index.tsx
@@ -2,6 +2,7 @@ import {createContext, useContext, useMemo, useState} from 'react'
 import {
   type AppBskyActorDefs,
   type AppBskyFeedDefs,
+  type AppBskyRichtextFacet,
   type AppBskyUnspeccedGetPostThreadV2,
   type ModerationDecision,
 } from '@atproto/api'
@@ -23,6 +24,7 @@ export interface ComposerOptsPostRef {
   uri: string
   cid: string
   text: string
+  facets?: AppBskyRichtextFacet.Main[]
   langs?: string[]
   author: AppBskyActorDefs.ProfileViewBasic
   embed?: AppBskyFeedDefs.PostView['embed']

--- a/src/view/com/composer/ComposerReplyTo.tsx
+++ b/src/view/com/composer/ComposerReplyTo.tsx
@@ -6,6 +6,7 @@ import {
   AppBskyEmbedRecord,
   AppBskyEmbedRecordWithMedia,
   AppBskyFeedPost,
+  RichText as RichTextAPI,
 } from '@atproto/api'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
@@ -17,6 +18,7 @@ import {PreviewableUserAvatar} from '#/view/com/util/UserAvatar'
 import {atoms as a, useTheme, web} from '#/alf'
 import {QuoteEmbed} from '#/components/Post/Embed'
 import {ProfileBadges} from '#/components/ProfileBadges'
+import {RichText} from '#/components/RichText'
 import {Text} from '#/components/Typography'
 import {parseEmbed} from '#/types/bsky/post'
 
@@ -24,6 +26,14 @@ export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
   const t = useTheme()
   const {_} = useLingui()
   const {embed} = replyTo
+
+  const richText = useMemo(() => {
+    const rt = new RichTextAPI({text: replyTo.text, facets: replyTo.facets})
+    if (!replyTo.facets) {
+      rt.detectFacetsWithoutResolution()
+    }
+    return rt
+  }, [replyTo.text, replyTo.facets])
 
   const [showFull, setShowFull] = useState(false)
 
@@ -110,12 +120,14 @@ export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
         </View>
         <View style={[a.flex_row, a.gap_md]}>
           <View style={[a.flex_1, a.flex_grow]}>
-            <Text
-              style={[a.text_md, a.leading_snug, t.atoms.text_contrast_high]}
+            <RichText
+              value={richText}
+              style={[a.text_md]}
               numberOfLines={!showFull ? 6 : undefined}
-              emoji>
-              {replyTo.text}
-            </Text>
+              enableTags
+              disableMentionFacetValidation
+              authorHandle={replyTo.author.handle}
+            />
           </View>
           {images && !replyTo.moderation?.ui('contentMedia').blur && (
             <ComposerReplyToImages images={images} showFull={showFull} />

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -136,6 +136,7 @@ function PostInner({
         uri: post.uri,
         cid: post.cid,
         text: record.text,
+        facets: record.facets,
         author: post.author,
         embed: post.embed,
         moderation,

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -191,6 +191,7 @@ let FeedItemInner = ({
         uri: post.uri,
         cid: post.cid,
         text: record.text || '',
+        facets: record.facets,
         author: post.author,
         embed: post.embed,
         moderation,


### PR DESCRIPTION
The reply-to preview in the composer rendered post text as plain text, so links, mentions, and hashtags appeared unstyled and weren't interactive.

The change is pretty small, the plain `<Text>` was jsut replaced with `RichText` (passing through the post facets)

Before: 
<img width="802" height="546" alt="image" src="https://github.com/user-attachments/assets/17762a5d-5104-4d92-80dc-1a65ad240985" />

After:
<img width="802" height="546" alt="image" src="https://github.com/user-attachments/assets/e7980be8-ab2c-40b1-af71-8c90c9d28abb" />
