### PR TITLE
Add bsky-stats API client, SSE client, and query hooks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,3 +49,7 @@ LIVE_EVENTS_DEV_URL=
 
 # app-config web worker URL
 APP_CONFIG_DEV_URL=
+
+# Bluesky Feed Consumer (bsky-stats) backend
+BSKY_STATS_BASE_URL=
+BSKY_STATS_API_KEY=

--- a/docs-tedd4u/implementation-order.md
+++ b/docs-tedd4u/implementation-order.md
@@ -1,0 +1,152 @@
+# Implementation Order
+
+Incremental build-up: each phase produces something testable in the web browser before moving on.
+
+## Phase 1: API Client + Plumbing
+
+Standalone data layer — no UI yet, but fully testable via Jest and browser console.
+
+1. **API client module** — `src/lib/api/bsky-stats.ts`
+   - Typed fetch wrapper for our backend (`/stats/{window}`, `/personas/...`, `/personas/{handle}/chat`)
+   - `X-Api-Key` header injection
+   - Error handling (network, 401, 500)
+   - Backend base URL from env/config
+
+2. **SSE client module** — `src/lib/api/bsky-stats-sse.ts`
+   - EventSource wrapper for live stats stream
+   - Parse `snapshot`, `update`, `token` event types into typed objects
+   - Auto-reconnect with backoff
+   - Cleanup on unmount
+
+3. **TanStack Query hooks** — `src/state/queries/bsky-stats.ts`
+   - `useStatsQuery(window)` — fetches `/stats/{window}`, refetches on focus
+   - `useStatsStream()` — SSE hook that updates query cache in real-time
+   - `usePersonaStatus(handle)` — polls `/personas/{handle}/status`
+   - `usePersonaChat(handle)` — fetches conversation history
+   - `usePersonaChatMutation(handle)` — sends message, handles streaming response
+
+4. **Unit tests** — `src/lib/api/__tests__/bsky-stats.test.ts`
+   - URL construction, header injection, error paths
+   - SSE event parsing (snapshot, update, token, malformed)
+   - Number formatting, velocity data transforms
+
+**Test review:** API client logic, SSE parsing, data transforms. Focus: correctness of URL construction, header injection, error handling, event deserialization. All pure-logic tests — no mocking React.
+
+**Exit criterion:** tests pass (`pnpm test`), hooks importable.
+
+## Phase 2: Stats Dashboard Screen
+
+First visible feature — a new screen showing live firehose stats.
+
+5. **Route registration**
+   - Add `BskyStats` to `CommonNavigatorParams` in `src/lib/routes/types.ts`
+   - Register screen in `src/Navigation.tsx` (in each tab navigator that needs it)
+
+6. **Stats dashboard screen** — `src/screens/BskyStats/`
+   - `index.tsx` — main screen component
+   - Counts row: posts/min, unique posters, likes, reposts, replies (per selected window)
+   - Window selector: tabs for 1m / 5m / 10m
+   - Top-N lists: top liked, top reposted, top replied (link to post threads)
+   - Language breakdown: horizontal bar chart or simple ranked list
+   - Velocity sparkline: posting rate over last hour (simple line/area chart)
+   - SSE connection: stats update live every ~2s
+
+7. **Nav entry point**
+   - Add a temporary entry point to reach the screen (e.g. button in Discover tab header, or a route you can type in the URL bar during dev)
+   - Decide on permanent nav placement later
+
+**Test review:** Revisit Phase 1 tests now that we've seen real data flowing. Add cases for: edge-case stat values (zeros, very large numbers), SSE reconnection behavior, query cache invalidation after window switch. Manual browser verification that live updates don't flicker or accumulate stale data.
+
+**Exit criterion:** screen loads in browser, shows live stats from the backend, updates in real-time.
+
+## Phase 3: Persona Chat — Registration + Status
+
+Wire up persona creation so we can start chatting.
+
+8. **Persona registration action** — `src/state/queries/bsky-stats.ts` (extend)
+   - `useRegisterPersonaMutation()` — `POST /personas` with a handle
+   - Invalidates persona status query on success
+
+9. **Profile menu entry point** — modify `src/view/com/profile/ProfileMenu.tsx`
+   - Add "Chat with AI {displayName}" menu item
+   - On tap: register persona (if not already), navigate to chat screen
+   - Conditional: only show when backend is configured/reachable
+
+**Test review:** Add tests for persona registration mutation — success, duplicate handle, network failure. Verify status polling transitions (loading → ready → error) and that the UI responds correctly to each state.
+
+**Exit criterion:** tap three-dot menu on a profile → "Chat with AI" item appears → persona registers on backend.
+
+## Phase 4: Persona Chat Screen
+
+The conversation UI.
+
+10. **Chat screen** — `src/screens/BskyStats/PersonaChat.tsx`
+    - Route: `PersonaChat` with `{handle: string}` param
+    - Message thread: scrollable list of user/AI messages
+    - Compose bar: text input + send button
+    - Streaming response: AI reply appears token-by-token via SSE
+    - Persona status indicator: loading spinner if corpus still fetching
+    - Debug info: corpus freshness timestamp in small type
+
+11. **Chat inbox screen** — `src/screens/BskyStats/PersonaChatList.tsx`
+    - List of active persona chats (personas with conversation history)
+    - Each row: avatar, display name, last message preview
+    - Tap → navigate to PersonaChat screen
+    - "Clear chat" swipe action or long-press menu
+
+12. **Chat inbox nav entry**
+    - Add nav item in sidebar/bottom tab area (similar to DM icon placement)
+    - Badge with unread/active count (optional, low priority)
+
+**Test review:** Add tests for chat mutation — message send, streaming token accumulation, error mid-stream. Test conversation history fetch and cache behavior (does sending a message optimistically update the list?). Manual browser verification of streaming UX: first-token latency, partial render, completion.
+
+**Exit criterion:** can have a full streaming conversation with an AI persona, navigate between chat list and individual chats.
+
+## Phase 5: Polish + Integration
+
+13. **Lingui i18n** — wrap all user-facing strings in `<Trans>` / `t` macros, run `pnpm intl:extract`
+14. **Theming** — verify light/dark mode, match existing app typography and spacing via ALF atoms
+15. **Error states** — network errors, backend unreachable, persona loading failures
+16. **Responsive layout** — verify mobile-width rendering in browser (phone-like viewport)
+
+**Test review:** Full test suite audit. Check coverage gaps across all phases. Verify no hardcoded strings escaped Lingui. Run `pnpm test` end-to-end — everything green before moving to device.
+
+**Exit criterion:** feature-complete, visually consistent, no hardcoded English strings outside Lingui.
+
+## Phase 6: On-Device Testing
+
+17. **iOS build + test** — build with Expo, install on physical iPhone, verify all screens and interactions
+18. **Android build + test** — build with Expo, install on physical Android device or emulator, verify parity
+19. **Platform-specific issues** — fix any RN component differences, safe area insets, keyboard avoidance, SSE polyfill behavior, gesture conflicts
+
+**Exit criterion:** both platforms functional, no web-only assumptions leaking through.
+
+---
+
+## File Map (planned)
+
+```
+src/
+  lib/api/
+    bsky-stats.ts          # fetch wrapper for our backend
+    bsky-stats-sse.ts      # SSE client for live stats
+    __tests__/
+      bsky-stats.test.ts   # unit tests
+  state/queries/
+    bsky-stats.ts           # TanStack Query hooks
+  screens/BskyStats/
+    index.tsx               # stats dashboard
+    PersonaChat.tsx         # chat conversation screen
+    PersonaChatList.tsx     # chat inbox / list screen
+    components/             # shared sub-components (sparkline, stat card, etc.)
+  view/com/profile/
+    ProfileMenu.tsx         # (modify) add "Chat with AI" item
+```
+
+## Dev Workflow
+
+- `fnm use 24.15.0` before running anything
+- `pnpm web` → iterate in browser at localhost:19006
+- `pnpm test` → run Jest unit tests
+- `pnpm intl:extract` → after adding Lingui strings
+- Each phase gets its own branch + PR

