### PR TITLE
AA reshuffling for group chats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ bskyweb/static/media/*.svg
 
 # superpowers plugin plans/specs — local-only workspace
 docs/superpowers/
+
+# claude code worktree isolation
+.claude/worktrees/

--- a/src/ageAssurance/index.tsx
+++ b/src/ageAssurance/index.tsx
@@ -41,6 +41,7 @@ const AgeAssuranceStateContext = createContext<{
   flags: {
     adultContentDisabled: boolean
     chatDisabled: boolean
+    isUnder18: boolean
     isOverRegionMinAccessAge: boolean
     isOverAppMinAccessAge: boolean
   }
@@ -55,6 +56,7 @@ const AgeAssuranceStateContext = createContext<{
   flags: {
     adultContentDisabled: false,
     chatDisabled: false,
+    isUnder18: false,
     isOverRegionMinAccessAge: false,
     isOverAppMinAccessAge: false,
   },
@@ -106,7 +108,9 @@ function InnerProvider({children}: {children: React.ReactNode}) {
     <AgeAssuranceStateContext.Provider
       value={useMemo(() => {
         const chatDisabled = state.access !== AgeAssuranceAccess.Full
-        const isUnderAdultAge = data?.birthdate
+        // Conservative default: if we don't yet know the birthdate, treat as
+        // under 18 so we don't briefly expose group-chat UI.
+        const isUnder18 = data?.birthdate
           ? isUnderAge(data.birthdate, 18)
           : true
         const isOverRegionMinAccessAge = data?.birthdate
@@ -116,7 +120,7 @@ function InnerProvider({children}: {children: React.ReactNode}) {
           ? !isUnderAge(data.birthdate, MIN_ACCESS_AGE)
           : false
         const adultContentDisabled =
-          state.access !== AgeAssuranceAccess.Full || isUnderAdultAge
+          state.access !== AgeAssuranceAccess.Full || isUnder18
         return {
           Access: AgeAssuranceAccess,
           Status: AgeAssuranceStatus,
@@ -124,6 +128,7 @@ function InnerProvider({children}: {children: React.ReactNode}) {
           flags: {
             adultContentDisabled,
             chatDisabled,
+            isUnder18,
             isOverRegionMinAccessAge,
             isOverAppMinAccessAge,
           },

--- a/src/ageAssurance/index.tsx
+++ b/src/ageAssurance/index.tsx
@@ -14,13 +14,13 @@ import {
 } from '#/ageAssurance/state'
 import {
   AgeAssuranceAccess,
+  type AgeAssuranceFlags,
   type AgeAssuranceState,
   AgeAssuranceStatus,
 } from '#/ageAssurance/types'
 import {
-  isUnderAge,
+  computeAgeAssuranceFlags,
   maybeRestrictChatSettings,
-  MIN_ACCESS_AGE,
   useAgeAssuranceRegionConfigWithFallback,
 } from '#/ageAssurance/util'
 
@@ -38,13 +38,7 @@ const AgeAssuranceStateContext = createContext<{
   Access: typeof AgeAssuranceAccess
   Status: typeof AgeAssuranceStatus
   state: AgeAssuranceState
-  flags: {
-    adultContentDisabled: boolean
-    chatDisabled: boolean
-    isUnder18: boolean
-    isOverRegionMinAccessAge: boolean
-    isOverAppMinAccessAge: boolean
-  }
+  flags: AgeAssuranceFlags
 }>({
   Access: AgeAssuranceAccess,
   Status: AgeAssuranceStatus,
@@ -107,31 +101,15 @@ function InnerProvider({children}: {children: React.ReactNode}) {
   return (
     <AgeAssuranceStateContext.Provider
       value={useMemo(() => {
-        const chatDisabled = state.access !== AgeAssuranceAccess.Full
-        // Conservative default: if we don't yet know the birthdate, treat as
-        // under 18 so we don't briefly expose group-chat UI.
-        const isUnder18 = data?.birthdate
-          ? isUnderAge(data.birthdate, 18)
-          : true
-        const isOverRegionMinAccessAge = data?.birthdate
-          ? !isUnderAge(data.birthdate, config.minAccessAge)
-          : false
-        const isOverAppMinAccessAge = data?.birthdate
-          ? !isUnderAge(data.birthdate, MIN_ACCESS_AGE)
-          : false
-        const adultContentDisabled =
-          state.access !== AgeAssuranceAccess.Full || isUnder18
         return {
           Access: AgeAssuranceAccess,
           Status: AgeAssuranceStatus,
           state,
-          flags: {
-            adultContentDisabled,
-            chatDisabled,
-            isUnder18,
-            isOverRegionMinAccessAge,
-            isOverAppMinAccessAge,
-          },
+          flags: computeAgeAssuranceFlags({
+            state,
+            config,
+            data,
+          }),
         }
       }, [state, data, config])}>
       {children}

--- a/src/ageAssurance/state.ts
+++ b/src/ageAssurance/state.ts
@@ -18,7 +18,10 @@ import {
   parseAccessFromString,
   parseStatusFromString,
 } from '#/ageAssurance/types'
-import {getAgeAssuranceRegionConfigWithFallback} from '#/ageAssurance/util'
+import {
+  computeAgeAssuranceFlags,
+  getAgeAssuranceRegionConfigWithFallback,
+} from '#/ageAssurance/util'
 import {type Geolocation, useGeolocation} from '#/geolocation'
 import {device} from '#/storage'
 
@@ -116,29 +119,42 @@ export function computeAgeAssuranceState({
 export function getAndComputeAgeAssuranceState({did}: {did: string}) {
   const config = getConfigFromCache()
   const state = getServerStateFromCache({did})
-  const data = getOtherRequiredDataFromCache({did})
+  const requiredData = getOtherRequiredDataFromCache({did})
   const geolocation = device.get(['mergedGeolocation'])
 
-  if (!geolocation || !config || !state || !data) {
+  if (!geolocation || !config || !state || !requiredData) {
     return {
-      status: AgeAssuranceStatus.Unknown,
-      access: AgeAssuranceAccess.Safe,
+      state: {
+        status: AgeAssuranceStatus.Unknown,
+        access: AgeAssuranceAccess.Safe,
+      },
     }
   }
 
-  return computeAgeAssuranceState({
+  const region = getAgeAssuranceRegionConfigWithFallback(config, geolocation)
+  const data = {
+    accountCreatedAt: state.metadata?.accountCreatedAt,
+    declaredAge: requiredData?.birthdate
+      ? getAge(new Date(requiredData.birthdate))
+      : undefined,
+    birthdate: requiredData?.birthdate,
+  }
+  const computed = computeAgeAssuranceState({
     hasSession: true,
     config,
     geolocation,
     state: state.state,
-    data: {
-      accountCreatedAt: state.metadata?.accountCreatedAt,
-      declaredAge: data?.birthdate
-        ? getAge(new Date(data.birthdate))
-        : undefined,
-      birthdate: data?.birthdate,
-    },
+    data,
   })
+
+  return {
+    state: computed,
+    flags: computeAgeAssuranceFlags({
+      state: computed,
+      config: region,
+      data,
+    }),
+  }
 }
 
 export function useAgeAssuranceState(): AgeAssuranceState {

--- a/src/ageAssurance/types.ts
+++ b/src/ageAssurance/types.ts
@@ -21,6 +21,14 @@ export type AgeAssuranceState = {
   error?: 'config' // maybe other specific cases in the future
 }
 
+export type AgeAssuranceFlags = {
+  adultContentDisabled: boolean
+  chatDisabled: boolean
+  isUnder18: boolean
+  isOverRegionMinAccessAge: boolean
+  isOverAppMinAccessAge: boolean
+}
+
 export function parseStatusFromString(raw: string) {
   switch (raw) {
     case 'unknown':

--- a/src/ageAssurance/util.ts
+++ b/src/ageAssurance/util.ts
@@ -11,11 +11,16 @@ import {getAge} from '#/lib/strings/time'
 import {restrictChatSettings} from '#/state/queries/messages/restrictChatSettings'
 import {DEFAULT_LOGGED_OUT_LABEL_PREFERENCES} from '#/state/queries/preferences/moderation'
 import {
+  type AgeAssuranceData,
   getDidFromAgentSession,
   getOtherRequiredDataFromCache,
   useAgeAssuranceDataContext,
 } from '#/ageAssurance/data'
-import {AgeAssuranceAccess} from '#/ageAssurance/types'
+import {
+  AgeAssuranceAccess,
+  type AgeAssuranceFlags,
+  type AgeAssuranceState,
+} from '#/ageAssurance/types'
 import {type Geolocation, useGeolocation} from '#/geolocation'
 
 export const MIN_ACCESS_AGE = 13
@@ -127,4 +132,35 @@ export function maybeRestrictChatSettings({agent}: {agent: AtpAgent}) {
   // ...update the chat setting record if allowIncoming is not already 'none'.
   if (data?.actorDeclaration?.allowIncoming === 'none') return
   restrictChatSettings({agent, did})
+}
+
+export function computeAgeAssuranceFlags({
+  state,
+  config,
+  data,
+}: {
+  state: AgeAssuranceState
+  config: AppBskyAgeassuranceDefs.ConfigRegion
+  data: AgeAssuranceData['data']
+}): AgeAssuranceFlags {
+  const chatDisabled = state.access !== AgeAssuranceAccess.Full
+  // Conservative default: if we don't yet know the birthdate, treat as
+  // under 18 so we don't briefly expose group-chat UI.
+  const isUnder18 = data?.birthdate ? isUnderAge(data.birthdate, 18) : true
+  const isOverRegionMinAccessAge = data?.birthdate
+    ? !isUnderAge(data.birthdate, config.minAccessAge)
+    : false
+  const isOverAppMinAccessAge = data?.birthdate
+    ? !isUnderAge(data.birthdate, MIN_ACCESS_AGE)
+    : false
+  const adultContentDisabled =
+    state.access !== AgeAssuranceAccess.Full || isUnder18
+
+  return {
+    adultContentDisabled,
+    chatDisabled,
+    isUnder18,
+    isOverRegionMinAccessAge,
+    isOverAppMinAccessAge,
+  }
 }

--- a/src/components/dms/InitiateChatFlow.tsx
+++ b/src/components/dms/InitiateChatFlow.tsx
@@ -32,6 +32,7 @@ import {PersonGroup_Stroke2_Corner2_Rounded as PersonGroupIcon} from '#/componen
 import {TimesLarge_Stroke2_Corner0_Rounded as XIcon} from '#/components/icons/Times'
 import * as ProfileCard from '#/components/ProfileCard'
 import {Text} from '#/components/Typography'
+import {useAgeAssurance} from '#/ageAssurance'
 import {IS_NATIVE, IS_WEB} from '#/env'
 import type * as bsky from '#/types/bsky'
 import {ChatProfileTabs} from './ChatProfileTabs'
@@ -205,6 +206,7 @@ export function InitiateChatFlow({
   const [footerHeight, setFooterHeight] = useState(0)
   const listRef = useRef<ListMethods>(null)
   const {currentAccount} = useSession()
+  const aa = useAgeAssurance()
   const inputRef = useRef<TextInput>(null)
 
   const [searchText, setSearchText] = useState('')
@@ -320,7 +322,11 @@ export function InitiateChatFlow({
       })
     }
 
-    if (chatState === ChatState.NEW_CHAT && searchText === '') {
+    if (
+      chatState === ChatState.NEW_CHAT &&
+      searchText === '' &&
+      !aa.flags.isUnder18
+    ) {
       _items.unshift({type: 'newGroupChat', key: 'newGroupChat'})
     }
 
@@ -334,6 +340,7 @@ export function InitiateChatFlow({
     results,
     currentAccount?.did,
     follows,
+    aa.flags.isUnder18,
   ])
 
   if (searchText && !isFetching && !items.length && !isError) {

--- a/src/screens/Messages/ChatList.tsx
+++ b/src/screens/Messages/ChatList.tsx
@@ -174,6 +174,7 @@ export function ChatList({
 }) {
   const t = useTheme()
   const {t: l} = useLingui()
+  const aa = useAgeAssurance()
   const scrollElRef: ListRef = useAnimatedRef()
   const {isWithinSplitView} = useIsWithinSplitView()
 
@@ -206,6 +207,7 @@ export function ChatList({
 
   const {refetch: refetchInbox} = useListConvosQuery({
     status: 'request',
+    kind: aa.flags.isUnder18 ? 'direct' : 'all',
   })
 
   useRefreshOnFocus(refetch)
@@ -408,6 +410,7 @@ export function ChatList({
 export function Header({newChatControl}: {newChatControl: DialogControlProps}) {
   const {t: l} = useLingui()
   const {gtMobile} = useBreakpoints()
+  const aa = useAgeAssurance()
   const requireEmailVerification = useRequireEmailVerification()
   const leftConvos = useLeftConvos()
 
@@ -415,6 +418,7 @@ export function Header({newChatControl}: {newChatControl: DialogControlProps}) {
     useListConvosQuery({
       status: 'request',
       readState: 'unread',
+      kind: aa.flags.isUnder18 ? 'direct' : 'all',
     })
 
   const inboxAllConvos =

--- a/src/screens/Messages/Inbox.tsx
+++ b/src/screens/Messages/Inbox.tsx
@@ -43,6 +43,7 @@ import * as Layout from '#/components/Layout'
 import {ListFooter} from '#/components/Lists'
 import * as Toast from '#/components/Toast'
 import {Text} from '#/components/Typography'
+import {useAgeAssurance} from '#/ageAssurance'
 import {IS_NATIVE} from '#/env'
 import {RequestListItem} from './components/RequestListItem'
 import {useIsWithinSplitView} from './components/splitView/context'
@@ -63,8 +64,12 @@ export function MessagesInboxScreen(props: Props) {
 
 export function MessagesInboxScreenInner({}: Props) {
   const {gtTablet} = useBreakpoints()
+  const aa = useAgeAssurance()
 
-  const listConvosQuery = useListConvosQuery({status: 'request'})
+  const listConvosQuery = useListConvosQuery({
+    status: 'request',
+    kind: aa.flags.isUnder18 ? 'direct' : 'all',
+  })
   const {data} = listConvosQuery
 
   const leftConvos = useLeftConvos()

--- a/src/screens/Messages/Settings.tsx
+++ b/src/screens/Messages/Settings.tsx
@@ -20,6 +20,7 @@ import {ChevronRight_Stroke2_Corner0_Rounded as ChevronRightIcon} from '#/compon
 import * as Layout from '#/components/Layout'
 import * as Toast from '#/components/Toast'
 import {Text} from '#/components/Typography'
+import {useAgeAssurance} from '#/ageAssurance'
 import {useAnalytics} from '#/analytics'
 import {IS_NATIVE} from '#/env'
 import {useBackgroundNotificationPreferences} from '../../../modules/expo-background-notification-handler/src/BackgroundNotificationHandlerProvider'
@@ -45,6 +46,7 @@ export function MessagesSettingsScreenInner({}: Props) {
   const t = useTheme()
   const {t: l} = useLingui()
   const ax = useAnalytics()
+  const aa = useAgeAssurance()
   const {currentAccount} = useSession()
   const {data: profile} = useProfileQuery({
     did: currentAccount!.did,
@@ -53,6 +55,7 @@ export function MessagesSettingsScreenInner({}: Props) {
   const exportCarControl = Dialog.useDialogControl()
 
   const isGroupChatEnabled = ax.features.enabled(ax.features.GroupChatsEnable)
+  const groupInvitesLocked = aa.flags.isUnder18
 
   const allowMessagesFromOptions: {name: AllowIncoming; label: string}[] = [
     {
@@ -190,17 +193,26 @@ export function MessagesSettingsScreenInner({}: Props) {
                     a.leading_snug,
                     t.atoms.text_contrast_high,
                   ]}>
-                  <Trans>
-                    You can continue ongoing conversations regardless of which
-                    setting you choose.
-                  </Trans>
+                  {groupInvitesLocked ? (
+                    <Trans>
+                      Group chats are only available to users 18 and over.
+                    </Trans>
+                  ) : (
+                    <Trans>
+                      You can continue ongoing conversations regardless of which
+                      setting you choose.
+                    </Trans>
+                  )}
                 </Text>
                 <Toggle.Group
+                  disabled={groupInvitesLocked}
                   label={l`Allow group chat invites from`}
                   type="radio"
                   values={[
-                    (profile?.associated?.chat
-                      ?.allowGroupInvites as AllowIncoming) ?? 'following',
+                    groupInvitesLocked
+                      ? 'none'
+                      : ((profile?.associated?.chat
+                          ?.allowGroupInvites as AllowIncoming) ?? 'following'),
                   ]}
                   onChange={onSelectGroupInvitesFrom}>
                   <View>

--- a/src/state/birthdate.ts
+++ b/src/state/birthdate.ts
@@ -1,6 +1,7 @@
 import {useMemo} from 'react'
 import {useMutation, useQueryClient} from '@tanstack/react-query'
 
+import {restrictGroupChatSettings} from '#/state/queries/messages/restrictChatSettings'
 import {preferencesQueryKey} from '#/state/queries/preferences'
 import {useAgent, useSession} from '#/state/session'
 import {usePatchAgeAssuranceOtherRequiredData} from '#/ageAssurance'
@@ -67,6 +68,10 @@ export function useBirthdateMutation() {
 
       if (isUnderAge(birthDate.toISOString(), 18)) {
         maybeRestrictChatSettings({agent})
+        const did = agent.sessionManager.did
+        if (did) {
+          await restrictGroupChatSettings({agent, did})
+        }
       }
 
       /**

--- a/src/state/queries/messages/list-conversations.tsx
+++ b/src/state/queries/messages/list-conversations.tsx
@@ -19,6 +19,7 @@ import {useMessagesEventBus} from '#/state/messages/events'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useAgent, useSession} from '#/state/session'
 import {parseConvoView} from '#/components/dms/util'
+import {useAgeAssurance} from '#/ageAssurance'
 import {useLeftConvos} from './leave-conversation'
 
 const DEFAULT_LIMIT = 10
@@ -111,10 +112,12 @@ export function ListConvosProviderInner({
 }: {
   children: React.ReactNode
 }) {
+  const aa = useAgeAssurance()
   const {refetch, data} = useListConvosQuery({
     readState: 'unread',
     limit: UNREAD_LIMIT,
     lockStatus: 'unlocked',
+    kind: aa.flags.isUnder18 ? 'direct' : 'all',
   })
   const messagesBus = useMessagesEventBus()
   const queryClient = useQueryClient()

--- a/src/state/queries/messages/restrictChatSettings.ts
+++ b/src/state/queries/messages/restrictChatSettings.ts
@@ -3,7 +3,10 @@ import {type ChatBskyActorDeclaration} from '@atproto/api'
 
 import {networkRetry} from '#/lib/async/retry'
 import {logger} from '#/logger'
-import {setOtherRequiredDataActorDeclarationCache} from '#/ageAssurance/data'
+import {
+  getOtherRequiredDataFromCache,
+  setOtherRequiredDataActorDeclarationCache,
+} from '#/ageAssurance/data'
 
 /**
  * Helper to update the chat settings record.
@@ -35,5 +38,46 @@ export async function restrictChatSettings({
     })
   } catch {
     logger.error(`restrictChatSettings: failed to set chat declaration`)
+  }
+}
+
+/**
+ * Locks the user out of being added to group chats by setting
+ * `allowGroupInvites: 'none'` on the chat actor declaration. Used for under-18
+ * users, who per spec cannot participate in group chats.
+ *
+ * Preserves the existing `allowIncoming` value if one is cached, otherwise
+ * defaults to 'following' (the lexicon default) since the field is required.
+ */
+export async function restrictGroupChatSettings({
+  agent,
+  did,
+}: {
+  agent: AtpAgent
+  did: string
+}): Promise<void> {
+  const cached = getOtherRequiredDataFromCache({did})?.actorDeclaration
+  if (cached?.allowGroupInvites === 'none') return
+
+  try {
+    const record: ChatBskyActorDeclaration.Main = {
+      $type: 'chat.bsky.actor.declaration',
+      allowIncoming: cached?.allowIncoming ?? 'following',
+      allowGroupInvites: 'none',
+    }
+    await networkRetry(3, () =>
+      agent.com.atproto.repo.putRecord({
+        repo: did,
+        collection: 'chat.bsky.actor.declaration',
+        rkey: 'self',
+        record,
+      }),
+    )
+    setOtherRequiredDataActorDeclarationCache({
+      did,
+      actorDeclaration: record,
+    })
+  } catch {
+    logger.error(`restrictGroupChatSettings: failed to set chat declaration`)
   }
 }

