### PR TITLE
Update husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 pnpm exec lint-staged --concurrent false

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     }
   },
   "scripts": {
-    "prepare": "is-ci || husky install",
+    "prepare": "is-ci || husky",
     "postinstall": "pnpm intl:compile-if-needed",
     "prebuild": "EXPO_NO_GIT_STATUS=1 expo prebuild --clean",
     "android": "expo run:android",
@@ -282,7 +282,7 @@
     "eslint-plugin-simple-import-sort": "^13.0.0",
     "file-loader": "6.2.0",
     "globals": "^17.0.0",
-    "husky": "^8.0.3",
+    "husky": "^9.1.7",
     "is-ci": "^3.0.1",
     "jest": "^29.7.0",
     "jest-expo": "~54.0.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -642,8 +642,8 @@ importers:
         specifier: ^17.0.0
         version: 17.6.0
       husky:
-        specifier: ^8.0.3
-        version: 8.0.3
+        specifier: ^9.1.7
+        version: 9.1.7
       is-ci:
         specifier: ^3.0.1
         version: 3.0.1
@@ -6472,9 +6472,9 @@ packages:
   humps@2.0.1:
     resolution: {integrity: sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g==}
 
-  husky@8.0.3:
-    resolution: {integrity: sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==}
-    engines: {node: '>=14'}
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   hyperlinker@1.0.0:
@@ -17419,7 +17419,7 @@ snapshots:
 
   humps@2.0.1: {}
 
-  husky@8.0.3: {}
+  husky@9.1.7: {}
 
   hyperlinker@1.0.0: {}
 


### PR DESCRIPTION
Was getting a perms error when trying to run husky during the `prepare` step, seems to be a [known thing in pnpm installs](https://github.com/typicode/husky/issues/1017). I just bumped husky and installed according to updated docs and that seems to resolve it.