### PR TITLE
Reduce the number of join requests per page to 20

### DIFF
--- a/src/state/queries/messages/list-join-requests.ts
+++ b/src/state/queries/messages/list-join-requests.ts
@@ -53,7 +53,7 @@ export function useListJoinRequestsQuery({
     queryKey: createListJoinRequestsQueryKey({convoId: convoId ?? ''}),
     queryFn: async ({pageParam}) => {
       const {data} = await agent.chat.bsky.group.listJoinRequests(
-        {convoId: convoId!, cursor: pageParam, limit: 50},
+        {convoId: convoId!, cursor: pageParam, limit: 20},
         {headers: DM_SERVICE_HEADERS},
       )
       return data


### PR DESCRIPTION
This matches what we’re going to use for request count on the chat list screen.