### PR TITLE
Update `date-fns` to latest

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -317,16 +317,6 @@
       "count": 1
     }
   },
-  "src/locale/i18n.web.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "src/platform/polyfills.web.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    }
-  },
   "src/screens/Bookmarks/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -327,16 +327,6 @@
       "count": 1
     }
   },
-  "src/locale/i18n.web.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "src/platform/polyfills.web.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    }
-  },
   "src/screens/Bookmarks/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "babel-plugin-transform-remove-console": "^6.9.4",
     "bcp-47": "^2.1.0",
     "bcp-47-match": "^2.0.3",
-    "date-fns": "^4.3.0",
+    "date-fns": "^4.4.0",
     "email-validator": "^2.0.4",
     "emoji-mart": "^5.6.0",
     "emoji-regex": "^10.4.0",

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "babel-plugin-transform-remove-console": "^6.9.4",
     "bcp-47": "^2.1.0",
     "bcp-47-match": "^2.0.3",
-    "date-fns": "^2.30.0",
+    "date-fns": "^4.3.0",
     "email-validator": "^2.0.4",
     "emoji-mart": "^5.6.0",
     "emoji-regex": "^10.4.0",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "babel-plugin-transform-remove-console": "^6.9.4",
     "bcp-47": "^2.1.0",
     "bcp-47-match": "^2.0.3",
-    "date-fns": "^2.30.0",
+    "date-fns": "^4.3.0",
     "email-validator": "^2.0.4",
     "emoji-mart": "^5.6.0",
     "emoji-regex": "^10.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,8 +416,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       date-fns:
-        specifier: ^2.30.0
-        version: 2.30.0
+        specifier: ^4.3.0
+        version: 4.3.0
       email-validator:
         specifier: ^2.0.4
         version: 2.0.4
@@ -4788,12 +4788,11 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
-  date-fns@2.30.0:
-    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
-    engines: {node: '>=0.11'}
-
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
+
+  date-fns@4.3.0:
+    resolution: {integrity: sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==}
 
   debounce@1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
@@ -14216,11 +14215,9 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  date-fns@2.30.0:
-    dependencies:
-      '@babel/runtime': 7.29.2
-
   date-fns@3.6.0: {}
+
+  date-fns@4.3.0: {}
 
   debounce@1.2.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,8 +416,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       date-fns:
-        specifier: ^4.3.0
-        version: 4.3.0
+        specifier: ^4.4.0
+        version: 4.4.0
       email-validator:
         specifier: ^2.0.4
         version: 2.0.4
@@ -4791,8 +4791,8 @@ packages:
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
 
-  date-fns@4.3.0:
-    resolution: {integrity: sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==}
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
   debounce@1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
@@ -14217,7 +14217,7 @@ snapshots:
 
   date-fns@3.6.0: {}
 
-  date-fns@4.3.0: {}
+  date-fns@4.4.0: {}
 
   debounce@1.2.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -428,8 +428,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       date-fns:
-        specifier: ^2.30.0
-        version: 2.30.0
+        specifier: ^4.3.0
+        version: 4.3.0
       email-validator:
         specifier: ^2.0.4
         version: 2.0.4
@@ -4824,12 +4824,11 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
-  date-fns@2.30.0:
-    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
-    engines: {node: '>=0.11'}
-
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
+
+  date-fns@4.3.0:
+    resolution: {integrity: sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==}
 
   debounce@1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
@@ -14295,11 +14294,9 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  date-fns@2.30.0:
-    dependencies:
-      '@babel/runtime': 7.29.2
-
   date-fns@3.6.0: {}
+
+  date-fns@4.3.0: {}
 
   debounce@1.2.1: {}
 

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -10,7 +10,7 @@ import '@formatjs/intl-displaynames/locale-data/en.js'
 
 import {useEffect, useState} from 'react'
 import {i18n} from '@lingui/core'
-import defaultLocale from 'date-fns/locale/en-US'
+import {enUS as defaultLocale} from 'date-fns/locale/en-US'
 
 import {sanitizeAppLanguageSetting} from '#/locale/helpers'
 import {AppLanguage} from '#/locale/languages'
