### PR TITLE
Wrap group chat names when appropriate

### DIFF
--- a/src/screens/Messages/components/MessagesListInfoPanel.tsx
+++ b/src/screens/Messages/components/MessagesListInfoPanel.tsx
@@ -90,15 +90,18 @@ export function MessagesListInfoPanel({
       <View style={[a.align_center, a.justify_center]}>
         <AvatarBubbles animate={true} profiles={convo.members} />
         {convo.details.name ? (
-          <Text style={[a.text_2xl, a.font_bold, a.mt_lg, t.atoms.text]}>
+          <Text
+            style={[a.text_2xl, a.font_bold, a.mt_lg, a.px_lg, t.atoms.text]}>
             {convo.details.name}
           </Text>
         ) : null}
         {names ? (
           <Text
             style={[
-              a.text_sm,
+              a.px_lg,
               a.mt_xs,
+              a.text_center,
+              a.text_sm,
               t.atoms.text_contrast_high,
               showButtons ? null : a.mb_4xl,
             ]}>


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="1206" height="2622" alt="before" src="https://github.com/user-attachments/assets/dbf10406-c717-46bd-92aa-1fd20f7b7d4b" /> | <img width="1206" height="2622" alt="after" src="https://github.com/user-attachments/assets/4687fe9c-2d1c-4a0e-83a8-9ec9cab02399" /> |
