### PR TITLE
[Chat] Disable group convos when owner has chats disabled

### DIFF
--- a/src/screens/Messages/Conversation.tsx
+++ b/src/screens/Messages/Conversation.tsx
@@ -49,6 +49,7 @@ import {ChatDisabled} from './components/ChatDisabled'
 import {ChatEnded} from './components/ChatEnded'
 import {ChatLocked} from './components/ChatLocked'
 import {RequestStatus} from './components/RequestStatus'
+import {GroupOwnerChatDisabled} from './components/GroupOwnerChatDisabled'
 
 type Props = NativeStackScreenProps<
   CommonNavigatorParams,
@@ -250,7 +251,9 @@ function InnerReady({
       />
     )
   } else if (convo?.kind === 'group') {
-    if (convo.details.lockStatus === 'locked') {
+    if (convo.primaryMember?.chatDisabled) {
+      footer = <GroupOwnerChatDisabled convo={convo} />
+    } else if (convo.details.lockStatus === 'locked') {
       footer = <ChatLocked convo={convo} />
     } else if (convo.details.lockStatus === 'locked-permanently') {
       footer = <ChatEnded convo={convo} />

--- a/src/screens/Messages/Conversation.tsx
+++ b/src/screens/Messages/Conversation.tsx
@@ -48,8 +48,8 @@ import {IS_LIQUID_GLASS} from '#/env'
 import {ChatDisabled} from './components/ChatDisabled'
 import {ChatEnded} from './components/ChatEnded'
 import {ChatLocked} from './components/ChatLocked'
-import {RequestStatus} from './components/RequestStatus'
 import {GroupOwnerChatDisabled} from './components/GroupOwnerChatDisabled'
+import {RequestStatus} from './components/RequestStatus'
 
 type Props = NativeStackScreenProps<
   CommonNavigatorParams,

--- a/src/screens/Messages/Conversation.tsx
+++ b/src/screens/Messages/Conversation.tsx
@@ -52,6 +52,7 @@ import {IS_INTERNAL, IS_LIQUID_GLASS} from '#/env'
 import {ChatDisabled} from './components/ChatDisabled'
 import {ChatEnded} from './components/ChatEnded'
 import {ChatLocked} from './components/ChatLocked'
+import {GroupOwnerChatDisabled} from './components/GroupOwnerChatDisabled'
 
 type Props = NativeStackScreenProps<
   CommonNavigatorParams,
@@ -274,7 +275,9 @@ function InnerReady({
       />
     )
   } else if (convo?.kind === 'group') {
-    if (convo.details.lockStatus === 'locked') {
+    if (convo.primaryMember?.chatDisabled) {
+      footer = <GroupOwnerChatDisabled convo={convo} />
+    } else if (convo.details.lockStatus === 'locked') {
       footer = <ChatLocked convo={convo} />
     } else if (convo.details.lockStatus === 'locked-permanently') {
       footer = <ChatEnded convo={convo} />

--- a/src/screens/Messages/components/GroupOwnerChatDisabled.tsx
+++ b/src/screens/Messages/components/GroupOwnerChatDisabled.tsx
@@ -41,7 +41,7 @@ export function GroupOwnerChatDisabled({
   return (
     <ChatFooter
       heading={l`This chat is unavailable`}
-      subheading={l`The group owner has been suspended`}
+      subheading={l`The group owner has lost access to chats`}
       icon={WarningIcon}>
       <Pressable
         accessibilityRole="button"

--- a/src/screens/Messages/components/GroupOwnerChatDisabled.tsx
+++ b/src/screens/Messages/components/GroupOwnerChatDisabled.tsx
@@ -1,0 +1,71 @@
+import {Pressable} from 'react-native'
+import {Trans, useLingui} from '@lingui/react/macro'
+import {StackActions, useNavigation} from '@react-navigation/native'
+
+import {HITSLOP_10} from '#/lib/constants'
+import {type NavigationProp} from '#/lib/routes/types'
+import {logger} from '#/logger'
+import {useLeaveConvo} from '#/state/queries/messages/leave-conversation'
+import {atoms as a, useTheme} from '#/alf'
+import {type ConvoWithDetails} from '#/components/dms/util'
+import {Warning_Stroke2_Corner0_Rounded as WarningIcon} from '#/components/icons/Warning'
+import * as Prompt from '#/components/Prompt'
+import * as Toast from '#/components/Toast'
+import {Text} from '#/components/Typography'
+import {LeaveChatPrompt} from '../ConversationSettings/prompts'
+import {ChatFooter} from './ChatFooter'
+
+export function GroupOwnerChatDisabled({
+  convo,
+}: {
+  convo: Extract<ConvoWithDetails, {kind: 'group'}>
+}) {
+  const t = useTheme()
+  const {t: l} = useLingui()
+
+  const leaveChatPrompt = Prompt.usePromptControl()
+  const navigation = useNavigation<NavigationProp>()
+
+  const {mutate: leaveConvo} = useLeaveConvo(convo.view.id, {
+    onSuccess: () => {
+      navigation.dispatch(StackActions.pop(2))
+    },
+    onError: e => {
+      logger.error('Failed to leave group chat', {message: e})
+      Toast.show(l({message: 'Failed to leave group chat', context: 'toast'}), {
+        type: 'error',
+      })
+    },
+  })
+
+  return (
+    <ChatFooter
+      heading={l`This chat is unavailable`}
+      subheading={l`The group owner has been suspended`}
+      icon={WarningIcon}>
+      <Pressable
+        accessibilityRole="button"
+        hitSlop={HITSLOP_10}
+        style={[a.mx_md]}
+        onPress={leaveChatPrompt.open}>
+        <Text
+          numberOfLines={1}
+          style={[
+            a.text_sm,
+            a.font_semi_bold,
+            a.leading_snug,
+            {
+              color: t.palette.negative_500,
+            },
+          ]}>
+          <Trans>Leave chat</Trans>
+        </Text>
+      </Pressable>
+      <LeaveChatPrompt
+        control={leaveChatPrompt}
+        groupName={convo.details.name}
+        onConfirm={leaveConvo}
+      />
+    </ChatFooter>
+  )
+}


### PR DESCRIPTION
## Summary

- When a group convo's owner (`primaryMember`) has `chatDisabled === true`, replace the composer with a compact "This chat is unavailable / The group owner has been suspended" footer.
- New `<GroupOwnerChatDisabled />` mirrors the `<ChatLocked />` / `<ChatEnded />` pill pattern. No appeal button (nothing for the viewer to appeal — it's the owner's moderation action). Keeps a "Leave chat" affordance.
- Self chat-disabled flow is unchanged (`<ChatDisabled />` with the appeal dialog still wins precedence).

## Why

The chat backend doesn't auto-lock groups when the owner is moderated, so members keep seeing a working composer in a group that's effectively dead — the owner can't unlock, can't be replaced, and any messages members send hit a wall. This is a client-only UX fix using `chatDisabled` data the chat service already emits on every `profileViewBasic`.

## Footer precedence

```
1. self isDisabled                            → ChatDisabled
2. primaryMember blocked                      → MessagesListBlockedFooter
3. group & primaryMember.chatDisabled         → GroupOwnerChatDisabled   ← new
4. group & lockStatus === 'locked'            → ChatLocked
5. group & lockStatus === 'locked-permanently'→ ChatEnded
```

Closes APP-2216

## Test plan

- [ ] Self chat-disabled in a group still shows `<ChatDisabled />` with the appeal button.
- [ ] Group with a chat-disabled owner shows the new pill and hides the composer.
- [ ] "Leave chat" works from the new pill.
- [ ] Direct convo with a chat-disabled recipient is unaffected.
- [ ] Owner-disabled + locked overlap: new pill wins (precedence #3 before #4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)