--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -19,9 +19,13 @@ import {
   PUBLIC_BSKY_SERVICE,
   TIMELINE_SAVED_FEED,
 } from '#/lib/constants'
+import {getAge} from '#/lib/strings/time'
 import {logger} from '#/logger'
 import {snoozeBirthdateUpdateAllowedForDid} from '#/state/birthdate'
-import {restrictChatSettings} from '#/state/queries/messages/restrictChatSettings'
+import {
+  restrictChatSettings,
+  restrictGroupChatSettings,
+} from '#/state/queries/messages/restrictChatSettings'
 import {snoozeEmailConfirmationPrompt} from '#/state/shell/reminders'
 import {
   prefetchAgeAssuranceData,
@@ -222,6 +226,9 @@ export async function createAgentAndCreateAccount(
         const state = getAndComputeAgeAssuranceState({did: account.did})
         if (state.access !== AgeAssuranceAccess.Full) {
           restrictChatSettings({agent, did: account.did})
+        }
+        if (getAge(birthDate) < 18) {
+          restrictGroupChatSettings({agent, did: account.did})
         }
       }),
     ]).then(promises => {

--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -223,7 +223,7 @@ export async function createAgentAndCreateAccount(
       }),
       // wait for AA data to load first, then check state
       aa.then(async () => {
-        const state = getAndComputeAgeAssuranceState({did: account.did})
+        const {state} = getAndComputeAgeAssuranceState({did: account.did})
         if (state.access !== AgeAssuranceAccess.Full) {
           restrictChatSettings({agent, did: account.did})
         }


### PR DESCRIPTION
A little reshuffling of logic could make this easier to read and implement.
- [x] break out flag computation into reusable util
- [ ] DRY things up
- [ ] expose flags through the `getAndComputeAgeAssuranceState` needed for account creation
- [ ] sort out "chat disabled" vs "group chat disabled" and the interactions therein
- [ ] use semantic name `groupChatsDisabled`
- [ ] implement same `maybe*` disable chats shape