### PR TITLE
[Chat] adjust list insets on web

### DIFF
--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -319,9 +319,7 @@ let MessageItem = ({
               t.atoms.border_contrast_low,
               t.atoms.shadow_xs,
               hasSelfReacted
-                ? {
-                    backgroundColor: t.palette.primary_100,
-                  }
+                ? {backgroundColor: t.palette.primary_100}
                 : t.atoms.bg_contrast_25,
               {
                 paddingTop: platform({android: 2, default: 3}),
@@ -384,7 +382,7 @@ let MessageItem = ({
   const messageInset = platform<ViewStyle | undefined>({
     ios: isFromSelf ? a.mr_md : isGroupChat ? a.ml_md : a.ml_sm,
     android: isFromSelf ? a.mr_sm : isGroupChat ? a.ml_sm : undefined,
-    web: isFromSelf ? a.mr_sm : isGroupChat ? a.ml_sm : undefined,
+    web: isFromSelf ? a.mr_lg : isGroupChat ? a.ml_lg : undefined,
   })
 
   return (

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -525,7 +525,7 @@ export function MessagesList({
             style={web({
               scrollbarWidth: 'thin',
               scrollbarColor: `${t.palette.contrast_100} transparent`,
-              scrollbarGutter: 'stable both-edges',
+              scrollbarGutter: 'stable',
             })}
             contentInset={{top: transparentHeaderHeight}}
             scrollIndicatorInsets={{top: transparentHeaderHeight}}


### PR DESCRIPTION
16px to match designs - ensures there's no overlap

<img width="653" height="134" alt="Screenshot 2026-05-18 at 10 22 13" src="https://github.com/user-attachments/assets/52bd2ab6-e54b-4535-931c-7031033bff2e" />
