### PR TITLE
Add profile tab double-tap account switching

### DIFF
--- a/src/state/session/__tests__/accounts.test.ts
+++ b/src/state/session/__tests__/accounts.test.ts
@@ -1,0 +1,68 @@
+import {
+  getNextAccount,
+  resetAccountCycleOrderForTest,
+} from '#/state/session/accounts'
+import {type SessionAccount} from '#/state/session/types'
+
+function account(did: string): SessionAccount {
+  return {
+    did,
+    service: `https://${did}.test/`,
+    handle: `${did}.test`,
+    email: undefined,
+    emailConfirmed: false,
+    emailAuthFactor: false,
+    refreshJwt: `${did}-refresh-jwt`,
+    accessJwt: `${did}-access-jwt`,
+    active: true,
+    status: undefined,
+    pdsUrl: undefined,
+    isSelfHosted: true,
+    signupQueued: false,
+  }
+}
+
+describe('getNextAccount', () => {
+  beforeEach(() => {
+    resetAccountCycleOrderForTest()
+  })
+
+  it('returns undefined without a current account', () => {
+    const accounts = [account('alice'), account('bob')]
+
+    expect(getNextAccount(accounts, undefined)).toBeUndefined()
+  })
+
+  it('returns undefined when there is only one account', () => {
+    const alice = account('alice')
+
+    expect(getNextAccount([alice], alice)).toBeUndefined()
+  })
+
+  it('returns the next account in account-list order', () => {
+    const alice = account('alice')
+    const bob = account('bob')
+    const jay = account('jay')
+
+    expect(getNextAccount([alice, bob, jay], alice)).toBe(bob)
+    expect(getNextAccount([alice, bob, jay], bob)).toBe(jay)
+  })
+
+  it('wraps to the first account', () => {
+    const alice = account('alice')
+    const bob = account('bob')
+    const jay = account('jay')
+
+    expect(getNextAccount([alice, bob, jay], jay)).toBe(alice)
+  })
+
+  it('preserves cycle order when the active account moves to the front', () => {
+    const alice = account('alice')
+    const bob = account('bob')
+    const jay = account('jay')
+
+    expect(getNextAccount([alice, bob, jay], alice)).toBe(bob)
+    expect(getNextAccount([bob, alice, jay], bob)).toBe(jay)
+    expect(getNextAccount([jay, bob, alice], jay)).toBe(alice)
+  })
+})

--- a/src/state/session/accounts.ts
+++ b/src/state/session/accounts.ts
@@ -1,0 +1,42 @@
+import {type SessionAccount} from './types'
+
+let accountCycleOrder: string[] = []
+
+export function getNextAccount(
+  accounts: SessionAccount[],
+  currentAccount: SessionAccount | undefined,
+) {
+  if (!currentAccount || accounts.length < 2) {
+    return undefined
+  }
+
+  accountCycleOrder = reconcileAccountCycleOrder(
+    accountCycleOrder,
+    accounts.map(account => account.did),
+  )
+
+  const currentIndex = accountCycleOrder.indexOf(currentAccount.did)
+  if (currentIndex === -1) {
+    return accounts[0]
+  }
+
+  const nextDid =
+    accountCycleOrder[(currentIndex + 1) % accountCycleOrder.length]
+  return accounts.find(account => account.did === nextDid)
+}
+
+function reconcileAccountCycleOrder(
+  previousOrder: string[],
+  nextOrder: string[],
+) {
+  const nextDids = new Set(nextOrder)
+  const preservedOrder = previousOrder.filter(did => nextDids.has(did))
+  return [
+    ...preservedOrder,
+    ...nextOrder.filter(did => !preservedOrder.includes(did)),
+  ]
+}
+
+export function resetAccountCycleOrderForTest() {
+  accountCycleOrder = []
+}

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -1,5 +1,6 @@
-import {type JSX, useCallback} from 'react'
-import {type GestureResponderEvent, View} from 'react-native'
+import {type JSX, useCallback, useMemo} from 'react'
+import {type AccessibilityActionEvent, View} from 'react-native'
+import {Gesture, GestureDetector} from 'react-native-gesture-handler'
 import Animated from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {msg, plural} from '@lingui/core/macro'
@@ -11,6 +12,7 @@ import {StackActions} from '@react-navigation/native'
 import {PressableScale} from '#/lib/custom-animations/PressableScale'
 import {BOTTOM_BAR_AVI} from '#/lib/demo'
 import {useHaptics} from '#/lib/haptics'
