### PR TITLE
Fix CI by restoring changes from #10538

### DIFF
--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -91,8 +91,6 @@ jobs:
         if: ${{ !steps.fingerprint.outputs.includes-changes }}
         with:
           expo-version: latest
-          eas-version: latest
-          packager: pnpm
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: ⛏️ Setup Expo
@@ -188,12 +186,7 @@ jobs:
         uses: expo/expo-github-action@main
         with:
           expo-version: latest
-          eas-version: latest
-          packager: pnpm
           token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: ⛏️ Setup EAS local builds
-        run: pnpm add -g eas-cli-local-build-plugin
 
       - name: ⚙️ Install dependencies
         run: pnpm install --frozen-lockfile
@@ -339,12 +332,7 @@ jobs:
         uses: expo/expo-github-action@main
         with:
           expo-version: latest
-          eas-version: latest
-          packager: pnpm
           token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: ⛏️ Setup EAS local builds
-        run: pnpm add -g eas-cli-local-build-plugin
 
       - uses: actions/setup-java@v5
         with:

--- a/.github/workflows/pull-request-comment.yml
+++ b/.github/workflows/pull-request-comment.yml
@@ -144,12 +144,7 @@ jobs:
         uses: expo/expo-github-action@main
         with:
           expo-version: latest
-          eas-version: latest
-          packager: pnpm
           token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: ⛏️ Setup Expo
-        run: pnpm add -g eas-cli-local-build-plugin
 
       - name: 🪛 Setup jq
         uses: dcarbone/install-jq-action@v2


### PR DESCRIPTION
It seems resolving a merge conflict unintentionally reverted the changes from #10538, which broke GitHub Actions again ([example](https://github.com/bluesky-social/social-app/actions/runs/26115934373/job/76805928894)).