### PR TITLE
adding focus to the editing block

### DIFF
--- a/src/view/com/feeds/ComposerPrompt.tsx
+++ b/src/view/com/feeds/ComposerPrompt.tsx
@@ -163,7 +163,6 @@ export function ComposerPrompt() {
         }),
         web({
           cursor: 'pointer',
-          outline: 'none',
         }),
         pressed && web({outline: 'none'}),
       ]}>


### PR DESCRIPTION
**Summary**

Hello! I fixed the issue described in this task. Please take a look when you have a chance.

**Related task**

https://github.com/bluesky-social/social-app/issues/10569#issue-4492336936

**Changes**

Added focus for the block that opens the editor when clicked.
<img width="1284" height="660" alt="Снимок экрана — 2026-05-22 в 19 43 20" src="https://github.com/user-attachments/assets/30a4bc28-5d97-42a0-aabb-7f9ef2b2f5b2" />


