### PR TITLE
Fix up prettier config, apply to more files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,9 +5,13 @@
 !**/*.jsx
 !**/*.ts
 !**/*.tsx
+!**/*.mjs
+!**/*.cjs
 !*/
 
 !**/*.css
+
+!**/pnpm-workspace.yaml
 
 # More specific ignores go below.
 .expo

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 import js from '@eslint/js'
 import tseslint from 'typescript-eslint'
-import { defineConfig } from 'eslint/config';
+import {defineConfig} from 'eslint/config'
 import react from 'eslint-plugin-react'
 import reactHooks from 'eslint-plugin-react-hooks'
 // @ts-expect-error no types
@@ -184,24 +184,30 @@ export default defineConfig(
        * Import linting
        */
       'import-x/consistent-type-specifier-style': ['warn', 'prefer-inline'],
-      'import-x/no-unresolved': ['error', {
-        /*
-         * The `postinstall` hook runs `compile-if-needed` locally, but not in
-         * CI. For CI-sake, ignore this.
-         */
-        ignore: ['^#\/locale\/locales\/.+\/messages'],
-      }],
-      'import-x/no-extraneous-dependencies': ['error', {
-        'whitelist': [
-          // test files only
-          '@jest/globals',
-          // we only use a really simple util from this, and we know it will be present
-          'expo-modules-core',
-          // this is a dep for @atproto/api, but we absolutely need them in sync, so just
-          // rely on the transient version
-          '@atproto/common-web',
-        ]
-      }],
+      'import-x/no-unresolved': [
+        'error',
+        {
+          /*
+           * The `postinstall` hook runs `compile-if-needed` locally, but not in
+           * CI. For CI-sake, ignore this.
+           */
+          ignore: ['^#\/locale\/locales\/.+\/messages'],
+        },
+      ],
+      'import-x/no-extraneous-dependencies': [
+        'error',
+        {
+          whitelist: [
+            // test files only
+            '@jest/globals',
+            // we only use a really simple util from this, and we know it will be present
+            'expo-modules-core',
+            // this is a dep for @atproto/api, but we absolutely need them in sync, so just
+            // rely on the transient version
+            '@atproto/common-web',
+          ],
+        },
+      ],
       'import-x/no-nodejs-modules': 'error',
 
       /**
@@ -222,9 +228,12 @@ export default defineConfig(
         {prefer: 'type-imports', fixStyle: 'inline-type-imports'},
       ],
       '@typescript-eslint/no-require-imports': 'off',
-      '@typescript-eslint/no-unused-expressions': ['error', {
-        allowTernary: true,
-      }],
+      '@typescript-eslint/no-unused-expressions': [
+        'error',
+        {
+          allowTernary: true,
+        },
+      ],
       /**
        * Maintain previous behavior - these are stricter in typescript-eslint
        * v8 `warn` ones are probably worth fixing. `off` ones are a bit too
@@ -251,13 +260,19 @@ export default defineConfig(
       '@typescript-eslint/prefer-promise-reject-errors': 'warn',
       '@typescript-eslint/await-thenable': 'warn',
 
-      "no-restricted-imports": ["error", {
-        "paths": [{
-          "name": "react",
-          "importNames": ["React", "default"],
-          "message": "React is already in the global type namespace. Use named imports for runtime modules."
-        }]
-      }],
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'react',
+              importNames: ['React', 'default'],
+              message:
+                'React is already in the global type namespace. Use named imports for runtime modules.',
+            },
+          ],
+        },
+      ],
 
       /**
        * Turn off rules that we haven't enforced thus far
@@ -298,7 +313,7 @@ export default defineConfig(
     languageOptions: {
       globals: {
         ...globals.jest,
-      }
+      },
     },
   },
 )

--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -1,4 +1,6 @@
-module.exports = {
+import {type Config} from 'prettier'
+
+const config: Config = {
   semi: false,
   arrowParens: 'avoid',
   bracketSameLine: true,
@@ -6,3 +8,5 @@ module.exports = {
   singleQuote: true,
   trailingComma: 'all',
 }
+
+export default config

--- a/scripts/migrate-patches.mjs
+++ b/scripts/migrate-patches.mjs
@@ -136,7 +136,14 @@ for (const [pkg, files] of groups) {
       try {
         execFileSync(
           'patch',
-          [`-p${stripLevel}`, '-l', '-N', '--no-backup-if-mismatch', '-i', patchPath],
+          [
+            `-p${stripLevel}`,
+            '-l',
+            '-N',
+            '--no-backup-if-mismatch',
+            '-i',
+            patchPath,
+          ],
           {cwd: tmp, stdio: 'pipe'},
         )
         console.log(`  applied  ${file}  (via GNU patch -l)`)
@@ -146,16 +153,17 @@ for (const [pkg, files] of groups) {
 
       // If reversing applies, the patch is already in upstream -- stale.
       try {
-        execFileSync(
-          'git',
-          [...gitArgs, '--reverse', '--check', patchPath],
-          {cwd: tmp, stdio: 'pipe'},
-        )
+        execFileSync('git', [...gitArgs, '--reverse', '--check', patchPath], {
+          cwd: tmp,
+          stdio: 'pipe',
+        })
         console.log(`  STALE    ${file}  (already in upstream, skipping)`)
         stale++
       } catch {
         console.error(`  FAILED   ${file}  (does not apply, not stale)`)
-        throw new Error(`patch ${file} does not apply against ${pkg}@${version}`)
+        throw new Error(
+          `patch ${file} does not apply against ${pkg}@${version}`,
+        )
       }
     }
 


### PR DESCRIPTION
Figured out why Prettier wasn't working on certain files - we had an overzealous allowlist. Added `mjs`/`cjs` files plus the `pnpm-workspace.yaml`