### PR TITLE
Gate group chat invites on allowGroupInvites

### DIFF
--- a/src/components/dms/AddMembersFlow.tsx
+++ b/src/components/dms/AddMembersFlow.tsx
@@ -18,7 +18,7 @@ import {type ListMethods} from '#/view/com/util/List'
 import {android, atoms as a, native, useTheme, web} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
-import {canBeMessaged, type ConvoWithDetails} from '#/components/dms/util'
+import {canBeAddedToGroup, type ConvoWithDetails} from '#/components/dms/util'
 import * as Toggle from '#/components/forms/Toggle'
 import {ArrowLeft_Stroke2_Corner0_Rounded as ArrowLeftIcon} from '#/components/icons/Arrow'
 import {TimesLarge_Stroke2_Corner0_Rounded as XIcon} from '#/components/icons/Times'
@@ -190,7 +190,9 @@ export function AddMembersFlow({
         }
 
         _items.sort(item => {
-          return item.type === 'profile' && canBeMessaged(item.profile) ? -1 : 1
+          return item.type === 'profile' && canBeAddedToGroup(item.profile)
+            ? -1
+            : 1
         })
       }
     } else {
@@ -206,7 +208,9 @@ export function AddMembersFlow({
         }
 
         _items.sort(item => {
-          return item.type === 'profile' && canBeMessaged(item.profile) ? -1 : 1
+          return item.type === 'profile' && canBeAddedToGroup(item.profile)
+            ? -1
+            : 1
         })
       } else {
         for (let i = 0; i < 10; i++) {

--- a/src/components/dms/InitiateChatFlow.tsx
+++ b/src/components/dms/InitiateChatFlow.tsx
@@ -20,7 +20,7 @@ import {type ListMethods} from '#/view/com/util/List'
 import {android, atoms as a, native, useTheme, web} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
-import {canBeMessaged} from '#/components/dms/util'
+import {canBeAddedToGroup, canBeMessaged} from '#/components/dms/util'
 import * as TextField from '#/components/forms/TextField'
 import * as Toggle from '#/components/forms/Toggle'
 import {
@@ -246,6 +246,8 @@ export function InitiateChatFlow({
 
   const items = useMemo(() => {
     let _items: Item[] = []
+    const checker =
+      chatState === ChatState.NEW_GROUP_CHAT ? canBeAddedToGroup : canBeMessaged
 
     if (isError) {
       _items.push({
@@ -276,7 +278,7 @@ export function InitiateChatFlow({
         }
 
         _items = _items.sort(item => {
-          return item.type === 'profile' && canBeMessaged(item.profile) ? -1 : 1
+          return item.type === 'profile' && checker(item.profile) ? -1 : 1
         })
       }
     } else {
@@ -299,7 +301,7 @@ export function InitiateChatFlow({
         }
 
         _items = _items.sort(item => {
-          return item.type === 'profile' && canBeMessaged(item.profile) ? -1 : 1
+          return item.type === 'profile' && checker(item.profile) ? -1 : 1
         })
       } else {
         _items.push(...placeholders)
@@ -825,7 +827,7 @@ function GroupChatMemberProfileCard({
   moderationOpts: ModerationOpts
 }) {
   const t = useTheme()
-  const enabled = canBeMessaged(profile)
+  const enabled = canBeAddedToGroup(profile)
   const handle = sanitizeHandle(profile.handle, '@')
 
   return (
@@ -845,7 +847,7 @@ function GroupChatMemberProfileCard({
             <Text
               style={[a.leading_snug, t.atoms.text_contrast_high]}
               numberOfLines={2}>
-              <Trans>{handle} can’t be messaged</Trans>
+              <Trans>{handle} can’t be added</Trans>
             </Text>
           )}
         </View>

--- a/src/components/dms/components/GroupChatProfileCard.tsx
+++ b/src/components/dms/components/GroupChatProfileCard.tsx
@@ -5,7 +5,7 @@ import {Trans} from '@lingui/react/macro'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {atoms as a, useTheme} from '#/alf'
-import {canBeMessaged} from '#/components/dms/util'
+import {canBeAddedToGroup} from '#/components/dms/util'
 import * as Toggle from '#/components/forms/Toggle'
 import * as ProfileCard from '#/components/ProfileCard'
 import {Text} from '#/components/Typography'
@@ -19,7 +19,7 @@ export function GroupChatProfileCard({
   moderationOpts: ModerationOpts
 }) {
   const t = useTheme()
-  const enabled = canBeMessaged(profile)
+  const enabled = canBeAddedToGroup(profile)
   const moderation = moderateProfile(profile, moderationOpts)
   const handle = sanitizeHandle(profile.handle, '@')
   const displayName = sanitizeDisplayName(
@@ -53,7 +53,7 @@ export function GroupChatProfileCard({
               <Text
                 style={[a.leading_snug, t.atoms.text_contrast_high]}
                 numberOfLines={2}>
-                <Trans>{handle} can’t be messaged</Trans>
+                <Trans>{handle} can’t be added</Trans>
               </Text>
             )}
           </View>

--- a/src/components/dms/util.ts
+++ b/src/components/dms/util.ts
@@ -24,6 +24,20 @@ export function canBeMessaged(profile: bsky.profile.AnyProfileView) {
   }
 }
 
+export function canBeAddedToGroup(profile: bsky.profile.AnyProfileView) {
+  switch (profile.associated?.chat?.allowGroupInvites) {
+    case 'none':
+      return false
+    case 'all':
+      return true
+    case 'following':
+    case undefined:
+      return Boolean(profile.viewer?.followedBy)
+    default:
+      return false
+  }
+}
+
 export function localDateString(date: Date) {
   // can't use toISOString because it should be in local time
   const mm = date.getMonth()


### PR DESCRIPTION
## Summary

The actor declaration record (`chat.bsky.actor.declaration`) has two independent permission fields:

- `allowIncoming` — controls 1-on-1 DMs
- `allowGroupInvites` — controls being added to group chats

`allowGroupInvites` is plumbed through the mutation and settings UI, but client enforcement was missing — every group-chat member-selection surface still gated on `canBeMessaged()`, which only reads `allowIncoming`.

- Add `canBeAddedToGroup()` helper in `src/components/dms/util.ts`, mirroring `canBeMessaged` semantics but reading `profile.associated?.chat?.allowGroupInvites`.
- Switch group-chat surfaces (`GroupChatProfileCard`, `AddMembersFlow`, `InitiateChatFlow` group sort + `GroupChatMemberProfileCard`) to the new helper. 1-on-1 surfaces stay on `canBeMessaged` — each setting controls its own surface.
- Update fallback copy on group surfaces from "{handle} can't be messaged" → "{handle} can't be added".

Linear: [APP-2215](https://linear.app/blueskyweb/issue/APP-2215/gate-group-chat-invites-on-allowgroupinvites-in-client-ui)

## Test plan

- [ ] `pnpm typecheck` and `pnpm lint` pass
- [ ] As account A, set "Allow group chat invites from" = No one. From B (follows A): A appears disabled in the new-group-chat picker and Add Members flow, with "can't be added" copy. 1-on-1 chat with A still works.
- [ ] Set A's group-invite to "Users I follow": A is addable to a group only if A follows B
- [ ] Set A: `allowIncoming: 'none'` + `allowGroupInvites: 'all'`: A is addable to groups, but the Message button on A's profile is hidden — confirms the two paths are independent

🤖 Generated with [Claude Code](https://claude.com/claude-code)