### PR TITLE
Workaround Android text widow truncation in RichText

### DIFF
--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -9,8 +9,20 @@ import {InlineLinkText, type LinkProps} from '#/components/Link'
 import {ProfileHoverCard} from '#/components/ProfileHoverCard'
 import {RichTextTag} from '#/components/RichTextTag'
 import {Text, type TextProps} from '#/components/Typography'
+import {IS_ANDROID} from '#/env'
 
 const WORD_WRAP = {wordWrap: 1}
+/*
+ * Workaround for an RN Android text-layout bug (see facebook/react-native#53286
+ * and #53344) that drops the last wrapped line when a single word would widow
+ * inside a row-flex container with `lineHeight` set. Appending a non-breaking
+ * space at the end of the text shifts the wrap measurement past the buggy
+ * path. NBSP is used over a regular space because trailing ASCII whitespace
+ * gets trimmed by Android's text engine before measurement.
+ *
+ * Bluesky issue: bluesky-social/social-app#5235
+ */
+const ANDROID_WIDOW_FIX = IS_ANDROID ? '\u00A0' : ''
 // lifted from facet detection in `RichText` impl, _without_ `gm` flags
 const URL_REGEX =
   /(^|\s|\()((https?:\/\/[\S]+)|((?<domain>[a-z][a-z0-9]*(\.[a-z0-9]+)+)[\S]*))/i
@@ -101,7 +113,7 @@ export function RichText({
         onTextLayout={onTextLayout}
         // @ts-ignore web only -prf
         dataSet={WORD_WRAP}>
-        {text}
+        {text + ANDROID_WIDOW_FIX}
       </Text>
     )
   }
@@ -175,6 +187,7 @@ export function RichText({
     }
     key++
   }
+  els.push(ANDROID_WIDOW_FIX)
 
   return (
     <Text


### PR DESCRIPTION
## Summary

Fixes #5235.

On Android, the last word of a post is sometimes silently dropped in the feed view when the final word would widow onto a new line. Tapping into the post detail view shows the full text, so users routinely miss content — particularly painful since the missing word often changes the meaning of the post.

## Root cause

This is an upstream React Native Android text-layout bug:

- facebook/react-native#53286 — Text rendering cut off on Android 15 & 16
- facebook/react-native#53344 — minimal reproducer (lineHeight + row)

The bug triggers when a `<Text>` with an explicit `lineHeight` is rendered inside a row-flex container and a single word would widow onto a new line. The Android text engine miscalculates the wrap measurement and the last line is never rendered. RichText hits this because post text is rendered with `a.leading_snug` (lineHeight) inside the feed item's avatar-content row.

## Fix

Append a non-breaking space (`U+00A0`) to the rendered post text on Android. The trailing NBSP shifts the wrap measurement past the buggy code path.

NBSP rather than a regular space because trailing ASCII whitespace gets trimmed by Android's text engine before measurement — I verified that a regular trailing space does **not** fix the bug, but NBSP does.

The constant is `''` on iOS and web, so this is Android-only and has no effect on those platforms.

## Test plan

- [x] Built a patched debug + release APK on a Pixel 9 Pro XL (Android 16), confirmed previously-truncated posts (e.g. ones with widow-prone trailing words) now render in full.
- [x] Scrolled home feed and Likes feed; could not find a reproducer of the original bug after the patch.
- [x] Sanity-checked text content with the patch — NBSP at end of text is invisible and copy-paste behavior is unchanged for short and long posts.
- [ ] Cross-device verification (only tested on one device — the bug's intermittent nature makes broader confirmation valuable).

## Notes

- The mitigation is one trailing character. The real fix needs to land upstream in RN's Android Text component; this is intended as a workaround until then.
- RichText is the shared rendering point for feed, detail, thread, and other surfaces — fixing it here covers all call sites without requiring per-site changes.