+import {useAccountSwitcher} from '#/lib/hooks/useAccountSwitcher'
 import {useDedupe} from '#/lib/hooks/useDedupe'
 import {useHideBottomBarBorder} from '#/lib/hooks/useHideBottomBarBorder'
 import {useMinimalShellFooterTransform} from '#/lib/hooks/useMinimalShellTransform'
@@ -22,6 +24,7 @@ import {useUnreadMessageCount} from '#/state/queries/messages/list-conversations
 import {useUnreadNotifications} from '#/state/queries/notifications/unread'
 import {useProfileQuery} from '#/state/queries/profile'
 import {useSession} from '#/state/session'
+import {getNextAccount} from '#/state/session/accounts'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
 import {useShellLayout} from '#/state/shell/shell-layout'
 import {useCloseAllActiveElements} from '#/state/util'
@@ -57,7 +60,7 @@ import {styles} from './BottomBarStyles'
 type TabOptions = 'Home' | 'Search' | 'Messages' | 'Notifications' | 'MyProfile'
 
 export function BottomBar({navigation}: BottomTabBarProps) {
-  const {hasSession, currentAccount} = useSession()
+  const {hasSession, currentAccount, accounts} = useSession()
   const t = useTheme()
   const {_} = useLingui()
   const safeAreaInsets = useSafeAreaInsets()
@@ -73,6 +76,7 @@ export function BottomBar({navigation}: BottomTabBarProps) {
   const closeAllActiveElements = useCloseAllActiveElements()
   const dedupe = useDedupe()
   const accountSwitchControl = useDialogControl()
+  const {onPressSwitchAccount, pendingDid} = useAccountSwitcher()
   const playHaptic = useHaptics()
   const hideBorder = useHideBottomBarBorder()
   const iconWidth = 28
@@ -128,6 +132,35 @@ export function BottomBar({navigation}: BottomTabBarProps) {
   const onPressProfile = useCallback(() => {
     onPressTab('MyProfile')
   }, [onPressTab])
+  const onDoublePressProfile = useCallback(() => {
+    if (pendingDid) {
+      return
+    }
+
+    const nextAccount = getNextAccount(accounts, currentAccount)
+    if (nextAccount) {
+      playHaptic()
+      void onPressSwitchAccount(nextAccount, 'SwitchAccount')
+    }
+  }, [accounts, currentAccount, onPressSwitchAccount, pendingDid, playHaptic])
+  const profileGesture = useMemo(() => {
+    const singleTap = Gesture.Tap()
+      .numberOfTaps(1)
+      .onEnd(() => {
+        onPressProfile()
+      })
+      .runOnJS(true)
+    const doubleTap = Gesture.Tap()
+      .numberOfTaps(2)
+      .onEnd(() => {
+        onDoublePressProfile()
+      })
+      .runOnJS(true)
+
+    // Order matters: the double tap must be given a chance to recognize before
+    // the single-tap tab action fires.
+    return Gesture.Exclusive(doubleTap, singleTap)
+  }, [onDoublePressProfile, onPressProfile])
   const onPressMessages = useCallback(() => {
     onPressTab('Messages')
   }, [onPressTab])
@@ -293,6 +326,7 @@ export function BottomBar({navigation}: BottomTabBarProps) {
                 </View>
               }
               onPress={onPressProfile}
+              gesture={profileGesture}
               onLongPress={onLongPressProfile}
               accessibilityRole="tab"
               accessibilityLabel={_(msg`Profile`)}
@@ -362,8 +396,9 @@ interface BtnProps extends Pick<
   icon: JSX.Element
   notificationCount?: string
   hasNew?: boolean
-  onPress?: (event: GestureResponderEvent) => void
-  onLongPress?: (event: GestureResponderEvent) => void
+  gesture?: React.ComponentProps<typeof GestureDetector>['gesture']
+  onPress?: () => void
+  onLongPress?: () => void
 }
 
 function Btn({
@@ -373,21 +408,36 @@ function Btn({
   notificationCount,
   onPress,
   onLongPress,
+  gesture,
   accessible,
   accessibilityHint,
   accessibilityLabel,
 }: BtnProps) {
   const t = useTheme()
 
-  return (
+  const content = (
     <PressableScale
       testID={testID}
       style={[styles.ctrl, a.flex_1]}
-      onPress={onPress}
+      onPress={gesture ? undefined : onPress}
       onLongPress={onLongPress}
       accessible={accessible}
       accessibilityLabel={accessibilityLabel}
       accessibilityHint={accessibilityHint}
+      accessibilityActions={
+        gesture && onPress
+          ? [{name: 'activate', label: accessibilityLabel}]
+          : undefined
+      }
+      onAccessibilityAction={
+        gesture && onPress
+          ? (event: AccessibilityActionEvent) => {
+              if (event.nativeEvent.actionName === 'activate') {
+                onPress()
+              }
+            }
+          : undefined
+      }
       targetScale={0.8}
       accessibilityLargeContentTitle={accessibilityLabel}
       accessibilityShowsLargeContentViewer>
@@ -411,5 +461,11 @@ function Btn({
         />
       ) : null}
     </PressableScale>
+  )
+
+  return gesture ? (
+    <GestureDetector gesture={gesture}>{content}</GestureDetector>
+  ) : (
+    content
   )
 }

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -397,7 +397,7 @@ interface BtnProps extends Pick<
   notificationCount?: string
   hasNew?: boolean
   gesture?: React.ComponentProps<typeof GestureDetector>['gesture']
-  onPress?: () => void
+  onPress: () => void
   onLongPress?: () => void
 }
 
@@ -414,30 +414,31 @@ function Btn({
   accessibilityLabel,
 }: BtnProps) {
   const t = useTheme()
+  const onAccessibilityAction = useCallback(
+    (event: AccessibilityActionEvent) => {
+      if (event.nativeEvent.actionName === 'activate') {
+        onPress()
+      }
+    },
+    [onPress],
+  )
+  const pressableOnPress = gesture ? undefined : onPress
+  const accessibilityActions = gesture
+    ? [{name: 'activate', label: accessibilityLabel}]
+    : undefined
+  const gestureAccessibilityAction = gesture ? onAccessibilityAction : undefined
 
   const content = (
     <PressableScale
       testID={testID}
       style={[styles.ctrl, a.flex_1]}
-      onPress={gesture ? undefined : onPress}
+      onPress={pressableOnPress}
       onLongPress={onLongPress}
       accessible={accessible}
       accessibilityLabel={accessibilityLabel}
       accessibilityHint={accessibilityHint}
-      accessibilityActions={
-        gesture && onPress
-          ? [{name: 'activate', label: accessibilityLabel}]
-          : undefined
-      }
-      onAccessibilityAction={
-        gesture && onPress
-          ? (event: AccessibilityActionEvent) => {
-              if (event.nativeEvent.actionName === 'activate') {
-                onPress()
-              }
-            }
-          : undefined
-      }
+      accessibilityActions={accessibilityActions}
+      onAccessibilityAction={gestureAccessibilityAction}
       targetScale={0.8}
       accessibilityLargeContentTitle={accessibilityLabel}
       accessibilityShowsLargeContentViewer>
@@ -463,9 +464,9 @@ function Btn({
     </PressableScale>
   )
 
-  return gesture ? (
-    <GestureDetector gesture={gesture}>{content}</GestureDetector>
-  ) : (
-    content
-  )
+  if (!gesture) {
+    return content
+  }
+
+  return <GestureDetector gesture={gesture}>{content}</GestureDetector>
 }


### PR DESCRIPTION
I'm often frustrated when I try to double tap on the profile icon in the tab bar to switch between accounts, the way that other social apps like Instagram and Threads allow you to. Rather than being annoyed I decided to fix this myself.

To be upfront I used Codex to build, run, and verify this functionality. I also did manual QA on both iOS and Android to ensure it works as one would expect, and additional automated QA by having Codex's Computer Use bang on this button hundreds of times with logs for every tap to verify that the functionality works consistently as one would expect. (I have subsequently removed those logs since they should not be shipped to production).

(It may not be easily visible in the video but the accounts switch every time I double tap.)
https://github.com/user-attachments/assets/a35131ef-cc1d-4a3d-819e-ac2d8defd634

I am not a React Native developer by trade, but as a 15+ year mobile developer I feel good vouching for this fix and that I've used the best approach available to my knowledge. I am of course open to feedback and suggestions, so please don't hesitate to tell me where I can do better or if anything doesn't work as one would expect in the context of the Bluesky app.

Anyhow, I'm a big fan of Bluesky so I hope that this can get merged in, so I can make my life easier as a person with two primary accounts. Thank you for all your hard work throughout the years. 🙂