### PR TITLE
Fix Image Options not opening on web

### DIFF
--- a/src/components/Lightbox/Lightbox.web.tsx
+++ b/src/components/Lightbox/Lightbox.web.tsx
@@ -268,6 +268,7 @@ function LightboxGallery({
                 icon={EllipsisIcon}
                 iconStyle={{transform: [{rotate: '90deg'}]}}
                 label={_(msg`Image options`)}
+                onPress={props.onPress}
               />
             </Pressable>
           )}

--- a/src/components/Lightbox/Lightbox.web.tsx
+++ b/src/components/Lightbox/Lightbox.web.tsx
@@ -260,17 +260,15 @@ function LightboxGallery({
       <Menu.Root>
         <Menu.Trigger label={_(msg`Image options`)}>
           {({props}) => (
-            <Pressable
-              {...props}
-              accessible={false}
-              style={[a.absolute, styles.menuBtn, delayedFadeInAnim]}>
+            <View style={[a.absolute, styles.menuBtn, delayedFadeInAnim]}>
               <CircleChromeButton
+                {...props}
+                accessible={false}
                 icon={EllipsisIcon}
                 iconStyle={{transform: [{rotate: '90deg'}]}}
                 label={_(msg`Image options`)}
-                onPress={props.onPress}
               />
-            </Pressable>
+            </View>
           )}
         </Menu.Trigger>
         <Menu.Outer>

--- a/src/components/Lightbox/chrome/CircleChromeButton.tsx
+++ b/src/components/Lightbox/chrome/CircleChromeButton.tsx
@@ -17,7 +17,15 @@ type Props = {
   label: string
   onPress?: PressableProps['onPress']
   testID?: string
-}
+} & Omit<
+  PressableProps,
+  | 'onPress'
+  | 'style'
+  | 'testID'
+  | 'accessibilityRole'
+  | 'accessibilityLabel'
+  | 'accessibilityHint'
+>
 
 const SIZE = 44
 const RADIUS = 24
@@ -29,9 +37,11 @@ export function CircleChromeButton({
   label,
   onPress,
   testID,
+  ...rest
 }: Props) {
   return (
     <Pressable
+      {...rest}
       accessibilityRole="button"
       accessibilityLabel={label}
       accessibilityHint=""

--- a/src/components/Lightbox/chrome/CircleChromeButton.web.tsx
+++ b/src/components/Lightbox/chrome/CircleChromeButton.web.tsx
@@ -17,7 +17,15 @@ type Props = {
   label: string
   onPress?: PressableProps['onPress']
   testID?: string
-}
+} & Omit<
+  PressableProps,
+  | 'onPress'
+  | 'style'
+  | 'testID'
+  | 'accessibilityRole'
+  | 'accessibilityLabel'
+  | 'accessibilityHint'
+>
 
 const SIZE = 44
 const RADIUS = 24
@@ -29,9 +37,11 @@ export function CircleChromeButton({
   label,
   onPress,
   testID,
+  ...rest
 }: Props) {
   return (
     <Pressable
+      {...rest}
       accessibilityRole="button"
       accessibilityLabel={label}
       accessibilityHint=""


### PR DESCRIPTION
After a recent refresh of the lightbox, the image options button on web has since stopped opening its menu

This adds an onPress prop to the menu trigger to restore functionality 🐙