### PR TITLE
Remove hard-coded chat member limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "icons:optimize": "svgo -f ./assets/icons"
   },
   "dependencies": {
-    "@atproto/api": "0.20.5",
+    "@atproto/api": "0.20.6",
     "@atproto/syntax": "0.6.1",
     "@bitdrift/react-native": "^0.6.8",
     "@braintree/sanitize-url": "^6.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,8 +242,8 @@ importers:
   .:
     dependencies:
       '@atproto/api':
-        specifier: 0.20.5
-        version: 0.20.5
+        specifier: 0.20.6
+        version: 0.20.6
       '@atproto/syntax':
         specifier: 0.6.1
         version: 0.6.1
@@ -877,8 +877,8 @@ packages:
       graphql:
         optional: true
 
-  '@atproto/api@0.20.5':
-    resolution: {integrity: sha512-VqkRYKR9vRRk36NhtytJz5TPhNtR1hczCcfM+bWoOK6MBvWUT8HwelufrycFAIbFIH7n4ws+5UbnLYpTIBQZ6Q==}
+  '@atproto/api@0.20.6':
+    resolution: {integrity: sha512-WnFPcUl+qZdXmt27+Tg93BDIvBt/WpXfLIiBzBTp3ms9aszM5hAsfc7G8KEsnsmnRvcm0xRfiKEjIt5FxTKdYg==}
     engines: {node: '>=22'}
 
   '@atproto/common-web@0.5.0':
@@ -9494,7 +9494,7 @@ snapshots:
 
   '@0no-co/graphql.web@1.2.0': {}
 
-  '@atproto/api@0.20.5':
+  '@atproto/api@0.20.6':
     dependencies:
       '@atproto/common-web': 0.5.0
       '@atproto/lexicon': 0.7.1

--- a/src/screens/Messages/ConversationSettings/MembersAndRequests.tsx
+++ b/src/screens/Messages/ConversationSettings/MembersAndRequests.tsx
@@ -5,15 +5,16 @@ import {Trans, useLingui} from '@lingui/react/macro'
 import {atoms as a, useTheme} from '#/alf'
 import {InlineLinkText} from '#/components/Link'
 import {Text} from '#/components/Typography'
-import {MEMBER_LIMIT} from './constants'
 
 export function MembersAndRequests({
   memberCount,
+  memberLimit,
   requestCount,
   hasMoreRequests,
   isOwner,
 }: {
   memberCount: number
+  memberLimit: number
   requestCount: number
   hasMoreRequests: boolean
   isOwner: boolean
@@ -31,7 +32,7 @@ export function MembersAndRequests({
         </Text>
         <Text style={[a.text_xs, a.font_medium, t.atoms.text_contrast_medium]}>
           {l({
-            message: `${memberCount}/${MEMBER_LIMIT}`,
+            message: `${memberCount}/${memberLimit}`,
             comment:
               'The number of group chat members out of the total number of permitted users.',
           })}

--- a/src/screens/Messages/ConversationSettings/constants.ts
+++ b/src/screens/Messages/ConversationSettings/constants.ts
@@ -1,1 +1,0 @@
-export const MEMBER_LIMIT = 50

--- a/src/screens/Messages/ConversationSettings/index.tsx
+++ b/src/screens/Messages/ConversationSettings/index.tsx
@@ -246,6 +246,7 @@ function GroupSettings({
         return (
           <MembersAndRequests
             memberCount={convo.details.memberCount}
+            memberLimit={convo.details.memberLimit ?? convo.details.memberCount}
             requestCount={requestCount}
             hasMoreRequests={!!hasMoreRequests}
             isOwner={isOwner}

--- a/src/screens/Messages/ConversationSettings/index.tsx
+++ b/src/screens/Messages/ConversationSettings/index.tsx
@@ -246,7 +246,7 @@ function GroupSettings({
         return (
           <MembersAndRequests
             memberCount={convo.details.memberCount}
-            memberLimit={convo.details.memberLimit ?? convo.details.memberCount}
+            memberLimit={convo.details.memberLimit}
             requestCount={requestCount}
             hasMoreRequests={!!hasMoreRequests}
             isOwner={isOwner}


### PR DESCRIPTION
We get this from the response now so that we can potentially increase it without requiring a client update.