--- a/docs-tedd4u/testing-approach.md
+++ b/docs-tedd4u/testing-approach.md
@@ -1,0 +1,79 @@
+# Testing Approach
+
+Our additions to the social-app (stats dashboard, persona chat screens) follow the existing testing conventions rather than introducing new patterns.
+
+## Existing Patterns in social-app
+
+| Layer | Framework | What's tested | Our usage |
+|-------|-----------|---------------|-----------|
+| Unit tests | Jest (`pnpm test`) | Pure logic: utilities, parsers, state classes | Yes - test our data layer |
+| E2E flows | Maestro (YAML) | Full mobile user flows (native only) | No - requires native builds, defeats web-first workflow |
+| Component render tests | Not used | (no `@testing-library/react-native` in codebase) | No - not the convention here |
+
+## What We Test
+
+### 1. API Client Module
+
+Unit test the fetch wrapper that talks to our backend:
+
+- Correct URL construction (`/stats/{window}`, `/personas/{handle}/chat`)
+- `X-Api-Key` header always included
+- Error handling (401, 500, network failure)
+- Response parsing
+
+### 2. SSE Event Parsing
+
+Unit test the EventSource message handler:
+
+- Parse `snapshot` events into typed stats objects
+- Parse `update` events (incremental stats)
+- Parse `token` events (persona chat streaming)
+- Handle malformed events gracefully
+
+### 3. Data Transforms
+
+Unit test formatting/display logic:
+
+- Number formatting (e.g., 2241 posts/min display)
+- Velocity sparkline data preparation (array of rates to chart-ready format)
+- Language breakdown percentages
+- Relative time formatting for corpus freshness
+
+### 4. TanStack Query Hooks (optional)
+
+If complex enough to warrant testing, test with a QueryClient wrapper:
+
+- Cache invalidation behavior
+- Refetch-on-focus behavior
+- Optimistic updates for chat messages
+
+## What We Don't Test
+
+- **Component rendering** - no precedent, and the web dev server gives immediate visual feedback
+- **Navigation flows** - Maestro-style E2E, requires native; manual testing via web browser
+- **Styling/layout** - visual verification in browser; no snapshot tests
+
+## Conventions
+
+- Test files live next to source: `src/features/bsky-stats/__tests__/api.test.ts`
+- Use `describe`/`it` from `@jest/globals`
+- Mock modules with `jest.mock()`
+- Mock `fetch` globally for API tests
+- Use fake timers (`jest.useFakeTimers()`) for interval/timeout logic
+
+## Internationalization
+
+All user-facing strings must use Lingui macros per `docs/localization.md`:
+
+```tsx
+// In components:
+import {Trans} from '@lingui/react/macro'
+<Text><Trans>Posts per minute</Trans></Text>
+
+// In variables/props:
+import {useLingui} from '@lingui/react/macro'
+const {t} = useLingui()
+<Text accessibilityLabel={t`Stats dashboard`}>...</Text>
+```
+
+Run `pnpm intl:extract` after adding strings (but don't run `intl:compile` - CI handles that).

--- a/src/lib/api/__tests__/bsky-stats.test.ts
+++ b/src/lib/api/__tests__/bsky-stats.test.ts
@@ -1,0 +1,473 @@
+import {beforeEach, describe, expect, it, jest} from '@jest/globals'
+
+import {
+  BskyStatsError,
+  type ChatStreamCallbacks,
+  configureBskyStats,
+  createPersona,
+  deleteChatHistory,
+  fetchChatHistory,
+  fetchPersonaStatus,
+  fetchStats,
+  listPersonas,
+  sendChatMessage,
+} from '../bsky-stats'
+import {parseSSEChunk} from '../bsky-stats-sse'
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+const MOCK_BASE = 'https://bsky.example.com'
+const MOCK_KEY = 'test-api-key-123'
+
+beforeEach(() => {
+  configureBskyStats(MOCK_BASE, MOCK_KEY)
+  jest.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Helper: mock fetch
+// ---------------------------------------------------------------------------
+
+function mockFetchJson(body: unknown, status = 200) {
+  const fn = jest.fn<typeof fetch>().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: () => Promise.resolve(body),
+    body: null,
+  } as Response)
+  global.fetch = fn
+  return fn
+}
+
+function mockFetchFailure(errorMessage: string) {
+  const fn = jest.fn<typeof fetch>().mockRejectedValue(new Error(errorMessage))
+  global.fetch = fn
+  return fn
+}
+
+// ---------------------------------------------------------------------------
+// API client: URL construction
+// ---------------------------------------------------------------------------
+
+describe('bsky-stats API client', () => {
+  describe('URL construction', () => {
+    it('builds correct stats URL with default top_n', async () => {
+      const fetchMock = mockFetchJson({window_seconds: 60})
+      await fetchStats(60)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      const url = fetchMock.mock.calls[0][0]
+      expect(url).toBe(`${MOCK_BASE}/stats/60?top_n=10`)
+    })
+
+    it('builds correct stats URL with custom top_n', async () => {
+      const fetchMock = mockFetchJson({window_seconds: 300})
+      await fetchStats(300, 25)
+      const url = fetchMock.mock.calls[0][0]
+      expect(url).toBe(`${MOCK_BASE}/stats/300?top_n=25`)
+    })
+
+    it('builds correct persona status URL with handle encoding', async () => {
+      const fetchMock = mockFetchJson({handle: 'test.bsky.social'})
+      await fetchPersonaStatus('test.bsky.social')
+      const url = fetchMock.mock.calls[0][0]
+      expect(url).toBe(`${MOCK_BASE}/personas/test.bsky.social/status`)
+    })
+
+    it('builds correct chat history URL', async () => {
+      const fetchMock = mockFetchJson({
+        handle: 'alice.bsky.social',
+        messages: [],
+      })
+      await fetchChatHistory('alice.bsky.social')
+      const url = fetchMock.mock.calls[0][0]
+      expect(url).toBe(`${MOCK_BASE}/personas/alice.bsky.social/chat`)
+    })
+
+    it('builds correct persona list URL', async () => {
+      const fetchMock = mockFetchJson([])
+      await listPersonas()
+      const url = fetchMock.mock.calls[0][0]
+      expect(url).toBe(`${MOCK_BASE}/personas`)
+    })
+
+    it('strips trailing slash from base URL', async () => {
+      configureBskyStats('https://example.com/', MOCK_KEY)
+      const fetchMock = mockFetchJson({})
+      await fetchStats(60)
+      const url = fetchMock.mock.calls[0][0]
+      expect(url).toBe('https://example.com/stats/60?top_n=10')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Header injection
+  // ---------------------------------------------------------------------------
+
+  describe('header injection', () => {
+    it('always includes X-Api-Key header', async () => {
+      const fetchMock = mockFetchJson({})
+      await fetchStats(60)
+      const opts = fetchMock.mock.calls[0][1] as RequestInit
+      const hdrs = opts.headers as Record<string, string>
+      expect(hdrs['X-Api-Key']).toBe(MOCK_KEY)
+    })
+
+    it('includes Content-Type: application/json', async () => {
+      const fetchMock = mockFetchJson({})
+      await fetchStats(60)
+      const opts = fetchMock.mock.calls[0][1] as RequestInit
+      const hdrs = opts.headers as Record<string, string>
+      expect(hdrs['Content-Type']).toBe('application/json')
+    })
+
+    it('POST requests include correct method and body', async () => {
+      const fetchMock = mockFetchJson({handle: 'test.bsky.social'}, 201)
+      await createPersona('test.bsky.social')
+      const opts = fetchMock.mock.calls[0][1] as RequestInit
+      expect(opts.method).toBe('POST')
+      expect(JSON.parse(opts.body as string)).toEqual({
+        handle: 'test.bsky.social',
+      })
+    })
+
+    it('DELETE requests use correct method', async () => {
+      const fn = jest.fn<typeof fetch>().mockResolvedValue({
+        ok: true,
+        status: 204,
+        statusText: 'No Content',
+        json: () => Promise.resolve(undefined),
+        body: null,
+      } as unknown as Response)
+      global.fetch = fn
+      await deleteChatHistory('alice.bsky.social')
+      const opts = fn.mock.calls[0][1] as RequestInit
+      expect(opts.method).toBe('DELETE')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Error handling
+  // ---------------------------------------------------------------------------
+
+  describe('error handling', () => {
+    it('throws BskyStatsError on HTTP 401', async () => {
+      mockFetchJson({detail: 'Invalid API key'}, 401)
+      await expect(fetchStats(60)).rejects.toThrow(BskyStatsError)
+      try {
+        await fetchStats(60)
+      } catch (e) {
+        const err = e as BskyStatsError
+        expect(err.status).toBe(401)
+        expect(err.detail).toBe('Invalid API key')
+      }
+    })
+
+    it('throws BskyStatsError on HTTP 500', async () => {
+      mockFetchJson({detail: 'Internal error'}, 500)
+      await expect(fetchStats(60)).rejects.toThrow(BskyStatsError)
+    })
+
+    it('throws BskyStatsError on HTTP 400 with detail', async () => {
+      mockFetchJson({detail: 'Invalid window 999. Valid: [60, 300, 600]'}, 400)
+      try {
+        await fetchStats(999)
+      } catch (e) {
+        const err = e as BskyStatsError
+        expect(err.status).toBe(400)
+        expect(err.detail).toContain('Invalid window')
+      }
+    })
+
+    it('throws on network failure', async () => {
+      mockFetchFailure('Failed to fetch')
+      await expect(fetchStats(60)).rejects.toThrow(BskyStatsError)
+      try {
+        await fetchStats(60)
+      } catch (e) {
+        const err = e as BskyStatsError
+        expect(err.status).toBe(0)
+        expect(err.message).toContain('Network error')
+      }
+    })
+
+    it('throws when client not configured', async () => {
+      configureBskyStats('', '')
+      await expect(fetchStats(60)).rejects.toThrow('not configured')
+    })
+
+    it('handles non-JSON error responses gracefully', async () => {
+      const fn = jest.fn<typeof fetch>().mockResolvedValue({
+        ok: false,
+        status: 502,
+        statusText: 'Bad Gateway',
+        json: () => Promise.reject(new Error('not json')),
+        body: null,
+      } as unknown as Response)
+      global.fetch = fn
+      try {
+        await fetchStats(60)
+      } catch (e) {
+        const err = e as BskyStatsError
+        expect(err.status).toBe(502)
+        expect(err.detail).toBeUndefined()
+      }
+    })
+
+    it('throws 409 on duplicate persona creation', async () => {
+      mockFetchJson({detail: 'Persona @test.bsky.social already exists'}, 409)
+      try {
+        await createPersona('test.bsky.social')
+      } catch (e) {
+        const err = e as BskyStatsError
+        expect(err.status).toBe(409)
+        expect(err.detail).toContain('already exists')
+      }
+    })
+
+    it('throws 404 for unknown persona', async () => {
+      mockFetchJson({detail: 'Persona @unknown not found'}, 404)
+      try {
+        await fetchPersonaStatus('unknown')
+      } catch (e) {
+        const err = e as BskyStatsError
+        expect(err.status).toBe(404)
+      }
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Response parsing
+  // ---------------------------------------------------------------------------
+
+  describe('response parsing', () => {
+    it('returns typed WindowStats from fetchStats', async () => {
+      const mockData = {
+        window_seconds: 60,
+        window_start: '2026-05-21T12:00:00Z',
+        metrics: {
+          post_count: 2241,
+          user_count: 1500,
+          like_count: 5000,
+          repost_count: 300,
+          reply_count: 800,
+        },
+        deltas: {
+          post_count: 0.12,
+          user_count: null,
+          like_count: -0.05,
+          repost_count: null,
+          reply_count: 0.03,
+        },
+        top_liked: [
+          {
+            uri: 'at://did:plc:abc/app.bsky.feed.post/123',
+            did: 'did:plc:abc',
+            text: 'Hello world',
+            count: 42,
+            timestamp: '2026-05-21T12:00:00Z',
+          },
+        ],
+        top_reposted: [],
+        language_breakdown: {en: 0.65, ja: 0.12, pt: 0.08, other: 0.15},
+      }
+      mockFetchJson(mockData)
+      const result = await fetchStats(60)
+      expect(result.metrics.post_count).toBe(2241)
+      expect(result.top_liked).toHaveLength(1)
+      expect(result.top_liked[0].uri).toBe(
+        'at://did:plc:abc/app.bsky.feed.post/123',
+      )
+      expect(result.language_breakdown.en).toBe(0.65)
+      expect(result.deltas?.post_count).toBe(0.12)
+    })
+
+    it('returns typed PersonaInfo from createPersona', async () => {
+      const mockData = {
+        handle: 'test.bsky.social',
+        display_name: 'Test User',
+        status: 'loading',
+        post_count: 0,
+        reply_count: 0,
+        last_corpus_update: null,
+        avatar_url: null,
+      }
+      mockFetchJson(mockData, 201)
+      const result = await createPersona('test.bsky.social')
+      expect(result.handle).toBe('test.bsky.social')
+      expect(result.status).toBe('loading')
+    })
+
+    it('returns typed ChatHistory from fetchChatHistory', async () => {
+      const mockData = {
+        handle: 'alice.bsky.social',
+        messages: [
+          {role: 'user', content: 'Hi!', created_at: '2026-05-21T12:00:00Z'},
+          {
+            role: 'assistant',
+            content: 'Hey there!',
+            created_at: '2026-05-21T12:00:01Z',
+          },
+        ],
+      }
+      mockFetchJson(mockData)
+      const result = await fetchChatHistory('alice.bsky.social')
+      expect(result.messages).toHaveLength(2)
+      expect(result.messages[0].role).toBe('user')
+      expect(result.messages[1].role).toBe('assistant')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SSE parsing
+// ---------------------------------------------------------------------------
+
+describe('SSE event parsing', () => {
+  it('parses a complete snapshot event', () => {
+    const input =
+      'event: snapshot\ndata: {"timestamp":"2026-05-21T12:00:00Z","windows":{},"velocity":{"current":0,"history":[]}}\n\n'
+    const {events, remainder} = parseSSEChunk(input)
+    expect(events).toHaveLength(1)
+    expect(events[0].event).toBe('snapshot')
+    const data = JSON.parse(events[0].data)
+    expect(data.timestamp).toBe('2026-05-21T12:00:00Z')
+    expect(remainder).toBe('')
+  })
+
+  it('parses an update event', () => {
+    const input =
+      'event: update\ndata: {"timestamp":"2026-05-21T12:00:02Z","windows":{},"velocity":{"current":5.2,"history":[1,2,3]}}\n\n'
+    const {events} = parseSSEChunk(input)
+    expect(events).toHaveLength(1)
+    expect(events[0].event).toBe('update')
+    const data = JSON.parse(events[0].data)
+    expect(data.velocity.current).toBe(5.2)
+  })
+
+  it('parses multiple events in one chunk', () => {
+    const input =
+      'event: snapshot\ndata: {"a":1}\n\nevent: update\ndata: {"b":2}\n\n'
+    const {events} = parseSSEChunk(input)
+    expect(events).toHaveLength(2)
+    expect(events[0].event).toBe('snapshot')
+    expect(events[1].event).toBe('update')
+  })
+
+  it('handles incomplete event (no trailing newline)', () => {
+    const input = 'event: update\ndata: {"partial":'
+    const {events, remainder} = parseSSEChunk(input)
+    expect(events).toHaveLength(0)
+    expect(remainder).toContain('update')
+  })
+
+  it('handles empty input', () => {
+    const {events, remainder} = parseSSEChunk('')
+    expect(events).toHaveLength(0)
+    expect(remainder).toBe('')
+  })
+
+  it('skips events with empty data', () => {
+    const input = 'event: heartbeat\n\n'
+    const {events} = parseSSEChunk(input)
+    // heartbeat has no data line, so no complete event
+    expect(events).toHaveLength(0)
+  })
+
+  it('handles malformed JSON in data gracefully (parser returns raw string)', () => {
+    const input = 'event: update\ndata: {not valid json}\n\n'
+    const {events} = parseSSEChunk(input)
+    expect(events).toHaveLength(1)
+    expect(events[0].data).toBe('{not valid json}')
+    // Caller is responsible for JSON.parse — this tests the parser layer
+    expect(() => JSON.parse(events[0].data)).toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Chat SSE streaming (sendChatMessage)
+// ---------------------------------------------------------------------------
+
+describe('sendChatMessage', () => {
+  it('sends POST with correct URL, headers, and body', () => {
+    const chunks = [
+      'event: token\ndata: {"text":"Hello"}\n\n',
+      'event: done\ndata: {"full_text":"Hello","context_posts_used":10}\n\n',
+    ]
+    let chunkIndex = 0
+
+    const mockReader = {
+      read: jest
+        .fn<() => Promise<{done: boolean; value: Uint8Array | undefined}>>()
+        .mockImplementation(() => {
+          if (chunkIndex < chunks.length) {
+            const chunk = new TextEncoder().encode(chunks[chunkIndex++])
+            return Promise.resolve({done: false, value: chunk})
+          }
+          return Promise.resolve({done: true, value: undefined})
+        }),
+    }
+
+    const fetchMock = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: {getReader: () => mockReader},
+    } as unknown as Response)
+    global.fetch = fetchMock
+
+    const callbacks: ChatStreamCallbacks = {
+      onToken: jest.fn(),
+      onDone: jest.fn(),
+      onError: jest.fn(),
+    }
+
+    sendChatMessage('test.bsky.social', 'Hi there', callbacks)
+
+    // Verify fetch was called with correct params
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${MOCK_BASE}/personas/test.bsky.social/chat`)
+    expect((opts as RequestInit).method).toBe('POST')
+    expect(JSON.parse((opts as RequestInit).body as string)).toEqual({
+      message: 'Hi there',
+    })
+  })
+
+  it('calls onError when HTTP response is not ok', async () => {
+    const fetchMock = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: () => Promise.resolve({detail: 'Persona not ready'}),
+      body: null,
+    } as unknown as Response)
+    global.fetch = fetchMock
+
+    const callbacks: ChatStreamCallbacks = {
+      onToken: jest.fn(),
+      onDone: jest.fn(),
+      onError: jest.fn(),
+    }
+
+    sendChatMessage('test.bsky.social', 'Hi', callbacks)
+
+    // Wait for the async error handling
+    await new Promise(resolve => setTimeout(resolve, 50))
+    expect(callbacks.onError).toHaveBeenCalledWith('Persona not ready')
+  })
+
+  it('returns an AbortController for cancellation', () => {
+    mockFetchJson({}, 200)
+    const callbacks: ChatStreamCallbacks = {
+      onToken: jest.fn(),
+      onDone: jest.fn(),
+      onError: jest.fn(),
+    }
+    const controller = sendChatMessage('test.bsky.social', 'Hi', callbacks)
+    expect(controller).toBeInstanceOf(AbortController)
+    expect(controller.signal.aborted).toBe(false)
+    controller.abort()
+    expect(controller.signal.aborted).toBe(true)
+  })
+})

--- a/src/lib/api/bsky-stats-sse.ts
+++ b/src/lib/api/bsky-stats-sse.ts
@@ -1,0 +1,184 @@
+/**
+ * SSE client for the live stats stream from /sse/stats.
+ *
+ * Uses a plain fetch + ReadableStream approach (works in both web and RN)
+ * rather than the EventSource API, which has spotty RN support.
+ *
+ * Provides auto-reconnect with exponential backoff.
+ */
+import {type StatsSnapshot} from './bsky-stats'
+import {getBaseUrl} from './bsky-stats'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface StatsSSECallbacks {
+  onSnapshot: (data: StatsSnapshot) => void
+  onUpdate: (data: StatsSnapshot) => void
+  onError: (error: Error) => void
+  onConnected?: () => void
+  onDisconnected?: () => void
+}
+
+export interface StatsSSEConnection {
+  /** Close the connection and stop reconnecting. */
+  close: () => void
+}
+
+// ---------------------------------------------------------------------------
+// SSE line parser (shared with tests)
+// ---------------------------------------------------------------------------
+
+export interface ParsedSSEEvent {
+  event: string
+  data: string
+}
+
+/**
+ * Parse a chunk of SSE text into events.
+ * Returns the parsed events and any remaining incomplete text.
+ */
+export function parseSSEChunk(buffer: string): {
+  events: ParsedSSEEvent[]
+  remainder: string
+} {
+  const events: ParsedSSEEvent[] = []
+  const lines = buffer.split('\n')
+  // Last element may be an incomplete line
+  const remainder = lines.pop() ?? ''
+
+  let currentEvent = ''
+  let currentData = ''
+
+  for (const line of lines) {
+    if (line.startsWith('event: ')) {
+      currentEvent = line.slice(7).trim()
+    } else if (line.startsWith('data: ')) {
+      currentData = line.slice(6)
+    } else if (line === '' && currentEvent && currentData) {
+      // Empty line = end of event
+      events.push({event: currentEvent, data: currentData})
+      currentEvent = ''
+      currentData = ''
+    }
+  }
+
+  // If we have a partial event in progress, put it back in the remainder
+  let partialPrefix = ''
+  if (currentEvent) {
+    partialPrefix += `event: ${currentEvent}\n`
+  }
+  if (currentData) {
+    partialPrefix += `data: ${currentData}\n`
+  }
+
+  return {events, remainder: partialPrefix + remainder}
+}
+
+// ---------------------------------------------------------------------------
+// Connection
+// ---------------------------------------------------------------------------
+
+const INITIAL_BACKOFF_MS = 1_000
+const MAX_BACKOFF_MS = 30_000
+
+export function connectStatsSSE(
+  apiKey: string,
+  callbacks: StatsSSECallbacks,
+): StatsSSEConnection {
+  let closed = false
+  let controller: AbortController | null = null
+  let backoff = INITIAL_BACKOFF_MS
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+
+  function scheduleReconnect() {
+    if (closed) return
+    callbacks.onDisconnected?.()
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null
+      if (!closed) connect()
+    }, backoff)
+    backoff = Math.min(backoff * 2, MAX_BACKOFF_MS)
+  }
+
+  async function connect() {
+    if (closed) return
+
+    const baseUrl = getBaseUrl()
+    if (!baseUrl) {
+      callbacks.onError(new Error('BskyStats client not configured'))
+      return
+    }
+
+    controller = new AbortController()
+
+    try {
+      const res = await fetch(`${baseUrl}/sse/stats`, {
+        headers: {'X-Api-Key': apiKey},
+        signal: controller.signal,
+      })
+
+      if (!res.ok) {
+        throw new Error(`SSE connect failed: HTTP ${res.status}`)
+      }
+
+      const reader = res.body?.getReader()
+      if (!reader) {
+        throw new Error('No response body for SSE stream')
+      }
+
+      // Connected successfully — reset backoff
+      backoff = INITIAL_BACKOFF_MS
+      callbacks.onConnected?.()
+
+      const decoder = new TextDecoder()
+      let buffer = ''
+
+      while (!closed) {
+        const {done, value} = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, {stream: true})
+        const {events, remainder} = parseSSEChunk(buffer)
+        buffer = remainder
+
+        for (const evt of events) {
+          try {
+            const parsed = JSON.parse(evt.data) as StatsSnapshot
+            if (evt.event === 'snapshot') {
+              callbacks.onSnapshot(parsed)
+            } else if (evt.event === 'update') {
+              callbacks.onUpdate(parsed)
+            }
+          } catch {
+            // Malformed JSON — skip this event
+          }
+        }
+      }
+    } catch (err) {
+      if (closed) return
+      if (err instanceof Error && err.name === 'AbortError') return
+      callbacks.onError(err instanceof Error ? err : new Error(String(err)))
+    }
+
+    // Stream ended or errored — reconnect
+    if (!closed) {
+      scheduleReconnect()
+    }
+  }
+
+  // Start first connection
+  connect()
+
+  return {
+    close() {
+      closed = true
+      controller?.abort()
+      if (reconnectTimer !== null) {
+        clearTimeout(reconnectTimer)
+        reconnectTimer = null
+      }
+    },
+  }
+}

--- a/src/lib/api/bsky-stats.ts
+++ b/src/lib/api/bsky-stats.ts
@@ -1,0 +1,317 @@
+/**
+ * API client for the Bluesky Feed Consumer backend.
+ *
+ * Typed fetch wrapper covering /stats, /personas, and /sse endpoints.
+ * All requests include the X-Api-Key header for authentication.
+ */
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+let _baseUrl = ''
+let _apiKey = ''
+
+/**
+ * Initialise the client. Call once at app startup before any fetches.
+ * Values typically come from EXPO_PUBLIC_* env vars.
+ */
+export function configureBskyStats(baseUrl: string, apiKey: string): void {
+  // Strip trailing slash so callers can just append paths
+  _baseUrl = baseUrl.replace(/\/+$/, '')
+  _apiKey = apiKey
+}
+
+export function getBaseUrl(): string {
+  return _baseUrl
+}
+
+// ---------------------------------------------------------------------------
+// Types — Stats
+// ---------------------------------------------------------------------------
+
+export interface StatsMetrics {
+  post_count: number
+  user_count: number
+  like_count: number
+  repost_count: number
+  reply_count: number
+}
+
+export interface StatsDeltas {
+  post_count: number | null
+  user_count: number | null
+  like_count: number | null
+  repost_count: number | null
+  reply_count: number | null
+}
+
+export interface TopItem {
+  uri: string
+  did: string
+  text: string
+  count: number
+  timestamp: string
+}
+
+export interface WindowStats {
+  window_seconds: number
+  window_start: string
+  metrics: StatsMetrics
+  deltas: StatsDeltas | null
+  top_liked: TopItem[]
+  top_reposted: TopItem[]
+  language_breakdown: Record<string, number>
+}
+
+export interface VelocityData {
+  current: number
+  history: number[]
+}
+
+/** Shape of the SSE snapshot/update event data. */
+export interface StatsSnapshot {
+  timestamp: string
+  windows: Record<string, WindowStats>
+  velocity: VelocityData
+}
+
+// ---------------------------------------------------------------------------
+// Types — Personas
+// ---------------------------------------------------------------------------
+
+export interface PersonaInfo {
+  handle: string
+  display_name: string | null
+  status: 'loading' | 'ready' | 'error'
+  post_count: number
+  reply_count: number
+  last_corpus_update: string | null
+  avatar_url: string | null
+}
+
+export interface PersonaStatusInfo extends PersonaInfo {
+  created_at: string
+  error_message: string | null
+}
+
+export interface ChatMessage {
+  role: 'user' | 'assistant'
+  content: string
+  created_at: string
+}
+
+export interface ChatHistory {
+  handle: string
+  messages: ChatMessage[]
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class BskyStatsError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly detail?: string,
+  ) {
+    super(message)
+    this.name = 'BskyStatsError'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function headers(): Record<string, string> {
+  return {
+    'X-Api-Key': _apiKey,
+    'Content-Type': 'application/json',
+  }
+}
+
+async function request<T>(path: string, opts?: RequestInit): Promise<T> {
+  if (!_baseUrl) {
+    throw new BskyStatsError('BskyStats client not configured', 0)
+  }
+
+  const url = `${_baseUrl}${path}`
+
+  let res: Response
+  try {
+    res = await fetch(url, {
+      ...opts,
+      headers: {
+        ...headers(),
+        ...(opts?.headers as Record<string, string>),
+      },
+    })
+  } catch (err) {
+    throw new BskyStatsError(
+      `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      0,
+    )
+  }
+
+  if (!res.ok) {
+    let detail: string | undefined
+    try {
+      const body = await res.json()
+      detail = body.detail
+    } catch {
+      // body wasn't JSON — that's fine
+    }
+    throw new BskyStatsError(
+      `HTTP ${res.status}: ${detail ?? res.statusText}`,
+      res.status,
+      detail,
+    )
+  }
+
+  // 204 No Content
+  if (res.status === 204) {
+    return undefined as unknown as T
+  }
+
+  return res.json() as Promise<T>
+}
+
+// ---------------------------------------------------------------------------
+// Stats API
+// ---------------------------------------------------------------------------
+
+export async function fetchStats(
+  window: number,
+  topN: number = 10,
+): Promise<WindowStats> {
+  return request<WindowStats>(`/stats/${window}?top_n=${topN}`)
+}
+
+// ---------------------------------------------------------------------------
+// Persona API
+// ---------------------------------------------------------------------------
+
+export async function createPersona(handle: string): Promise<PersonaInfo> {
+  return request<PersonaInfo>('/personas', {
+    method: 'POST',
+    body: JSON.stringify({handle}),
+  })
+}
+
+export async function listPersonas(): Promise<PersonaInfo[]> {
+  return request<PersonaInfo[]>('/personas')
+}
+
+export async function fetchPersonaStatus(
+  handle: string,
+): Promise<PersonaStatusInfo> {
+  return request<PersonaStatusInfo>(
+    `/personas/${encodeURIComponent(handle)}/status`,
+  )
+}
+
+export async function fetchChatHistory(handle: string): Promise<ChatHistory> {
+  return request<ChatHistory>(`/personas/${encodeURIComponent(handle)}/chat`)
+}
+
+export async function deleteChatHistory(handle: string): Promise<void> {
+  return request<void>(`/personas/${encodeURIComponent(handle)}/chat`, {
+    method: 'DELETE',
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Chat SSE (persona streaming response)
+//
+// sendChatMessage posts to /personas/{handle}/chat and returns an
+// EventSource-like reader for the SSE stream. This is intentionally
+// separate from the stats SSE stream.
+// ---------------------------------------------------------------------------
+
+export interface ChatStreamCallbacks {
+  onToken: (text: string) => void
+  onDone: (fullText: string, contextPostsUsed: number) => void
+  onError: (error: string) => void
+}
+
+/**
+ * Send a chat message and stream the AI response token-by-token.
+ * Returns an AbortController the caller can use to cancel.
+ */
+export function sendChatMessage(
+  handle: string,
+  message: string,
+  callbacks: ChatStreamCallbacks,
+): AbortController {
+  const controller = new AbortController()
+  const url = `${_baseUrl}/personas/${encodeURIComponent(handle)}/chat`
+
+  fetch(url, {
+    method: 'POST',
+    headers: headers(),
+    body: JSON.stringify({message}),
+    signal: controller.signal,
+  })
+    .then(async res => {
+      if (!res.ok) {
+        let detail: string | undefined
+        try {
+          const body = await res.json()
+          detail = body.detail
+        } catch {
+          // not JSON
+        }
+        callbacks.onError(detail ?? `HTTP ${res.status}`)
+        return
+      }
+
+      const reader = res.body?.getReader()
+      if (!reader) {
+        callbacks.onError('No response body')
+        return
+      }
+
+      const decoder = new TextDecoder()
+      let buffer = ''
+
+      while (true) {
+        const {done, value} = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, {stream: true})
+        const lines = buffer.split('\n')
+        // Keep the last (possibly incomplete) line in the buffer
+        buffer = lines.pop() ?? ''
+
+        let currentEvent = ''
+        for (const line of lines) {
+          if (line.startsWith('event: ')) {
+            currentEvent = line.slice(7).trim()
+          } else if (line.startsWith('data: ')) {
+            const data = line.slice(6)
+            try {
+              const parsed = JSON.parse(data)
+              if (currentEvent === 'token') {
+                callbacks.onToken(parsed.text)
+              } else if (currentEvent === 'done') {
+                callbacks.onDone(parsed.full_text, parsed.context_posts_used)
+              } else if (currentEvent === 'error') {
+                callbacks.onError(parsed.error)
+              }
+            } catch {
+              // Malformed JSON — skip
+            }
+            currentEvent = ''
+          }
+        }
+      }
+    })
+    .catch(err => {
+      if (controller.signal.aborted) return
+      callbacks.onError(err instanceof Error ? err.message : String(err))
+    })
+
+  return controller
+}

--- a/src/state/queries/bsky-stats.ts
+++ b/src/state/queries/bsky-stats.ts
@@ -1,0 +1,301 @@
+/**
+ * TanStack Query hooks for the Bluesky Feed Consumer backend.
+ *
+ * Provides reactive data access for stats, personas, and chat.
+ */
+import {useCallback, useEffect, useRef} from 'react'
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseQueryResult,
+} from '@tanstack/react-query'
+
+import {
+  type ChatHistory,
+  type ChatMessage,
+  createPersona,
+  deleteChatHistory,
+  fetchChatHistory,
+  fetchPersonaStatus,
+  fetchStats,
+  listPersonas,
+  type PersonaInfo,
+  type PersonaStatusInfo,
+  sendChatMessage,
+  type StatsSnapshot,
+  type WindowStats,
+} from '#/lib/api/bsky-stats'
+import {
+  connectStatsSSE,
+  type StatsSSEConnection,
+} from '#/lib/api/bsky-stats-sse'
+
+// ---------------------------------------------------------------------------
+// Query keys
+// ---------------------------------------------------------------------------
+
+export const BSKY_STATS_KEYS = {
+  stats: (window: number, topN?: number) =>
+    ['bsky-stats', 'stats', window, topN ?? 10] as const,
+  statsStream: () => ['bsky-stats', 'stream'] as const,
+  personas: () => ['bsky-stats', 'personas'] as const,
+  personaStatus: (handle: string) =>
+    ['bsky-stats', 'persona-status', handle] as const,
+  chatHistory: (handle: string) =>
+    ['bsky-stats', 'chat-history', handle] as const,
+}
+
+// ---------------------------------------------------------------------------
+// Stats queries
+// ---------------------------------------------------------------------------
+
+export function useStatsQuery(
+  window: number,
+  topN: number = 10,
+): UseQueryResult<WindowStats> {
+  return useQuery({
+    queryKey: BSKY_STATS_KEYS.stats(window, topN),
+    queryFn: () => fetchStats(window, topN),
+    refetchOnWindowFocus: true,
+    staleTime: 5_000,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Live stats stream
+// ---------------------------------------------------------------------------
+
+/**
+ * Subscribe to the live SSE stats stream.
+ * Writes snapshot data directly into the query cache so any component
+ * using useStatsQuery gets updates automatically.
+ *
+ * @param apiKey  The API key for SSE authentication.
+ * @param enabled Whether the stream should be active.
+ */
+export function useStatsStream(apiKey: string, enabled: boolean = true) {
+  const queryClient = useQueryClient()
+  const connectionRef = useRef<StatsSSEConnection | null>(null)
+
+  const handleData = useCallback(
+    (data: StatsSnapshot) => {
+      // Update the stream cache (useful for velocity data)
+      queryClient.setQueryData(BSKY_STATS_KEYS.statsStream(), data)
+
+      // Also update individual window caches
+      for (const [windowKey, windowStats] of Object.entries(data.windows)) {
+        const window = Number(windowKey)
+        queryClient.setQueryData(BSKY_STATS_KEYS.stats(window), windowStats)
+      }
+    },
+    [queryClient],
+  )
+
+  useEffect(() => {
+    if (!enabled || !apiKey) return
+
+    const connection = connectStatsSSE(apiKey, {
+      onSnapshot: handleData,
+      onUpdate: handleData,
+      onError: _err => {
+        // Errors are handled by the SSE client (auto-reconnect).
+        // Could add logging here in future.
+      },
+    })
+    connectionRef.current = connection
+
+    return () => {
+      connection.close()
+      connectionRef.current = null
+    }
+  }, [apiKey, enabled, handleData])
+
+  return {
+    /** The latest full snapshot from the stream. */
+    data: queryClient.getQueryData<StatsSnapshot>(
+      BSKY_STATS_KEYS.statsStream(),
+    ),
+    /** Close the stream early. */
+    close: () => connectionRef.current?.close(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Persona queries
+// ---------------------------------------------------------------------------
+
+export function usePersonasQuery() {
+  return useQuery({
+    queryKey: BSKY_STATS_KEYS.personas(),
+    queryFn: listPersonas,
+    staleTime: 30_000,
+  })
+}
+
+export function usePersonaStatusQuery(
+  handle: string,
+  opts?: {enabled?: boolean},
+): UseQueryResult<PersonaStatusInfo> {
+  return useQuery({
+    queryKey: BSKY_STATS_KEYS.personaStatus(handle),
+    queryFn: () => fetchPersonaStatus(handle),
+    enabled: opts?.enabled ?? true,
+    refetchInterval: query => {
+      // Poll while loading, stop once ready or errored
+      if (query.state.data?.status === 'loading') return 3_000
+      return false
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Persona mutations
+// ---------------------------------------------------------------------------
+
+export function useRegisterPersonaMutation() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (handle: string) => createPersona(handle),
+    onSuccess: (_data: PersonaInfo, handle: string) => {
+      queryClient.invalidateQueries({queryKey: BSKY_STATS_KEYS.personas()})
+      queryClient.invalidateQueries({
+        queryKey: BSKY_STATS_KEYS.personaStatus(handle),
+      })
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Chat queries
+// ---------------------------------------------------------------------------
+
+export function useChatHistoryQuery(
+  handle: string,
+  opts?: {enabled?: boolean},
+): UseQueryResult<ChatHistory> {
+  return useQuery({
+    queryKey: BSKY_STATS_KEYS.chatHistory(handle),
+    queryFn: () => fetchChatHistory(handle),
+    enabled: opts?.enabled ?? true,
+  })
+}
+
+export function useDeleteChatMutation() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (handle: string) => deleteChatHistory(handle),
+    onSuccess: (_data: void, handle: string) => {
+      queryClient.setQueryData(BSKY_STATS_KEYS.chatHistory(handle), {
+        handle,
+        messages: [],
+      })
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Chat streaming mutation
+// ---------------------------------------------------------------------------
+
+/**
+ * Hook for sending a chat message with streaming AI response.
+ *
+ * Returns a function that accepts a message string.
+ * The streaming tokens are accumulated and the chat history cache
+ * is optimistically updated as tokens arrive.
+ */
+export function useSendChatMessage(handle: string) {
+  const queryClient = useQueryClient()
+  const controllerRef = useRef<AbortController | null>(null)
+
+  const send = useCallback(
+    (message: string) => {
+      // Optimistically add the user message to the cache
+      queryClient.setQueryData<ChatHistory>(
+        BSKY_STATS_KEYS.chatHistory(handle),
+        old => {
+          const userMsg: ChatMessage = {
+            role: 'user',
+            content: message,
+            created_at: new Date().toISOString(),
+          }
+          return {
+            handle,
+            messages: [...(old?.messages ?? []), userMsg],
+          }
+        },
+      )
+
+      // Add a placeholder for the assistant response
+      queryClient.setQueryData<ChatHistory>(
+        BSKY_STATS_KEYS.chatHistory(handle),
+        old => {
+          const assistantMsg: ChatMessage = {
+            role: 'assistant',
+            content: '',
+            created_at: new Date().toISOString(),
+          }
+          return {
+            handle,
+            messages: [...(old?.messages ?? []), assistantMsg],
+          }
+        },
+      )
+
+      const controller = sendChatMessage(handle, message, {
+        onToken: (text: string) => {
+          // Append token to the last (assistant) message
+          queryClient.setQueryData<ChatHistory>(
+            BSKY_STATS_KEYS.chatHistory(handle),
+            old => {
+              if (!old) return old
+              const msgs = [...old.messages]
+              const last = msgs[msgs.length - 1]
+              if (last?.role === 'assistant') {
+                msgs[msgs.length - 1] = {
+                  ...last,
+                  content: last.content + text,
+                }
+              }
+              return {...old, messages: msgs}
+            },
+          )
+        },
+        onDone: (_fullText: string, _contextPostsUsed: number) => {
+          // Refetch to get the server-authoritative history
+          queryClient.invalidateQueries({
+            queryKey: BSKY_STATS_KEYS.chatHistory(handle),
+          })
+        },
+        onError: (error: string) => {
+          // Remove the placeholder assistant message on error
+          queryClient.setQueryData<ChatHistory>(
+            BSKY_STATS_KEYS.chatHistory(handle),
+            old => {
+              if (!old) return old
+              const msgs = [...old.messages]
+              const last = msgs[msgs.length - 1]
+              if (last?.role === 'assistant' && last.content === '') {
+                msgs.pop()
+              }
+              return {...old, messages: msgs}
+            },
+          )
+          // TODO: expose error to UI via a state callback
+          console.error('Chat stream error:', error)
+        },
+      })
+
+      controllerRef.current = controller
+    },
+    [handle, queryClient],
+  )
+
+  const cancel = useCallback(() => {
+    controllerRef.current?.abort()
+    controllerRef.current = null
+  }, [])
+
+  return {send, cancel}
+}


### PR DESCRIPTION
## Summary
- Typed fetch wrapper for the Bluesky Feed Consumer backend (`/stats`, `/personas`, `/sse` endpoints)
- SSE client for live stats streaming with auto-reconnect and exponential backoff
- TanStack Query hooks for reactive data access (stats, personas, chat with streaming)
- 31 unit tests covering URL construction, auth headers, error handling, response parsing, and SSE event parsing
- Project docs: implementation order and testing approach
- Env var placeholders for backend config (`BSKY_STATS_BASE_URL`, `BSKY_STATS_API_KEY`)

## Test plan
- [x] `pnpm test` — 31 new tests pass, 505 existing tests unaffected
- [x] `tsc --noEmit` — no type errors
- [x] Lint-staged (eslint + prettier) passes on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)