### PR TITLE
Fix stuck tooltip bubble on Safari

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -114,6 +114,11 @@ input:focus {
   white-space: nowrap;
   font-size: 12px;
   z-index: 10;
+  /* HACK: promote to its own layer so Safari's compositor doesn't latch the
+     bubble's `display: block` state when SubtleHover (also promoted) sits in
+     the same stacking context. Without this, hovering certain notification
+     items can leave the bubble visible permanently until a relayout. -sfn */
+  will-change: transform;
 }
 [data-tooltip]::before {
   content: '';


### PR DESCRIPTION
Fixes https://bsky.app/profile/brentwould.bsky.social/post/3mm5rw3dbnk2u

## Summary

- The `[data-tooltip]::after` pseudo (used for post/notification timestamp tooltips) can stick around permanently on macOS Safari after the cursor leaves the trigger.
- Most reliably reproducible on aggregated notification items (e.g. "x and 3 others liked your post").
- Force-toggling `:hover` off in devtools clears the bubble, which means Safari has latched the element's `:hover` state. The arrow (`::before`) clears correctly on its own, only the bubble (`::after`) sticks.

The bug existed before #10135 but was masked: leaving the row used to repaint the area via SubtleHover's opacity transition, which incidentally cleared the latched bubble. Once SubtleHover started using `will-change: opacity`, that repaint moved to its own compositor layer and stopped sweeping the bubble's layer with it.

Fix: promote the bubble pseudo onto its own layer with `will-change: transform`. The arrow doesn't need promotion (and promoting both produced a subpixel gap between them).

### Before

https://github.com/user-attachments/assets/d77eef4d-cd74-4611-8524-e623f2a1b518



### After


https://github.com/user-attachments/assets/2bb5683b-b4f3-491b-b057-1680aa721dce




## Test plan

- [ ] On macOS Safari, hover several aggregated notification items in the Notifications tab. Bubble appears and clears reliably; no permanent sticking.
- [ ] Single-author notifs still show their tooltip on hover.
- [ ] Post timestamps in feeds show their tooltip on hover.
- [ ] No visible gap between the bubble and the arrow.
- [ ] Other browsers (Chrome, Firefox) still render tooltips correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)