### PR TITLE
Disable other chat settings when a chat is locked

### DIFF
--- a/src/screens/Messages/ConversationSettings/index.tsx
+++ b/src/screens/Messages/ConversationSettings/index.tsx
@@ -215,7 +215,7 @@ function GroupSettings({
       type: 'MEMBERS_AND_REQUESTS',
       key: 'members-and-requests',
     },
-    ...(isOwner
+    ...(isOwner && convo.details.lockStatus === 'unlocked'
       ? [{type: 'ADD_MEMBERS_LINK', key: 'add-members-link'} as const]
       : []),
   ]
@@ -477,7 +477,7 @@ function SettingsHeader({
           ]}>
           <SettingsButton
             color={convo.view.muted ? 'negative_subtle' : 'secondary'}
-            disabled={!isReady || isMuting}
+            disabled={!isReady || isMuting || lockStatus !== 'unlocked'}
             icon={convo.view.muted ? BellOffIcon : BellIcon}
             label={
               convo.view.muted
@@ -489,7 +489,7 @@ function SettingsHeader({
           />
           {isOwner ? (
             <SettingsButton
-              disabled={!isReady || isEditingName}
+              disabled={!isReady || isEditingName || lockStatus !== 'unlocked'}
               icon={EditIcon}
               label={l`Edit this group chat’s name`}
               text={l`Edit name`}

--- a/src/screens/Messages/components/MessagesListGroupInfoPanel.tsx
+++ b/src/screens/Messages/components/MessagesListGroupInfoPanel.tsx
@@ -83,9 +83,7 @@ export function MessagesListGroupInfoPanel({
     )
   }
 
-  const isLocked =
-    convo.details.lockStatus === 'locked' ||
-    convo.details.lockStatus === 'locked-permanently'
+  const isLocked = convo.details.lockStatus !== 'unlocked'
 
   const showButtons = !isLocked && (isOwner || isJoinLinkEnabled)
 

--- a/src/screens/Messages/components/MessagesListGroupInfoPanel.tsx
+++ b/src/screens/Messages/components/MessagesListGroupInfoPanel.tsx
@@ -83,7 +83,11 @@ export function MessagesListGroupInfoPanel({
     )
   }
 
-  const showButtons = isOwner || isJoinLinkEnabled
+  const isLocked =
+    convo.details.lockStatus === 'locked' ||
+    convo.details.lockStatus === 'locked-permanently'
+
+  const showButtons = !isLocked && (isOwner || isJoinLinkEnabled)
 
   return (
     <>


### PR DESCRIPTION
These options error when used on a locked conversation anyway, so we remove or disable them in the UI here.