### PR TITLE
[Chat] Fix iOS group chat notifications rendering as direct messages

### DIFF
--- a/modules/BlueskyNSE/NotificationService.swift
+++ b/modules/BlueskyNSE/NotificationService.swift
@@ -104,7 +104,7 @@ class NotificationService: UNNotificationServiceExtension {
 
     var speakableGroupName: INSpeakableString? = nil
     if userInfo["convoKind"] as? String == "group",
-       let groupName = userInfo["convoGroupName"] as? String,
+       let groupName = userInfo["groupName"] as? String,
        !groupName.isEmpty {
       speakableGroupName = INSpeakableString(spokenPhrase: groupName)
     }
@@ -126,10 +126,10 @@ class NotificationService: UNNotificationServiceExtension {
     // `recipientCount` on the donation metadata is Apple's documented escape
     // hatch for this case, and overrides the (zero-length) recipients array.
     if userInfo["convoKind"] as? String == "group",
-       let convoMemberCount = userInfo["convoMemberCount"] as? Int,
-       convoMemberCount > 0 {
+       let groupMemberCount = userInfo["groupMemberCount"] as? Int,
+       groupMemberCount > 0 {
       let metadata = INSendMessageIntentDonationMetadata()
-      metadata.recipientCount = convoMemberCount
+      metadata.recipientCount = groupMemberCount
       intent.donationMetadata = metadata
     }
 
@@ -209,7 +209,7 @@ class NotificationService: UNNotificationServiceExtension {
     userInfo: [AnyHashable: Any]
   ) {
     guard userInfo["convoKind"] as? String == "group",
-          let groupName = userInfo["convoGroupName"] as? String,
+          let groupName = userInfo["groupName"] as? String,
           !groupName.isEmpty else {
       return
     }

--- a/modules/BlueskyNSE/NotificationService.swift
+++ b/modules/BlueskyNSE/NotificationService.swift
@@ -120,6 +120,19 @@ class NotificationService: UNNotificationServiceExtension {
       attachments: nil
     )
 
+    // The push payload omits the full recipient list for group convos. Without
+    // any signal of multiple recipients, iOS classifies the notification as
+    // `MessagingDirect` and ignores `speakableGroupName`. Setting
+    // `recipientCount` on the donation metadata is Apple's documented escape
+    // hatch for this case, and overrides the (zero-length) recipients array.
+    if userInfo["convoKind"] as? String == "group",
+       let convoMemberCount = userInfo["convoMemberCount"] as? Int,
+       convoMemberCount > 0 {
+      let metadata = INSendMessageIntentDonationMetadata()
+      metadata.recipientCount = convoMemberCount
+      intent.donationMetadata = metadata
+    }
+
     // For group convos, attach the composite group avatar (rendered by the
     // ogcard service) to the `speakableGroupName` parameter so iOS shows it
     // alongside the sender on the Communication Notification.


### PR DESCRIPTION
## Summary

- iOS classifies Communication Notifications as `MessagingDirect` or `MessagingGroup` based on the recipient count on the `INSendMessageIntent`. Our push payload doesn't include the recipient list, so iOS sees zero recipients, falls back to `MessagingDirect`, and ignores `speakableGroupName` — which is why group chat notifications were missing the group label and treatment.
- Use `INSendMessageIntentDonationMetadata.recipientCount`, populated from the new `groupMemberCount` field on the push payload, to tell iOS the conversation has multiple participants. Apple [documents this](https://developer.apple.com/documentation/usernotifications/implementing-communication-notifications) as the supported escape hatch when shipping the full recipient list isn't practical.
- Companion server change adding the field (already merged): bluesky-social/chat#161. Also renames `convoGroupName` -> `groupName`, which this PR matches.

## Test plan

- [ ] Confirm bluesky-social/chat#161 has been deployed.
- [ ] Send a message to a group convo from another account; confirm the iOS notification renders with the group name visible (not just the sender).
- [ ] Confirm direct convo notifications still render as before (single sender, no group label).
- [ ] Confirm group system events (`chat-added-to-group`, `chat-removed-from-group`, `chat-join-request-rejected`) still render correctly — these don't go through `INSendMessageIntent` so should be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)