### PR TITLE
Expand muted words to more surfaces

### DIFF
--- a/src/components/dialogs/MutedWords.tsx
+++ b/src/components/dialogs/MutedWords.tsx
@@ -28,7 +28,9 @@ import * as Toggle from '#/components/forms/Toggle'
 import {useFormatDistance} from '#/components/hooks/dates'
 import {Hashtag_Stroke2_Corner0_Rounded as Hashtag} from '#/components/icons/Hashtag'
 import {PageText_Stroke2_Corner0_Rounded as PageText} from '#/components/icons/PageText'
+import {Person_Stroke2_Corner0_Rounded as Person} from '#/components/icons/Person'
 import {PlusLarge_Stroke2_Corner0_Rounded as Plus} from '#/components/icons/Plus'
+import {OpenQuote_Stroke2_Corner0_Rounded as Quote} from '#/components/icons/Quote'
 import {TimesLarge_Stroke2_Corner0_Rounded as X} from '#/components/icons/Times'
 import {Loader} from '#/components/Loader'
 import * as Menu from '#/components/Menu'
@@ -66,9 +68,12 @@ function MutedWordsInner() {
 
   const submit = useCallback(async () => {
     const sanitizedValue = sanitizeMutedWordValue(field)
-    const surfaces = ['tag', targets.includes('content') && 'content'].filter(
-      Boolean,
-    ) as AppBskyActorDefs.MutedWord['targets']
+    const surfaceSet = new Set(
+      targets.filter(t => ['content', 'tag', 'profiles', 'embeds'].includes(t)),
+    )
+    // 'Text & tags' (content) always implies tags
+    if (surfaceSet.has('content')) surfaceSet.add('tag')
+    const surfaces = [...surfaceSet] as AppBskyActorDefs.MutedWord['targets']
     const actorTarget = excludeFollowing ? 'exclude-following' : 'all'
 
     const now = Date.now()
@@ -121,9 +126,10 @@ function MutedWordsInner() {
         </Text>
         <Text style={[a.pb_lg, a.leading_snug, t.atoms.text_contrast_medium]}>
           <Trans>
-            Posts can be muted based on their text, their tags, or both. We
-            recommend avoiding common words that appear in many posts, since it
-            can result in no posts being shown.
+            Choose which surfaces to mute this word in. "Profiles" covers
+            display names, bios, and image alt text. We recommend avoiding
+            common words that appear in many posts, since it can result in no
+            posts being shown.
           </Trans>
         </Text>
 
@@ -248,8 +254,8 @@ function MutedWordsInner() {
           </Toggle.Group>
 
           <Toggle.Group
-            label={_(msg`Select what content this mute word should apply to.`)}
-            type="radio"
+            label={_(msg`Select where this mute word should apply.`)}
+            type="checkbox"
             values={targets}
             onChange={setTargets}>
             <Text
@@ -262,38 +268,92 @@ function MutedWordsInner() {
               <Trans>Mute in:</Trans>
             </Text>
 
-            <View style={[a.flex_row, a.align_center, a.gap_sm, a.flex_wrap]}>
-              <Toggle.Item
-                label={_(msg`Mute this word in post text and tags`)}
-                name="content"
-                style={[a.flex_1]}>
-                <TargetToggle>
-                  <View
-                    style={[a.flex_1, a.flex_row, a.align_center, a.gap_sm]}>
-                    <Toggle.Radio />
-                    <Toggle.LabelText style={[a.flex_1, a.leading_tight]}>
-                      <Trans>Text & tags</Trans>
-                    </Toggle.LabelText>
-                  </View>
-                  <PageText size="sm" />
-                </TargetToggle>
-              </Toggle.Item>
+            <View
+              style={[
+                gtMobile && [a.flex_row, a.align_center, a.justify_start],
+                a.gap_sm,
+              ]}>
+              <View
+                style={[
+                  a.flex_1,
+                  a.flex_row,
+                  a.justify_start,
+                  a.align_center,
+                  a.gap_sm,
+                ]}>
+                <Toggle.Item
+                  label={_(msg`Mute this word in post text and tags`)}
+                  name="content"
+                  style={[a.flex_1]}>
+                  <TargetToggle>
+                    <View
+                      style={[a.flex_1, a.flex_row, a.align_center, a.gap_sm]}>
+                      <Toggle.Checkbox />
+                      <Toggle.LabelText style={[a.flex_1, a.leading_tight]}>
+                        <Trans>Text & Tags</Trans>
+                      </Toggle.LabelText>
+                    </View>
+                    <PageText size="sm" />
+                  </TargetToggle>
+                </Toggle.Item>
 
-              <Toggle.Item
-                label={_(msg`Mute this word in tags only`)}
-                name="tag"
-                style={[a.flex_1]}>
-                <TargetToggle>
-                  <View
-                    style={[a.flex_1, a.flex_row, a.align_center, a.gap_sm]}>
-                    <Toggle.Radio />
-                    <Toggle.LabelText style={[a.flex_1, a.leading_tight]}>
-                      <Trans>Tags only</Trans>
-                    </Toggle.LabelText>
-                  </View>
-                  <Hashtag size="sm" />
-                </TargetToggle>
-              </Toggle.Item>
+                <Toggle.Item
+                  label={_(msg`Mute this word in tags`)}
+                  name="tag"
+                  style={[a.flex_1]}>
+                  <TargetToggle>
+                    <View
+                      style={[a.flex_1, a.flex_row, a.align_center, a.gap_sm]}>
+                      <Toggle.Checkbox />
+                      <Toggle.LabelText style={[a.flex_1, a.leading_tight]}>
+                        <Trans>Tags</Trans>
+                      </Toggle.LabelText>
+                    </View>
+                    <Hashtag size="sm" />
+                  </TargetToggle>
+                </Toggle.Item>
+              </View>
+
+              <View
+                style={[
+                  a.flex_1,
+                  a.flex_row,
+                  a.justify_start,
+                  a.align_center,
+                  a.gap_sm,
+                ]}>
+                <Toggle.Item
+                  label={_(msg`Mute this word in display names and bios`)}
+                  name="profiles"
+                  style={[a.flex_1]}>
+                  <TargetToggle>
+                    <View
+                      style={[a.flex_1, a.flex_row, a.align_center, a.gap_sm]}>
+                      <Toggle.Checkbox />
+                      <Toggle.LabelText style={[a.flex_1, a.leading_tight]}>
+                        <Trans>Profiles</Trans>
+                      </Toggle.LabelText>
+                    </View>
+                    <Person size="sm" />
+                  </TargetToggle>
+                </Toggle.Item>
+
+                <Toggle.Item
+                  label={_(msg`Mute this word in quoted posts`)}
+                  name="embeds"
+                  style={[a.flex_1]}>
+                  <TargetToggle>
+                    <View
+                      style={[a.flex_1, a.flex_row, a.align_center, a.gap_sm]}>
+                      <Toggle.Checkbox />
+                      <Toggle.LabelText style={[a.flex_1, a.leading_tight]}>
+                        <Trans>Quoted posts</Trans>
+                      </Toggle.LabelText>
+                    </View>
+                    <Quote size="sm" />
+                  </TargetToggle>
+                </Toggle.Item>
+              </View>
             </View>
           </Toggle.Group>
 
@@ -480,29 +540,38 @@ function MutedWordRow({
                   wordBreak: 'break-word',
                 }),
               ]}>
-              {word.targets.find(t => t === 'content') ? (
-                <Trans comment="Pattern: {wordValue} in text, tags">
-                  {word.value}{' '}
-                  <Text style={[a.font_normal, t.atoms.text_contrast_medium]}>
-                    in{' '}
-                    <Text
-                      style={[a.font_semi_bold, t.atoms.text_contrast_medium]}>
-                      text & tags
+              {(() => {
+                const surfaces: string[] = []
+                if (word.targets.includes('content')) {
+                  surfaces.push('Text & Tags')
+                } else if (word.targets.includes('tag')) {
+                  surfaces.push('tags')
+                }
+                // 'content' implies profiles for backward compat
+                if (
+                  word.targets.includes('profiles') ||
+                  word.targets.includes('content')
+                )
+                  surfaces.push('profiles')
+                if (word.targets.includes('embeds'))
+                  surfaces.push('quoted posts')
+                const label = surfaces.join(', ').replace(/, ([^,]*)$/, ' & $1')
+                return (
+                  <Trans comment="Pattern: {wordValue} in {surfaces}">
+                    {word.value}{' '}
+                    <Text style={[a.font_normal, t.atoms.text_contrast_medium]}>
+                      in{' '}
+                      <Text
+                        style={[
+                          a.font_semi_bold,
+                          t.atoms.text_contrast_medium,
+                        ]}>
+                        {label}
+                      </Text>
                     </Text>
-                  </Text>
-                </Trans>
-              ) : (
-                <Trans comment="Pattern: {wordValue} in tags">
-                  {word.value}{' '}
-                  <Text style={[a.font_normal, t.atoms.text_contrast_medium]}>
-                    in{' '}
-                    <Text
-                      style={[a.font_semi_bold, t.atoms.text_contrast_medium]}>
-                      tags
-                    </Text>
-                  </Text>
-                </Trans>
-              )}
+                  </Trans>
+                )
+              })()}
             </Text>
           </View>
 

--- a/src/lib/moderation.ts
+++ b/src/lib/moderation.ts
@@ -1,5 +1,11 @@
 import {useMemo} from 'react'
 import {
+  type AppBskyActorDefs,
+  AppBskyEmbedImages,
+  AppBskyEmbedRecord,
+  AppBskyEmbedRecordWithMedia,
+  type AppBskyFeedDefs,
+  type AppBskyFeedPost,
   type AppBskyLabelerDefs,
   BskyAgent,
   type ComAtprotoLabelDefs,
@@ -151,4 +157,173 @@ export function unique(
       item => getModerationCauseKey(item) === getModerationCauseKey(value),
     ) === index
   )
+}
+
+function getActiveMutedWords(
+  mutedWords: AppBskyActorDefs.MutedWord[],
+  viewer: {following?: string} | undefined,
+  now: Date,
+  target: string,
+): string[] {
+  return mutedWords
+    .filter(
+      w =>
+        !(w.expiresAt && new Date(w.expiresAt) < now) &&
+        !(w.actorTarget === 'exclude-following' && viewer?.following) &&
+        w.targets.includes(target),
+    )
+    .map(w => w.value.toLowerCase())
+}
+
+// For backward compat: words saved before the 'profiles' target existed used
+// 'content' to cover both post text and profile name/bio/alt filtering.
+function getActiveMutedContentWords(
+  mutedWords: AppBskyActorDefs.MutedWord[],
+  viewer: {following?: string} | undefined,
+  now: Date,
+): string[] {
+  return getActiveMutedWords(mutedWords, viewer, now, 'content')
+}
+
+function getActiveMutedProfileWords(
+  mutedWords: AppBskyActorDefs.MutedWord[],
+  viewer: {following?: string} | undefined,
+  now: Date,
+): string[] {
+  // Include 'content' words for backward compat with words saved before the
+  // explicit 'profiles' target was introduced.
+  const byProfile = getActiveMutedWords(mutedWords, viewer, now, 'profiles')
+  const byContent = getActiveMutedWords(mutedWords, viewer, now, 'content')
+  return [...new Set([...byProfile, ...byContent])]
+}
+
+export function hasMutedWordInText({
+  mutedWords,
+  text,
+  author,
+}: {
+  mutedWords: AppBskyActorDefs.MutedWord[]
+  text: string
+  author?: {viewer?: {following?: string}}
+}): boolean {
+  if (!mutedWords.length || !text) return false
+  const lowerText = text.toLowerCase()
+  const active = getActiveMutedContentWords(
+    mutedWords,
+    author?.viewer,
+    new Date(),
+  )
+  return active.some(v => lowerText.includes(v))
+}
+
+export function hasMutedWordInAuthorName({
+  mutedWords,
+  author,
+}: {
+  mutedWords: AppBskyActorDefs.MutedWord[]
+  author: {
+    displayName?: string
+    description?: string
+    viewer?: {following?: string}
+  }
+}): boolean {
+  if (!mutedWords.length) return false
+  const displayName = author.displayName?.toLowerCase() ?? ''
+  const description = author.description?.toLowerCase() ?? ''
+  if (!displayName && !description) return false
+  const active = getActiveMutedProfileWords(
+    mutedWords,
+    author.viewer,
+    new Date(),
+  )
+  return active.some(v => displayName.includes(v) || description.includes(v))
+}
+
+export function hasMutedWordInPostAltText({
+  mutedWords,
+  post,
+}: {
+  mutedWords: AppBskyActorDefs.MutedWord[]
+  post: AppBskyFeedDefs.PostView
+}): boolean {
+  if (!mutedWords.length) return false
+  const {embed} = post
+  if (!embed) return false
+  const active = getActiveMutedProfileWords(
+    mutedWords,
+    post.author.viewer,
+    new Date(),
+  )
+  if (!active.length) return false
+  const matchesAlt = (alt: string) => {
+    const lower = alt.toLowerCase()
+    return active.some(v => lower.includes(v))
+  }
+  if (AppBskyEmbedImages.isView(embed)) {
+    return embed.images.some(img => img.alt && matchesAlt(img.alt))
+  }
+  if (
+    AppBskyEmbedRecordWithMedia.isView(embed) &&
+    AppBskyEmbedImages.isView(embed.media)
+  ) {
+    return embed.media.images.some(img => img.alt && matchesAlt(img.alt))
+  }
+  return false
+}
+
+export function hasMutedWordInEmbeddedPost({
+  mutedWords,
+  post,
+}: {
+  mutedWords: AppBskyActorDefs.MutedWord[]
+  post: AppBskyFeedDefs.PostView
+}): boolean {
+  if (!mutedWords.length) return false
+  const {embed} = post
+  if (!embed) return false
+  // Get non-expired 'embeds' words without applying exclude-following yet,
+  // since we need to check it against the embedded post's author, not the
+  // outer (quoting) post's author.
+  const now = new Date()
+  const candidates = mutedWords.filter(
+    w =>
+      !(w.expiresAt && new Date(w.expiresAt) < now) &&
+      w.targets.includes('embeds'),
+  )
+  if (!candidates.length) return false
+
+  const checkViewRecord = (record: AppBskyEmbedRecord.ViewRecord): boolean => {
+    // Apply exclude-following based on the embedded post's author.
+    const active = candidates
+      .filter(
+        w =>
+          !(
+            w.actorTarget === 'exclude-following' &&
+            record.author.viewer?.following
+          ),
+      )
+      .map(w => w.value.toLowerCase())
+    if (!active.length) return false
+    const text = (record.value as AppBskyFeedPost.Record)?.text ?? ''
+    if (text) {
+      const lowerText = text.toLowerCase()
+      if (active.some(v => lowerText.includes(v))) return true
+    }
+    const displayName = record.author.displayName?.toLowerCase() ?? ''
+    return displayName ? active.some(v => displayName.includes(v)) : false
+  }
+
+  if (AppBskyEmbedRecord.isView(embed)) {
+    return (
+      AppBskyEmbedRecord.isViewRecord(embed.record) &&
+      checkViewRecord(embed.record)
+    )
+  }
+  if (AppBskyEmbedRecordWithMedia.isView(embed)) {
+    return (
+      AppBskyEmbedRecord.isViewRecord(embed.record.record) &&
+      checkViewRecord(embed.record.record)
+    )
+  }
+  return false
 }

--- a/src/state/queries/actor-search.ts
+++ b/src/state/queries/actor-search.ts
@@ -1,4 +1,7 @@
-import {type AppBskyActorSearchActors} from '@atproto/api'
+import {
+  type AppBskyActorDefs,
+  type AppBskyActorSearchActors,
+} from '@atproto/api'
 import {
   type InfiniteData,
   keepPreviousData,
@@ -7,6 +10,8 @@ import {
   useInfiniteQuery,
 } from '@tanstack/react-query'
 
+import {hasMutedWordInAuthorName} from '#/lib/moderation'
+import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {STALE} from '#/state/queries'
 import {useAgent} from '#/state/session'
 
@@ -29,6 +34,9 @@ export function useActorSearch({
   limit?: number
 }) {
   const agent = useAgent()
+  const moderationOpts = useModerationOpts()
+  const mutedWords = moderationOpts?.prefs.mutedWords ?? []
+
   return useInfiniteQuery<
     AppBskyActorSearchActors.OutputSchema,
     Error,
@@ -50,12 +58,15 @@ export function useActorSearch({
     initialPageParam: undefined,
     getNextPageParam: lastPage => lastPage.cursor,
     placeholderData: maintainData ? keepPreviousData : undefined,
-    select,
+    select: data => selectActors(data, mutedWords),
   })
 }
 
-function select(data: InfiniteData<AppBskyActorSearchActors.OutputSchema>) {
-  // enforce uniqueness
+function selectActors(
+  data: InfiniteData<AppBskyActorSearchActors.OutputSchema>,
+  mutedWords: AppBskyActorDefs.MutedWord[],
+) {
+  // enforce uniqueness and filter muted display names
   const dids = new Set()
 
   return {
@@ -66,6 +77,9 @@ function select(data: InfiniteData<AppBskyActorSearchActors.OutputSchema>) {
           return false
         }
         dids.add(actor.did)
+        if (hasMutedWordInAuthorName({mutedWords, author: actor})) {
+          return false
+        }
         return true
       }),
     })),

--- a/src/state/queries/explore-feed-previews.tsx
+++ b/src/state/queries/explore-feed-previews.tsx
@@ -2,6 +2,7 @@ import {useMemo, useRef} from 'react'
 import {
   type AppBskyActorDefs,
   AppBskyFeedDefs,
+  type AppBskyFeedPost,
   AtUri,
   moderatePost,
 } from '@atproto/api'
@@ -16,6 +17,12 @@ import {
 import {CustomFeedAPI} from '#/lib/api/feed/custom'
 import {aggregateUserInterests} from '#/lib/api/feed/utils'
 import {FeedTuner} from '#/lib/api/feed-manip'
+import {
+  hasMutedWordInAuthorName,
+  hasMutedWordInEmbeddedPost,
+  hasMutedWordInPostAltText,
+  hasMutedWordInText,
+} from '#/lib/moderation'
 import {cleanError} from '#/lib/strings/errors'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {
@@ -211,8 +218,35 @@ export function useFeedPreviews(
               )
 
               // apply moderation filters
-              item.items = item.items.filter((_, i) => {
-                return !moderations[i]?.ui('contentList').filter
+              const mutedWords = moderationOpts!.prefs.mutedWords
+              item.items = item.items.filter((sliceItem, i) => {
+                if (moderations[i]?.ui('contentList').filter) return false
+                if (
+                  hasMutedWordInAuthorName({
+                    mutedWords,
+                    author: sliceItem.post.author,
+                  })
+                )
+                  return false
+                if (
+                  hasMutedWordInText({
+                    mutedWords,
+                    text:
+                      (sliceItem.post.record as AppBskyFeedPost.Record)?.text ??
+                      '',
+                    author: sliceItem.post.author,
+                  })
+                )
+                  return false
+                if (
+                  hasMutedWordInPostAltText({mutedWords, post: sliceItem.post})
+                )
+                  return false
+                if (
+                  hasMutedWordInEmbeddedPost({mutedWords, post: sliceItem.post})
+                )
+                  return false
+                return true
               })
 
               const slice = {

--- a/src/state/queries/feed.ts
+++ b/src/state/queries/feed.ts
@@ -20,6 +20,7 @@ import {
 } from '@tanstack/react-query'
 
 import {DISCOVER_FEED_URI, DISCOVER_SAVED_FEED} from '#/lib/constants'
+import {hasMutedWordInAuthorName} from '#/lib/moderation'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {GCTIME, STALE} from '#/state/queries'
@@ -376,9 +377,21 @@ export function usePopularFeedsSearch({
     },
     placeholderData: keepPreviousData,
     select(data) {
+      const mutedWords = moderationOpts!.prefs.mutedWords
       return data.filter(feed => {
         const decision = moderateFeedGenerator(feed, moderationOpts!)
-        return !decision.ui('contentMedia').blur
+        if (decision.ui('contentMedia').blur) return false
+        if (
+          hasMutedWordInAuthorName({
+            mutedWords,
+            author: {
+              displayName: feed.displayName,
+              description: feed.description,
+            },
+          })
+        )
+          return false
+        return true
       })
     },
   })

--- a/src/state/queries/notifications/util.ts
+++ b/src/state/queries/notifications/util.ts
@@ -14,7 +14,10 @@ import {
 import {type QueryClient} from '@tanstack/react-query'
 import chunk from 'lodash.chunk'
 
-import {labelIsHideableOffense} from '#/lib/moderation'
+import {
+  hasMutedWordInAuthorName,
+  labelIsHideableOffense,
+} from '#/lib/moderation'
 import * as bsky from '#/types/bsky'
 import {precacheProfile} from '../profile'
 import {
@@ -132,14 +135,18 @@ export function shouldFilterNotif(
       notif.record,
       AppBskyFeedPost.isRecord,
     ) &&
-    hasMutedWord({
+    (hasMutedWord({
       mutedWords: moderationOpts.prefs.mutedWords,
       text: notif.record.text,
       facets: notif.record.facets,
       outlineTags: notif.record.tags,
       languages: notif.record.langs,
       actor: notif.author,
-    })
+    }) ||
+      hasMutedWordInAuthorName({
+        mutedWords: moderationOpts.prefs.mutedWords,
+        author: notif.author,
+      }))
   ) {
     return true
   }

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -30,6 +30,12 @@ import {type FeedAPI, type ReasonFeedSource} from '#/lib/api/feed/types'
 import {aggregateUserInterests} from '#/lib/api/feed/utils'
 import {FeedTuner, type FeedTunerFn} from '#/lib/api/feed-manip'
 import {DISCOVER_FEED_URI} from '#/lib/constants'
+import {
+  hasMutedWordInAuthorName,
+  hasMutedWordInEmbeddedPost,
+  hasMutedWordInPostAltText,
+  hasMutedWordInText,
+} from '#/lib/moderation'
 import {logger} from '#/logger'
 import {STALE} from '#/state/queries'
 import {DEFAULT_LOGGED_OUT_PREFERENCES} from '#/state/queries/preferences/const'
@@ -292,6 +298,7 @@ export function usePostFeedQuery(
                   )
 
                   // apply moderation filter
+                  const mutedWords = moderationOpts!.prefs.mutedWords
                   for (let i = 0; i < slice.items.length; i++) {
                     const ignoreFilter =
                       slice.items[i].post.author.did === ignoreFilterFor
@@ -304,6 +311,45 @@ export function usePostFeedQuery(
                     if (
                       !ignoreFilter &&
                       moderations[i]?.ui('contentList').filter
+                    ) {
+                      return undefined
+                    }
+                    if (
+                      !ignoreFilter &&
+                      hasMutedWordInAuthorName({
+                        mutedWords,
+                        author: slice.items[i].post.author,
+                      })
+                    ) {
+                      return undefined
+                    }
+                    if (
+                      !ignoreFilter &&
+                      hasMutedWordInText({
+                        mutedWords,
+                        text:
+                          (slice.items[i].post.record as AppBskyFeedPost.Record)
+                            ?.text ?? '',
+                        author: slice.items[i].post.author,
+                      })
+                    ) {
+                      return undefined
+                    }
+                    if (
+                      !ignoreFilter &&
+                      hasMutedWordInPostAltText({
+                        mutedWords,
+                        post: slice.items[i].post,
+                      })
+                    ) {
+                      return undefined
+                    }
+                    if (
+                      !ignoreFilter &&
+                      hasMutedWordInEmbeddedPost({
+                        mutedWords,
+                        post: slice.items[i].post,
+                      })
                     ) {
                       return undefined
                     }

--- a/src/state/queries/search-posts.ts
+++ b/src/state/queries/search-posts.ts
@@ -2,6 +2,7 @@ import {useCallback, useMemo, useRef} from 'react'
 import {
   type AppBskyActorDefs,
   type AppBskyFeedDefs,
+  type AppBskyFeedPost,
   type AppBskyFeedSearchPosts,
   AtUri,
   moderatePost,
@@ -13,6 +14,12 @@ import {
   useInfiniteQuery,
 } from '@tanstack/react-query'
 
+import {
+  hasMutedWordInAuthorName,
+  hasMutedWordInEmbeddedPost,
+  hasMutedWordInPostAltText,
+  hasMutedWordInText,
+} from '#/lib/moderation'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useAgent} from '#/state/session'
 import {
@@ -121,11 +128,32 @@ export function useSearchPostsQuery({
           pages: [
             ...reusedPages,
             ...data.pages.slice(reusedPages.length).map(page => {
+              const mutedWords = moderationOpts!.prefs.mutedWords
               return {
                 ...page,
                 posts: page.posts.filter(post => {
                   const mod = moderatePost(post, moderationOpts!)
-                  return !mod.ui('contentList').filter
+                  if (mod.ui('contentList').filter) return false
+                  if (
+                    hasMutedWordInAuthorName({
+                      mutedWords,
+                      author: post.author,
+                    })
+                  )
+                    return false
+                  if (
+                    hasMutedWordInText({
+                      mutedWords,
+                      text: (post.record as AppBskyFeedPost.Record)?.text ?? '',
+                      author: post.author,
+                    })
+                  )
+                    return false
+                  if (hasMutedWordInPostAltText({mutedWords, post}))
+                    return false
+                  if (hasMutedWordInEmbeddedPost({mutedWords, post}))
+                    return false
+                  return true
                 }),
               }
             }),


### PR DESCRIPTION
Muted words previously only filtered post text and hashtags. This extends filtering to author display names, profile bios, image alt text, quoted post content, and search results (people and feeds).

New mute targets added to the dialog: **Text & Tags** (existing behavior), **Tags** (tags only), **Profiles** (display names, bios), and **Quoted posts** (embedded/quoted post text and display names).

Uses substring matching (`String.includes`) in addition to the existing SDK tokenizer, which correctly catches emoji in muted words where word-boundary tokenization falls short (e.g. muting 🚨 now works).

Respects the "Exclude users you follow" setting correctly across all new surfaces, including checking the embedded post's author rather than the outer post's author for quoted posts.

Backward compatible — words previously saved with only the `content` target continue to filter profile names and bios.

Closes #3145