@@ -64,8 +64,8 @@ export async function dynamicActivate(locale: AppLanguage) {
   switch (locale) {
     case AppLanguage.an: {
       i18n.loadAndActivate({locale, messages: messagesAn})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/es'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/es').then(m => m.es),
         import('@formatjs/intl-pluralrules/locale-data/an.js'),
         import('@formatjs/intl-numberformat/locale-data/an.js'),
         import('@formatjs/intl-displaynames/locale-data/an.js'),
@@ -74,8 +74,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.ast: {
       i18n.loadAndActivate({locale, messages: messagesAst})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/es'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/es').then(m => m.es),
         import('@formatjs/intl-pluralrules/locale-data/ast.js'),
         import('@formatjs/intl-numberformat/locale-data/ast.js'),
         import('@formatjs/intl-displaynames/locale-data/ast.js'),
@@ -84,8 +84,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.ca: {
       i18n.loadAndActivate({locale, messages: messagesCa})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/ca'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/ca').then(m => m.ca),
         import('@formatjs/intl-pluralrules/locale-data/ca.js'),
         import('@formatjs/intl-numberformat/locale-data/ca.js'),
         import('@formatjs/intl-displaynames/locale-data/ca.js'),
@@ -94,8 +94,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.cy: {
       i18n.loadAndActivate({locale, messages: messagesCy})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/cy'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/cy').then(m => m.cy),
         import('@formatjs/intl-pluralrules/locale-data/cy.js'),
         import('@formatjs/intl-numberformat/locale-data/cy.js'),
         import('@formatjs/intl-displaynames/locale-data/cy.js'),
@@ -104,8 +104,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.da: {
       i18n.loadAndActivate({locale, messages: messagesDa})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/da'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/da').then(m => m.da),
         import('@formatjs/intl-pluralrules/locale-data/da.js'),
         import('@formatjs/intl-numberformat/locale-data/da.js'),
         import('@formatjs/intl-displaynames/locale-data/da.js'),
@@ -114,8 +114,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.de: {
       i18n.loadAndActivate({locale, messages: messagesDe})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/de'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/de').then(m => m.de),
         import('@formatjs/intl-pluralrules/locale-data/de.js'),
         import('@formatjs/intl-numberformat/locale-data/de.js'),
         import('@formatjs/intl-displaynames/locale-data/de.js'),
@@ -124,8 +124,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.el: {
       i18n.loadAndActivate({locale, messages: messagesEl})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/el'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/el').then(m => m.el),
         import('@formatjs/intl-pluralrules/locale-data/el.js'),
         import('@formatjs/intl-numberformat/locale-data/el.js'),
         import('@formatjs/intl-displaynames/locale-data/el.js'),
@@ -134,8 +134,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.en_GB: {
       i18n.loadAndActivate({locale, messages: messagesEn_GB})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/en-GB'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/en-GB').then(m => m.enGB),
         import('@formatjs/intl-pluralrules/locale-data/en.js'),
         import('@formatjs/intl-numberformat/locale-data/en-GB.js'),
         import('@formatjs/intl-displaynames/locale-data/en-GB.js'),
@@ -144,8 +144,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.eo: {
       i18n.loadAndActivate({locale, messages: messagesEo})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/eo'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/eo').then(m => m.eo),
         import('@formatjs/intl-pluralrules/locale-data/eo.js'),
         import('@formatjs/intl-numberformat/locale-data/eo.js'),
         import('@formatjs/intl-displaynames/locale-data/eo.js'),
@@ -154,8 +154,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.es: {
       i18n.loadAndActivate({locale, messages: messagesEs})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/es'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/es').then(m => m.es),
         import('@formatjs/intl-pluralrules/locale-data/es.js'),
         import('@formatjs/intl-numberformat/locale-data/es.js'),
         import('@formatjs/intl-displaynames/locale-data/es.js'),
@@ -164,8 +164,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.eu: {
       i18n.loadAndActivate({locale, messages: messagesEu})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/eu'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/eu').then(m => m.eu),
         import('@formatjs/intl-pluralrules/locale-data/eu.js'),
         import('@formatjs/intl-numberformat/locale-data/eu.js'),
         import('@formatjs/intl-displaynames/locale-data/eu.js'),
@@ -174,8 +174,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.fi: {
       i18n.loadAndActivate({locale, messages: messagesFi})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/fi'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/fi').then(m => m.fi),
         import('@formatjs/intl-pluralrules/locale-data/fi.js'),
         import('@formatjs/intl-numberformat/locale-data/fi.js'),
         import('@formatjs/intl-displaynames/locale-data/fi.js'),
@@ -184,8 +184,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.fr: {
       i18n.loadAndActivate({locale, messages: messagesFr})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/fr'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/fr').then(m => m.fr),
         import('@formatjs/intl-pluralrules/locale-data/fr.js'),
         import('@formatjs/intl-numberformat/locale-data/fr.js'),
         import('@formatjs/intl-displaynames/locale-data/fr.js'),
@@ -194,8 +194,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.fy: {
       i18n.loadAndActivate({locale, messages: messagesFy})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/fy'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/fy').then(m => m.fy),
         import('@formatjs/intl-pluralrules/locale-data/fy.js'),
         import('@formatjs/intl-numberformat/locale-data/fy.js'),
         import('@formatjs/intl-displaynames/locale-data/fy.js'),
@@ -213,8 +213,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.gd: {
       i18n.loadAndActivate({locale, messages: messagesGd})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/gd'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/gd').then(m => m.gd),
         import('@formatjs/intl-pluralrules/locale-data/gd.js'),
         import('@formatjs/intl-numberformat/locale-data/gd.js'),
         import('@formatjs/intl-displaynames/locale-data/gd.js'),
@@ -223,8 +223,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.gl: {
       i18n.loadAndActivate({locale, messages: messagesGl})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/gl'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/gl').then(m => m.gl),
         import('@formatjs/intl-pluralrules/locale-data/gl.js'),
         import('@formatjs/intl-numberformat/locale-data/gl.js'),
         import('@formatjs/intl-displaynames/locale-data/gl.js'),
@@ -233,8 +233,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.hi: {
       i18n.loadAndActivate({locale, messages: messagesHi})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/hi'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/hi').then(m => m.hi),
         import('@formatjs/intl-pluralrules/locale-data/hi.js'),
         import('@formatjs/intl-numberformat/locale-data/hi.js'),
         import('@formatjs/intl-displaynames/locale-data/hi.js'),
@@ -243,8 +243,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.hu: {
       i18n.loadAndActivate({locale, messages: messagesHu})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/hu'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/hu').then(m => m.hu),
         import('@formatjs/intl-pluralrules/locale-data/hu.js'),
         import('@formatjs/intl-numberformat/locale-data/hu.js'),
         import('@formatjs/intl-displaynames/locale-data/hu.js'),
@@ -262,8 +262,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.id: {
       i18n.loadAndActivate({locale, messages: messagesId})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/id'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/id').then(m => m.id),
         import('@formatjs/intl-pluralrules/locale-data/id.js'),
         import('@formatjs/intl-numberformat/locale-data/id.js'),
         import('@formatjs/intl-displaynames/locale-data/id.js'),
@@ -272,8 +272,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.it: {
       i18n.loadAndActivate({locale, messages: messagesIt})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/it'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/it').then(m => m.it),
         import('@formatjs/intl-pluralrules/locale-data/it.js'),
         import('@formatjs/intl-numberformat/locale-data/it.js'),
         import('@formatjs/intl-displaynames/locale-data/it.js'),
@@ -282,8 +282,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.ja: {
       i18n.loadAndActivate({locale, messages: messagesJa})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/ja'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/ja').then(m => m.ja),
         import('@formatjs/intl-pluralrules/locale-data/ja.js'),
         import('@formatjs/intl-numberformat/locale-data/ja.js'),
         import('@formatjs/intl-displaynames/locale-data/ja.js'),
@@ -292,8 +292,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.km: {
       i18n.loadAndActivate({locale, messages: messagesKm})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/km'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/km').then(m => m.km),
         import('@formatjs/intl-pluralrules/locale-data/km.js'),
         import('@formatjs/intl-numberformat/locale-data/km.js'),
         import('@formatjs/intl-displaynames/locale-data/km.js'),
@@ -302,8 +302,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.ko: {
       i18n.loadAndActivate({locale, messages: messagesKo})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/ko'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/ko').then(m => m.ko),
         import('@formatjs/intl-pluralrules/locale-data/ko.js'),
         import('@formatjs/intl-numberformat/locale-data/ko.js'),
         import('@formatjs/intl-displaynames/locale-data/ko.js'),
@@ -321,8 +321,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.nl: {
       i18n.loadAndActivate({locale, messages: messagesNl})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/nl'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/nl').then(m => m.nl),
         import('@formatjs/intl-pluralrules/locale-data/nl.js'),
         import('@formatjs/intl-numberformat/locale-data/nl.js'),
         import('@formatjs/intl-displaynames/locale-data/nl.js'),
@@ -331,8 +331,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.pl: {
       i18n.loadAndActivate({locale, messages: messagesPl})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/pl'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/pl').then(m => m.pl),
         import('@formatjs/intl-pluralrules/locale-data/pl.js'),
         import('@formatjs/intl-numberformat/locale-data/pl.js'),
         import('@formatjs/intl-displaynames/locale-data/pl.js'),
@@ -341,8 +341,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.pt_BR: {
       i18n.loadAndActivate({locale, messages: messagesPt_BR})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/pt-BR'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/pt-BR').then(m => m.ptBR),
         import('@formatjs/intl-pluralrules/locale-data/pt.js'),
         import('@formatjs/intl-numberformat/locale-data/pt.js'),
         import('@formatjs/intl-displaynames/locale-data/pt.js'),
@@ -351,8 +351,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.pt_PT: {
       i18n.loadAndActivate({locale, messages: messagesPt_PT})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/pt'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/pt').then(m => m.pt),
         import('@formatjs/intl-pluralrules/locale-data/pt-PT.js'),
         import('@formatjs/intl-numberformat/locale-data/pt-PT.js'),
         import('@formatjs/intl-displaynames/locale-data/pt-PT.js'),
@@ -361,8 +361,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.ro: {
       i18n.loadAndActivate({locale, messages: messagesRo})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/ro'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/ro').then(m => m.ro),
         import('@formatjs/intl-pluralrules/locale-data/ro.js'),
         import('@formatjs/intl-numberformat/locale-data/ro.js'),
         import('@formatjs/intl-displaynames/locale-data/ro.js'),
@@ -371,8 +371,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.ru: {
       i18n.loadAndActivate({locale, messages: messagesRu})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/ru'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/ru').then(m => m.ru),
         import('@formatjs/intl-pluralrules/locale-data/ru.js'),
         import('@formatjs/intl-numberformat/locale-data/ru.js'),
         import('@formatjs/intl-displaynames/locale-data/ru.js'),
@@ -381,8 +381,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.sv: {
       i18n.loadAndActivate({locale, messages: messagesSv})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/sv'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/sv').then(m => m.sv),
         import('@formatjs/intl-pluralrules/locale-data/sv.js'),
         import('@formatjs/intl-numberformat/locale-data/sv.js'),
         import('@formatjs/intl-displaynames/locale-data/sv.js'),
@@ -391,8 +391,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.th: {
       i18n.loadAndActivate({locale, messages: messagesTh})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/th'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/th').then(m => m.th),
         import('@formatjs/intl-pluralrules/locale-data/th.js'),
         import('@formatjs/intl-numberformat/locale-data/th.js'),
         import('@formatjs/intl-displaynames/locale-data/th.js'),
@@ -401,8 +401,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.tr: {
       i18n.loadAndActivate({locale, messages: messagesTr})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/tr'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/tr').then(m => m.tr),
         import('@formatjs/intl-pluralrules/locale-data/tr.js'),
         import('@formatjs/intl-numberformat/locale-data/tr.js'),
         import('@formatjs/intl-displaynames/locale-data/tr.js'),
@@ -411,8 +411,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.uk: {
       i18n.loadAndActivate({locale, messages: messagesUk})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/uk'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/uk').then(m => m.uk),
         import('@formatjs/intl-pluralrules/locale-data/uk.js'),
         import('@formatjs/intl-numberformat/locale-data/uk.js'),
         import('@formatjs/intl-displaynames/locale-data/uk.js'),
@@ -421,8 +421,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.vi: {
       i18n.loadAndActivate({locale, messages: messagesVi})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/vi'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/vi').then(m => m.vi),
         import('@formatjs/intl-pluralrules/locale-data/vi.js'),
         import('@formatjs/intl-numberformat/locale-data/vi.js'),
         import('@formatjs/intl-displaynames/locale-data/vi.js'),
@@ -431,8 +431,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.zh_CN: {
       i18n.loadAndActivate({locale, messages: messagesZh_CN})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/zh-CN'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/zh-CN').then(m => m.zhCN),
         import('@formatjs/intl-pluralrules/locale-data/zh.js'),
         import('@formatjs/intl-numberformat/locale-data/zh.js'),
         import('@formatjs/intl-displaynames/locale-data/zh.js'),
@@ -441,8 +441,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.zh_HK: {
       i18n.loadAndActivate({locale, messages: messagesZh_HK})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/zh-HK'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/zh-HK').then(m => m.zhHK),
         import('@formatjs/intl-pluralrules/locale-data/zh.js'),
         import('@formatjs/intl-numberformat/locale-data/yue-Hant.js'),
         import('@formatjs/intl-displaynames/locale-data/yue-Hant.js'),
@@ -451,8 +451,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.zh_TW: {
       i18n.loadAndActivate({locale, messages: messagesZh_TW})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/zh-TW'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/zh-TW').then(m => m.zhTW),
         import('@formatjs/intl-pluralrules/locale-data/zh.js'),
         import('@formatjs/intl-numberformat/locale-data/zh-Hant.js'),
         import('@formatjs/intl-displaynames/locale-data/zh-Hant.js'),
@@ -471,9 +471,11 @@ export function useLocaleLanguage() {
   const [dateLocale, setDateLocale] = useState(defaultLocale)
 
   useEffect(() => {
-    dynamicActivate(sanitizeAppLanguageSetting(appLanguage)).then(locale => {
-      setDateLocale(locale ?? defaultLocale)
-    })
+    void dynamicActivate(sanitizeAppLanguageSetting(appLanguage)).then(
+      locale => {
+        setDateLocale(locale ?? defaultLocale)
+      },
+    )
   }, [appLanguage])
 
   return dateLocale

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -10,7 +10,7 @@ import '@formatjs/intl-displaynames/locale-data/en'
 
 import {useEffect, useState} from 'react'
 import {i18n} from '@lingui/core'
-import defaultLocale from 'date-fns/locale/en-US'
+import {enUS as defaultLocale} from 'date-fns/locale/en-US'
 
 import {sanitizeAppLanguageSetting} from '#/locale/helpers'
 import {AppLanguage} from '#/locale/languages'
@@ -64,8 +64,8 @@ export async function dynamicActivate(locale: AppLanguage) {
   switch (locale) {
     case AppLanguage.an: {
       i18n.loadAndActivate({locale, messages: messagesAn})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/es'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/es').then(m => m.es),
         import('@formatjs/intl-pluralrules/locale-data/an'),
         import('@formatjs/intl-numberformat/locale-data/es'),
         import('@formatjs/intl-displaynames/locale-data/es'),
@@ -74,8 +74,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.ast: {
       i18n.loadAndActivate({locale, messages: messagesAst})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/es'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/es').then(m => m.es),
         import('@formatjs/intl-pluralrules/locale-data/ast'),
         import('@formatjs/intl-numberformat/locale-data/ast'),
         import('@formatjs/intl-displaynames/locale-data/ast'),
@@ -84,8 +84,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.ca: {
       i18n.loadAndActivate({locale, messages: messagesCa})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/ca'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/ca').then(m => m.ca),
         import('@formatjs/intl-pluralrules/locale-data/ca'),
         import('@formatjs/intl-numberformat/locale-data/ca'),
         import('@formatjs/intl-displaynames/locale-data/ca'),
@@ -94,8 +94,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.cy: {
       i18n.loadAndActivate({locale, messages: messagesCy})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/cy'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/cy').then(m => m.cy),
         import('@formatjs/intl-pluralrules/locale-data/cy'),
         import('@formatjs/intl-numberformat/locale-data/cy'),
         import('@formatjs/intl-displaynames/locale-data/cy'),
@@ -104,8 +104,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.da: {
       i18n.loadAndActivate({locale, messages: messagesDa})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/da'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/da').then(m => m.da),
         import('@formatjs/intl-pluralrules/locale-data/da'),
         import('@formatjs/intl-numberformat/locale-data/da'),
         import('@formatjs/intl-displaynames/locale-data/da'),
@@ -114,8 +114,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.de: {
       i18n.loadAndActivate({locale, messages: messagesDe})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/de'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/de').then(m => m.de),
         import('@formatjs/intl-pluralrules/locale-data/de'),
         import('@formatjs/intl-numberformat/locale-data/de'),
         import('@formatjs/intl-displaynames/locale-data/de'),
@@ -124,8 +124,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.el: {
       i18n.loadAndActivate({locale, messages: messagesEl})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/el'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/el').then(m => m.el),
         import('@formatjs/intl-pluralrules/locale-data/el'),
         import('@formatjs/intl-numberformat/locale-data/el'),
         import('@formatjs/intl-displaynames/locale-data/el'),
@@ -134,8 +134,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.en_GB: {
       i18n.loadAndActivate({locale, messages: messagesEn_GB})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/en-GB'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/en-GB').then(m => m.enGB),
         import('@formatjs/intl-pluralrules/locale-data/en'),
         import('@formatjs/intl-numberformat/locale-data/en-GB'),
         import('@formatjs/intl-displaynames/locale-data/en-GB'),
@@ -144,8 +144,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.eo: {
       i18n.loadAndActivate({locale, messages: messagesEo})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/eo'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/eo').then(m => m.eo),
         import('@formatjs/intl-pluralrules/locale-data/eo'),
         import('@formatjs/intl-numberformat/locale-data/eo'),
         // borked, see https://github.com/bluesky-social/social-app/pull/9574
@@ -155,8 +155,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.es: {
       i18n.loadAndActivate({locale, messages: messagesEs})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/es'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/es').then(m => m.es),
         import('@formatjs/intl-pluralrules/locale-data/es'),
         import('@formatjs/intl-numberformat/locale-data/es'),
         import('@formatjs/intl-displaynames/locale-data/es'),
@@ -165,8 +165,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.eu: {
       i18n.loadAndActivate({locale, messages: messagesEu})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/eu'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/eu').then(m => m.eu),
         import('@formatjs/intl-pluralrules/locale-data/eu'),
         import('@formatjs/intl-numberformat/locale-data/eu'),
         import('@formatjs/intl-displaynames/locale-data/eu'),
@@ -175,8 +175,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.fi: {
       i18n.loadAndActivate({locale, messages: messagesFi})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/fi'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/fi').then(m => m.fi),
         import('@formatjs/intl-pluralrules/locale-data/fi'),
         import('@formatjs/intl-numberformat/locale-data/fi'),
         import('@formatjs/intl-displaynames/locale-data/fi'),
@@ -185,8 +185,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.fr: {
       i18n.loadAndActivate({locale, messages: messagesFr})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/fr'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/fr').then(m => m.fr),
         import('@formatjs/intl-pluralrules/locale-data/fr'),
         import('@formatjs/intl-numberformat/locale-data/fr'),
         import('@formatjs/intl-displaynames/locale-data/fr'),
@@ -195,8 +195,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.fy: {
       i18n.loadAndActivate({locale, messages: messagesFy})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/fy'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/fy').then(m => m.fy),
         import('@formatjs/intl-pluralrules/locale-data/fy'),
         import('@formatjs/intl-numberformat/locale-data/fy'),
         import('@formatjs/intl-displaynames/locale-data/fy'),
@@ -214,8 +214,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.gd: {
       i18n.loadAndActivate({locale, messages: messagesGd})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/gd'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/gd').then(m => m.gd),
         import('@formatjs/intl-pluralrules/locale-data/gd'),
         import('@formatjs/intl-numberformat/locale-data/gd'),
         import('@formatjs/intl-displaynames/locale-data/gd'),
@@ -224,8 +224,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.gl: {
       i18n.loadAndActivate({locale, messages: messagesGl})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/gl'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/gl').then(m => m.gl),
         import('@formatjs/intl-pluralrules/locale-data/gl'),
         import('@formatjs/intl-numberformat/locale-data/gl'),
         import('@formatjs/intl-displaynames/locale-data/gl'),
@@ -234,8 +234,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.hi: {
       i18n.loadAndActivate({locale, messages: messagesHi})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/hi'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/hi').then(m => m.hi),
         import('@formatjs/intl-pluralrules/locale-data/hi'),
         import('@formatjs/intl-numberformat/locale-data/hi'),
         import('@formatjs/intl-displaynames/locale-data/hi'),
@@ -244,8 +244,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.hu: {
       i18n.loadAndActivate({locale, messages: messagesHu})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/hu'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/hu').then(m => m.hu),
         import('@formatjs/intl-pluralrules/locale-data/hu'),
         import('@formatjs/intl-numberformat/locale-data/hu'),
         import('@formatjs/intl-displaynames/locale-data/hu'),
@@ -263,8 +263,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.id: {
       i18n.loadAndActivate({locale, messages: messagesId})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/id'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/id').then(m => m.id),
         import('@formatjs/intl-pluralrules/locale-data/id'),
         import('@formatjs/intl-numberformat/locale-data/id'),
         import('@formatjs/intl-displaynames/locale-data/id'),
@@ -273,8 +273,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.it: {
       i18n.loadAndActivate({locale, messages: messagesIt})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/it'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/it').then(m => m.it),
         import('@formatjs/intl-pluralrules/locale-data/it'),
         import('@formatjs/intl-numberformat/locale-data/it'),
         import('@formatjs/intl-displaynames/locale-data/it'),
@@ -283,8 +283,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.ja: {
       i18n.loadAndActivate({locale, messages: messagesJa})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/ja'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/ja').then(m => m.ja),
         import('@formatjs/intl-pluralrules/locale-data/ja'),
         import('@formatjs/intl-numberformat/locale-data/ja'),
         import('@formatjs/intl-displaynames/locale-data/ja'),
@@ -293,8 +293,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.km: {
       i18n.loadAndActivate({locale, messages: messagesKm})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/km'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/km').then(m => m.km),
         import('@formatjs/intl-pluralrules/locale-data/km'),
         import('@formatjs/intl-numberformat/locale-data/km'),
         import('@formatjs/intl-displaynames/locale-data/km'),
@@ -303,8 +303,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.ko: {
       i18n.loadAndActivate({locale, messages: messagesKo})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/ko'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/ko').then(m => m.ko),
         import('@formatjs/intl-pluralrules/locale-data/ko'),
         import('@formatjs/intl-numberformat/locale-data/ko'),
         import('@formatjs/intl-displaynames/locale-data/ko'),
@@ -322,8 +322,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.nl: {
       i18n.loadAndActivate({locale, messages: messagesNl})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/nl'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/nl').then(m => m.nl),
         import('@formatjs/intl-pluralrules/locale-data/nl'),
         import('@formatjs/intl-numberformat/locale-data/nl'),
         import('@formatjs/intl-displaynames/locale-data/nl'),
@@ -332,8 +332,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.pl: {
       i18n.loadAndActivate({locale, messages: messagesPl})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/pl'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/pl').then(m => m.pl),
         import('@formatjs/intl-pluralrules/locale-data/pl'),
         import('@formatjs/intl-numberformat/locale-data/pl'),
         import('@formatjs/intl-displaynames/locale-data/pl'),
@@ -342,8 +342,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.pt_BR: {
       i18n.loadAndActivate({locale, messages: messagesPt_BR})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/pt-BR'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/pt-BR').then(m => m.ptBR),
         import('@formatjs/intl-pluralrules/locale-data/pt'),
         import('@formatjs/intl-numberformat/locale-data/pt'),
         import('@formatjs/intl-displaynames/locale-data/pt'),
@@ -352,8 +352,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.pt_PT: {
       i18n.loadAndActivate({locale, messages: messagesPt_PT})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/pt'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/pt').then(m => m.pt),
         import('@formatjs/intl-pluralrules/locale-data/pt-PT'),
         import('@formatjs/intl-numberformat/locale-data/pt-PT'),
         import('@formatjs/intl-displaynames/locale-data/pt-PT'),
@@ -362,8 +362,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.ro: {
       i18n.loadAndActivate({locale, messages: messagesRo})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/ro'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/ro').then(m => m.ro),
         import('@formatjs/intl-pluralrules/locale-data/ro'),
         import('@formatjs/intl-numberformat/locale-data/ro'),
         import('@formatjs/intl-displaynames/locale-data/ro'),
@@ -372,8 +372,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.ru: {
       i18n.loadAndActivate({locale, messages: messagesRu})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/ru'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/ru').then(m => m.ru),
         import('@formatjs/intl-pluralrules/locale-data/ru'),
         import('@formatjs/intl-numberformat/locale-data/ru'),
         import('@formatjs/intl-displaynames/locale-data/ru'),
@@ -382,8 +382,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.sv: {
       i18n.loadAndActivate({locale, messages: messagesSv})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/sv'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/sv').then(m => m.sv),
         import('@formatjs/intl-pluralrules/locale-data/sv'),
         import('@formatjs/intl-numberformat/locale-data/sv'),
         import('@formatjs/intl-displaynames/locale-data/sv'),
@@ -392,8 +392,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.th: {
       i18n.loadAndActivate({locale, messages: messagesTh})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/th'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/th').then(m => m.th),
         import('@formatjs/intl-pluralrules/locale-data/th'),
         import('@formatjs/intl-numberformat/locale-data/th'),
         import('@formatjs/intl-displaynames/locale-data/th'),
@@ -402,8 +402,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.tr: {
       i18n.loadAndActivate({locale, messages: messagesTr})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/tr'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/tr').then(m => m.tr),
         import('@formatjs/intl-pluralrules/locale-data/tr'),
         import('@formatjs/intl-numberformat/locale-data/tr'),
         import('@formatjs/intl-displaynames/locale-data/tr'),
@@ -412,8 +412,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.uk: {
       i18n.loadAndActivate({locale, messages: messagesUk})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/uk'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/uk').then(m => m.uk),
         import('@formatjs/intl-pluralrules/locale-data/uk'),
         import('@formatjs/intl-numberformat/locale-data/uk'),
         import('@formatjs/intl-displaynames/locale-data/uk'),
@@ -422,8 +422,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.vi: {
       i18n.loadAndActivate({locale, messages: messagesVi})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/vi'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/vi').then(m => m.vi),
         import('@formatjs/intl-pluralrules/locale-data/vi'),
         import('@formatjs/intl-numberformat/locale-data/vi'),
         import('@formatjs/intl-displaynames/locale-data/vi'),
@@ -432,8 +432,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.zh_CN: {
       i18n.loadAndActivate({locale, messages: messagesZh_CN})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/zh-CN'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/zh-CN').then(m => m.zhCN),
         import('@formatjs/intl-pluralrules/locale-data/zh'),
         import('@formatjs/intl-numberformat/locale-data/zh'),
         import('@formatjs/intl-displaynames/locale-data/zh'),
@@ -442,8 +442,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.zh_HK: {
       i18n.loadAndActivate({locale, messages: messagesZh_HK})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/zh-HK'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/zh-HK').then(m => m.zhHK),
         import('@formatjs/intl-pluralrules/locale-data/zh'),
         import('@formatjs/intl-numberformat/locale-data/zh'),
         import('@formatjs/intl-displaynames/locale-data/zh'),
@@ -452,8 +452,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.zh_TW: {
       i18n.loadAndActivate({locale, messages: messagesZh_TW})
-      const [{default: dateLocale}] = await Promise.all([
-        import('date-fns/locale/zh-TW'),
+      const [dateLocale] = await Promise.all([
+        import('date-fns/locale/zh-TW').then(m => m.zhTW),
         import('@formatjs/intl-pluralrules/locale-data/zh'),
         import('@formatjs/intl-numberformat/locale-data/zh'),
         import('@formatjs/intl-displaynames/locale-data/zh'),
@@ -472,9 +472,11 @@ export function useLocaleLanguage() {
   const [dateLocale, setDateLocale] = useState(defaultLocale)
 
   useEffect(() => {
-    dynamicActivate(sanitizeAppLanguageSetting(appLanguage)).then(locale => {
-      setDateLocale(locale ?? defaultLocale)
-    })
+    void dynamicActivate(sanitizeAppLanguageSetting(appLanguage)).then(
+      locale => {
+        setDateLocale(locale ?? defaultLocale)
+      },
+    )
   }, [appLanguage])
 
   return dateLocale

--- a/src/locale/i18n.web.ts
+++ b/src/locale/i18n.web.ts
@@ -1,6 +1,7 @@
 import {useEffect, useState} from 'react'
-import {i18n} from '@lingui/core'
-import defaultLocale from 'date-fns/locale/en-US'
+import {i18n, type Messages} from '@lingui/core'
+import {type Locale} from 'date-fns/locale'
+import {enUS as defaultLocale} from 'date-fns/locale/en-US'
 
 import {sanitizeAppLanguageSetting} from '#/locale/helpers'
 import {AppLanguage} from '#/locale/languages'
@@ -10,288 +11,288 @@ import {useLanguagePrefs} from '#/state/preferences'
  * We do a dynamic import of just the catalog that we need
  */
 export async function dynamicActivate(locale: AppLanguage) {
-  let mod: any
+  let messages: Messages
   let dateLocale: Locale = defaultLocale
 
   switch (locale) {
     case AppLanguage.an: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/an/messages`),
-        import('date-fns/locale/es'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/an/messages`).then(m => m.messages),
+        import('date-fns/locale/es').then(m => m.es),
       ])
       break
     }
     case AppLanguage.ast: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/ast/messages`),
-        import('date-fns/locale/es'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/ast/messages`).then(m => m.messages),
+        import('date-fns/locale/es').then(m => m.es),
       ])
       break
     }
     case AppLanguage.ca: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/ca/messages`),
-        import('date-fns/locale/ca'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/ca/messages`).then(m => m.messages),
+        import('date-fns/locale/ca').then(m => m.ca),
       ])
       break
     }
     case AppLanguage.cy: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/cy/messages`),
-        import('date-fns/locale/cy'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/cy/messages`).then(m => m.messages),
+        import('date-fns/locale/cy').then(m => m.cy),
       ])
       break
     }
     case AppLanguage.da: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/da/messages`),
-        import('date-fns/locale/da'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/da/messages`).then(m => m.messages),
+        import('date-fns/locale/da').then(m => m.da),
       ])
       break
     }
     case AppLanguage.de: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/de/messages`),
-        import('date-fns/locale/de'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/de/messages`).then(m => m.messages),
+        import('date-fns/locale/de').then(m => m.de),
       ])
       break
     }
     case AppLanguage.el: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/el/messages`),
-        import('date-fns/locale/el'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/el/messages`).then(m => m.messages),
+        import('date-fns/locale/el').then(m => m.el),
       ])
       break
     }
     case AppLanguage.en_GB: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/en-GB/messages`),
-        import('date-fns/locale/en-GB'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/en-GB/messages`).then(m => m.messages),
+        import('date-fns/locale/en-GB').then(m => m.enGB),
       ])
       break
     }
     case AppLanguage.eo: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/eo/messages`),
-        import('date-fns/locale/eo'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/eo/messages`).then(m => m.messages),
+        import('date-fns/locale/eo').then(m => m.eo),
       ])
       break
     }
     case AppLanguage.es: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/es/messages`),
-        import('date-fns/locale/es'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/es/messages`).then(m => m.messages),
+        import('date-fns/locale/es').then(m => m.es),
       ])
       break
     }
     case AppLanguage.eu: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/eu/messages`),
-        import('date-fns/locale/eu'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/eu/messages`).then(m => m.messages),
+        import('date-fns/locale/eu').then(m => m.eu),
       ])
       break
     }
     case AppLanguage.fi: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/fi/messages`),
-        import('date-fns/locale/fi'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/fi/messages`).then(m => m.messages),
+        import('date-fns/locale/fi').then(m => m.fi),
       ])
       break
     }
     case AppLanguage.fr: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/fr/messages`),
-        import('date-fns/locale/fr'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/fr/messages`).then(m => m.messages),
+        import('date-fns/locale/fr').then(m => m.fr),
       ])
       break
     }
     case AppLanguage.fy: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/fy/messages`),
-        import('date-fns/locale/fy'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/fy/messages`).then(m => m.messages),
+        import('date-fns/locale/fy').then(m => m.fy),
       ])
       break
     }
     case AppLanguage.ga: {
-      mod = await import(`./locales/ga/messages`)
+      messages = await import(`./locales/ga/messages`).then(m => m.messages)
       break
     }
     case AppLanguage.gd: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/gd/messages`),
-        import('date-fns/locale/gd'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/gd/messages`).then(m => m.messages),
+        import('date-fns/locale/gd').then(m => m.gd),
       ])
       break
     }
     case AppLanguage.gl: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/gl/messages`),
-        import('date-fns/locale/gl'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/gl/messages`).then(m => m.messages),
+        import('date-fns/locale/gl').then(m => m.gl),
       ])
       break
     }
     case AppLanguage.hi: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/hi/messages`),
-        import('date-fns/locale/hi'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/hi/messages`).then(m => m.messages),
+        import('date-fns/locale/hi').then(m => m.hi),
       ])
       break
     }
     case AppLanguage.hu: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/hu/messages`),
-        import('date-fns/locale/hu'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/hu/messages`).then(m => m.messages),
+        import('date-fns/locale/hu').then(m => m.hu),
       ])
       break
     }
     case AppLanguage.ia: {
-      mod = await import(`./locales/ia/messages`)
+      messages = await import(`./locales/ia/messages`).then(m => m.messages)
       break
     }
     case AppLanguage.id: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/id/messages`),
-        import('date-fns/locale/id'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/id/messages`).then(m => m.messages),
+        import('date-fns/locale/id').then(m => m.id),
       ])
       break
     }
     case AppLanguage.it: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/it/messages`),
-        import('date-fns/locale/it'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/it/messages`).then(m => m.messages),
+        import('date-fns/locale/it').then(m => m.it),
       ])
       break
     }
     case AppLanguage.ja: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/ja/messages`),
-        import('date-fns/locale/ja'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/ja/messages`).then(m => m.messages),
+        import('date-fns/locale/ja').then(m => m.ja),
       ])
       break
     }
     case AppLanguage.km: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/km/messages`),
-        import('date-fns/locale/km'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/km/messages`).then(m => m.messages),
+        import('date-fns/locale/km').then(m => m.km),
       ])
       break
     }
     case AppLanguage.ko: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/ko/messages`),
-        import('date-fns/locale/ko'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/ko/messages`).then(m => m.messages),
+        import('date-fns/locale/ko').then(m => m.ko),
       ])
       break
     }
     case AppLanguage.ne: {
-      mod = await import(`./locales/ne/messages`)
+      messages = await import(`./locales/ne/messages`).then(m => m.messages)
       break
     }
     case AppLanguage.nl: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/nl/messages`),
-        import('date-fns/locale/nl'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/nl/messages`).then(m => m.messages),
+        import('date-fns/locale/nl').then(m => m.nl),
       ])
       break
     }
     case AppLanguage.pl: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/pl/messages`),
-        import('date-fns/locale/pl'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/pl/messages`).then(m => m.messages),
+        import('date-fns/locale/pl').then(m => m.pl),
       ])
       break
     }
     case AppLanguage.pt_BR: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/pt-BR/messages`),
-        import('date-fns/locale/pt-BR'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/pt-BR/messages`).then(m => m.messages),
+        import('date-fns/locale/pt-BR').then(m => m.ptBR),
       ])
       break
     }
     case AppLanguage.pt_PT: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/pt-PT/messages`),
-        import('date-fns/locale/pt'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/pt-PT/messages`).then(m => m.messages),
+        import('date-fns/locale/pt').then(m => m.pt),
       ])
       break
     }
     case AppLanguage.ro: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/ro/messages`),
-        import('date-fns/locale/ro'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/ro/messages`).then(m => m.messages),
+        import('date-fns/locale/ro').then(m => m.ro),
       ])
       break
     }
     case AppLanguage.ru: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/ru/messages`),
-        import('date-fns/locale/ru'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/ru/messages`).then(m => m.messages),
+        import('date-fns/locale/ru').then(m => m.ru),
       ])
       break
     }
     case AppLanguage.sv: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/sv/messages`),
-        import('date-fns/locale/sv'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/sv/messages`).then(m => m.messages),
+        import('date-fns/locale/sv').then(m => m.sv),
       ])
       break
     }
     case AppLanguage.th: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/th/messages`),
-        import('date-fns/locale/th'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/th/messages`).then(m => m.messages),
+        import('date-fns/locale/th').then(m => m.th),
       ])
       break
     }
     case AppLanguage.tr: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/tr/messages`),
-        import('date-fns/locale/tr'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/tr/messages`).then(m => m.messages),
+        import('date-fns/locale/tr').then(m => m.tr),
       ])
       break
     }
     case AppLanguage.uk: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/uk/messages`),
-        import('date-fns/locale/uk'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/uk/messages`).then(m => m.messages),
+        import('date-fns/locale/uk').then(m => m.uk),
       ])
       break
     }
     case AppLanguage.vi: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/vi/messages`),
-        import('date-fns/locale/vi'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/vi/messages`).then(m => m.messages),
+        import('date-fns/locale/vi').then(m => m.vi),
       ])
       break
     }
     case AppLanguage.zh_CN: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/zh-CN/messages`),
-        import('date-fns/locale/zh-CN'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/zh-CN/messages`).then(m => m.messages),
+        import('date-fns/locale/zh-CN').then(m => m.zhCN),
       ])
       break
     }
     case AppLanguage.zh_HK: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/zh-HK/messages`),
-        import('date-fns/locale/zh-HK'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/zh-HK/messages`).then(m => m.messages),
+        import('date-fns/locale/zh-HK').then(m => m.zhHK),
       ])
       break
     }
     case AppLanguage.zh_TW: {
-      ;[mod, {default: dateLocale}] = await Promise.all([
-        import(`./locales/zh-TW/messages`),
-        import('date-fns/locale/zh-TW'),
+      ;[messages, dateLocale] = await Promise.all([
+        import(`./locales/zh-TW/messages`).then(m => m.messages),
+        import('date-fns/locale/zh-TW').then(m => m.zhTW),
       ])
       break
     }
     default: {
-      mod = await import(`./locales/en/messages`)
+      messages = await import(`./locales/en/messages`).then(m => m.messages)
       break
     }
   }
 
-  i18n.load(locale, mod.messages)
+  i18n.load(locale, messages)
   i18n.activate(locale)
 
   return dateLocale
@@ -305,7 +306,7 @@ export function useLocaleLanguage() {
     const sanitizedLanguage = sanitizeAppLanguageSetting(appLanguage)
 
     document.documentElement.lang = sanitizedLanguage
-    dynamicActivate(sanitizedLanguage).then(locale => {
+    void dynamicActivate(sanitizedLanguage).then(locale => {
       setDateLocale(locale)
     })
   }, [appLanguage])

--- a/src/logger/transports/console.ts
+++ b/src/logger/transports/console.ts
@@ -1,4 +1,4 @@
-import format from 'date-fns/format'
+import {format} from 'date-fns/format'
 
 import {LogLevel, type Transport} from '#/logger/types'
 import {prepareMetadata} from '#/logger/util'

--- a/src/platform/polyfills.web.ts
+++ b/src/platform/polyfills.web.ts
@@ -25,7 +25,8 @@ if (process.env.NODE_ENV !== 'production') {
       thrownErrors.add(err)
       throw err
     } else if (!thrownErrors.has(msgOrError)) {
-      return realConsoleError.apply(this, arguments as any)
+      // @ts-expect-error
+      return realConsoleError.apply(this, arguments)
     }
   }
 }


### PR DESCRIPTION
Latest `date-fns` is slightly smaller, and supports languages that were previously missing/broken.

The biggest change is that it now uses named exports instead of default exports. so I added a bunch of `.then()`s 