### PR TITLE
Fix status bars not showing

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
     "react-native-date-picker": "^5.0.13",
     "react-native-device-attest": "^0.1.6",
     "react-native-drawer-layout": "^4.2.3",
-    "react-native-edge-to-edge": "^1.6.0",
+    "react-native-edge-to-edge": "^1.8.1",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "^1.21.7",
     "react-native-pager-view": "6.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -638,7 +638,7 @@ importers:
         specifier: ^4.2.3
         version: 4.2.3(patch_hash=74f2c043cc22ab87054f219e7c7373a509b779b18bfa79d27e7d051d73355130)(react-native-gesture-handler@2.28.0(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-reanimated@3.19.1(patch_hash=97a1967f37a4213fbab59e1fd59a1bf859b5efc79af5e1b528a47fe488e6c5d6)(@babel/core@7.29.0)(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-edge-to-edge:
-        specifier: ^1.6.0
+        specifier: ^1.8.1
         version: 1.8.1(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-gesture-handler:
         specifier: ~2.28.0

--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -221,6 +221,10 @@ export function Shell() {
   return (
     <View testID="mobileShellView" style={[a.h_full, t.atoms.bg]}>
       <SystemBars
+        hidden={{
+          statusBar: false,
+          navigationBar: false,
+        }}
         style={{
           statusBar:
             t.name !== 'light' ||


### PR DESCRIPTION
Something in `react-native-edge-to-edge` changed which meant that if the status bars were hidden (such as by the lightbox), unless explicitly shown again, they'd stay hidden. The fix is to make the root `<SystemBars>` component have an explicit `hidden: false`.

This has the neat side effect of fixing the case where opening the app whilst it's sideways wouldn't show the status bars