### PR TITLE
Colocate all chat log event handlers

### DIFF
--- a/src/state/queries/messages/list-conversations.tsx
+++ b/src/state/queries/messages/list-conversations.tsx
@@ -173,6 +173,49 @@ export function ListConvosProviderInner({
           )
         }
 
+        function handleMemberAdded(
+          convoId: string,
+          did: string,
+          relatedProfiles: ChatBskyActorDefs.ProfileViewBasic[],
+          rev: string,
+        ) {
+          const newMember = relatedProfiles.find(r => r.did === did)
+          if (!newMember) return
+          // If the optimistic add already added them, skip the
+          // memberCount bump to avoid double-counting.
+          const alreadyKnownMember =
+            queryClient
+              .getQueryData<
+                ChatBskyActorDefs.ProfileViewBasic[]
+              >(listConvoMembersQueryKey(convoId))
+              ?.some(m => m.did === did) ?? false
+          mutateMembers(convoId, list =>
+            list.some(m => m.did === did) ? list : list.concat(newMember),
+          )
+          mutateConvoView(convoId, convo =>
+            addMemberToConvoView(convo, newMember, rev, alreadyKnownMember),
+          )
+        }
+
+        function handleMemberRemoved(
+          convoId: string,
+          did: string,
+          rev: string,
+        ) {
+          // If the optimistic remove already dropped them from the full
+          // list, skip the memberCount decrement to avoid double-counting.
+          const alreadyRemovedMember =
+            queryClient
+              .getQueryData<
+                ChatBskyActorDefs.ProfileViewBasic[]
+              >(listConvoMembersQueryKey(convoId))
+              ?.some(m => m.did === did) === false
+          mutateMembers(convoId, list => list.filter(m => m.did !== did))
+          mutateConvoView(convoId, convo =>
+            removeMemberFromConvoView(convo, did, rev, alreadyRemovedMember),
+          )
+        }
+
         for (const log of events.logs) {
           if (ChatBskyConvoDefs.isLogBeginConvo(log)) {
             debouncedRefetch()
@@ -474,32 +517,12 @@ export function ListConvosProviderInner({
                 ChatBskyConvoDefs.isSystemMessageDataAddMember,
               )
             ) {
-              const newMember = log.relatedProfiles.find(
-                r => r.did === data.member.did,
+              handleMemberAdded(
+                log.convoId,
+                data.member.did,
+                log.relatedProfiles,
+                log.rev,
               )
-              if (newMember) {
-                // If the optimistic add already added them, skip the
-                // memberCount bump to avoid double-counting.
-                const alreadyKnownMember =
-                  queryClient
-                    .getQueryData<
-                      ChatBskyActorDefs.ProfileViewBasic[]
-                    >(listConvoMembersQueryKey(log.convoId))
-                    ?.some(m => m.did === newMember.did) ?? false
-                mutateMembers(log.convoId, list =>
-                  list.some(m => m.did === newMember.did)
-                    ? list
-                    : list.concat(newMember),
-                )
-                mutateConvoView(log.convoId, convo =>
-                  addMemberToConvoView(
-                    convo,
-                    newMember,
-                    log.rev,
-                    alreadyKnownMember,
-                  ),
-                )
-              }
             }
             // Refetch so the server can refresh the curated members list.
             void queryClient.invalidateQueries({
@@ -514,31 +537,13 @@ export function ListConvosProviderInner({
                 ChatBskyConvoDefs.isSystemMessageDataRemoveMember,
               )
             ) {
-              // If the optimistic remove already dropped them from the full
-              // list, skip the memberCount decrement to avoid double-counting.
-              const alreadyRemovedMember =
-                queryClient
-                  .getQueryData<
-                    ChatBskyActorDefs.ProfileViewBasic[]
-                  >(listConvoMembersQueryKey(log.convoId))
-                  ?.some(m => m.did === data.member.did) === false
-              mutateMembers(log.convoId, list =>
-                list.filter(m => m.did !== data.member.did),
-              )
-              mutateConvoView(log.convoId, convo =>
-                removeMemberFromConvoView(
-                  convo,
-                  data.member.did,
-                  log.rev,
-                  alreadyRemovedMember,
-                ),
-              )
-              // Refetch so the server can refill the curated members list.
-              void queryClient.invalidateQueries({
-                queryKey: CONVO_KEY(log.convoId),
-              })
-              debouncedRefetch()
+              handleMemberRemoved(log.convoId, data.member.did, log.rev)
             }
+            // Refetch so the server can refill the curated members list.
+            void queryClient.invalidateQueries({
+              queryKey: CONVO_KEY(log.convoId),
+            })
+            debouncedRefetch()
           } else if (ChatBskyConvoDefs.isLogMemberJoin(log)) {
             const data = log.message.data
             if (
@@ -547,30 +552,12 @@ export function ListConvosProviderInner({
                 ChatBskyConvoDefs.isSystemMessageDataMemberJoin,
               )
             ) {
-              const newMember = log.relatedProfiles.find(
-                r => r.did === data.member.did,
+              handleMemberAdded(
+                log.convoId,
+                data.member.did,
+                log.relatedProfiles,
+                log.rev,
               )
-              if (newMember) {
-                const alreadyKnownMember =
-                  queryClient
-                    .getQueryData<
-                      ChatBskyActorDefs.ProfileViewBasic[]
-                    >(listConvoMembersQueryKey(log.convoId))
-                    ?.some(m => m.did === newMember.did) ?? false
-                mutateMembers(log.convoId, list =>
-                  list.some(m => m.did === newMember.did)
-                    ? list
-                    : list.concat(newMember),
-                )
-                mutateConvoView(log.convoId, convo =>
-                  addMemberToConvoView(
-                    convo,
-                    newMember,
-                    log.rev,
-                    alreadyKnownMember,
-                  ),
-                )
-              }
             }
             void queryClient.invalidateQueries({
               queryKey: CONVO_KEY(log.convoId),
@@ -584,28 +571,12 @@ export function ListConvosProviderInner({
                 ChatBskyConvoDefs.isSystemMessageDataMemberLeave,
               )
             ) {
-              const alreadyRemovedMember =
-                queryClient
-                  .getQueryData<
-                    ChatBskyActorDefs.ProfileViewBasic[]
-                  >(listConvoMembersQueryKey(log.convoId))
-                  ?.some(m => m.did === data.member.did) === false
-              mutateMembers(log.convoId, list =>
-                list.filter(m => m.did !== data.member.did),
-              )
-              mutateConvoView(log.convoId, convo =>
-                removeMemberFromConvoView(
-                  convo,
-                  data.member.did,
-                  log.rev,
-                  alreadyRemovedMember,
-                ),
-              )
-              void queryClient.invalidateQueries({
-                queryKey: CONVO_KEY(log.convoId),
-              })
-              debouncedRefetch()
+              handleMemberRemoved(log.convoId, data.member.did, log.rev)
             }
+            void queryClient.invalidateQueries({
+              queryKey: CONVO_KEY(log.convoId),
+            })
+            debouncedRefetch()
           } else if (ChatBskyConvoDefs.isLogRemoveReaction(log)) {
             queryClient.setQueriesData(
               {queryKey: [RQKEY_ROOT]},
@@ -797,11 +768,9 @@ function removeMemberFromConvoView(
   rev: string,
   alreadyRemovedMember: boolean,
 ): ChatBskyConvoDefs.ConvoView {
+  // Member add/remove/join/leave events are only meaningful for group convos.
+  if (!ChatBskyConvoDefs.isGroupConvo(convo.kind)) return convo
   const nextMembers = convo.members.filter(m => m.did !== did)
-  const wasInCuratedList = nextMembers.length !== convo.members.length
-  if (!ChatBskyConvoDefs.isGroupConvo(convo.kind)) {
-    return wasInCuratedList ? {...convo, members: nextMembers, rev} : convo
-  }
   return {
     ...convo,
     rev,
@@ -821,13 +790,12 @@ function addMemberToConvoView(
   rev: string,
   alreadyKnownMember: boolean,
 ): ChatBskyConvoDefs.ConvoView {
+  // Member add/remove/join/leave events are only meaningful for group convos.
+  if (!ChatBskyConvoDefs.isGroupConvo(convo.kind)) return convo
   const alreadyInCuratedList = convo.members.some(m => m.did === member.did)
   const nextMembers = alreadyInCuratedList
     ? convo.members
     : convo.members.concat(member)
-  if (!ChatBskyConvoDefs.isGroupConvo(convo.kind)) {
-    return {...convo, members: nextMembers, rev}
-  }
   return {
     ...convo,
     rev,

--- a/src/state/queries/messages/list-conversations.tsx
+++ b/src/state/queries/messages/list-conversations.tsx
@@ -21,6 +21,7 @@ import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useAgent, useSession} from '#/state/session'
 import {parseConvoView} from '#/components/dms/util'
 import * as bsky from '#/types/bsky'
+import {RQKEY as CONVO_KEY} from './conversation'
 import {useLeftConvos} from './leave-conversation'
 import {listConvoMembersQueryKey} from './list-convo-members'
 
@@ -153,6 +154,22 @@ export function ListConvosProviderInner({
               if (!old) return // query doesn't exist yet, skip
               return fn(old)
             },
+          )
+        }
+
+        function mutateConvoView(
+          convoId: string,
+          fn: (
+            convo: ChatBskyConvoDefs.ConvoView,
+          ) => ChatBskyConvoDefs.ConvoView,
+        ) {
+          queryClient.setQueryData<ChatBskyConvoDefs.ConvoView>(
+            CONVO_KEY(convoId),
+            old => (old ? fn(old) : old),
+          )
+          queryClient.setQueriesData<ConvoListQueryData>(
+            {queryKey: [RQKEY_ROOT]},
+            old => optimisticUpdate(convoId, old, fn),
           )
         }
 
@@ -466,7 +483,15 @@ export function ListConvosProviderInner({
                     ? list
                     : list.concat(newMember),
                 )
+                mutateConvoView(log.convoId, convo =>
+                  addMemberToConvoView(convo, newMember, log.rev),
+                )
               }
+              // Refetch so the server can refresh the curated members list.
+              void queryClient.invalidateQueries({
+                queryKey: CONVO_KEY(log.convoId),
+              })
+              debouncedRefetch()
             }
           } else if (ChatBskyConvoDefs.isLogRemoveMember(log)) {
             const data = log.message.data
@@ -479,6 +504,14 @@ export function ListConvosProviderInner({
               mutateMembers(log.convoId, list =>
                 list.filter(m => m.did !== data.member.did),
               )
+              mutateConvoView(log.convoId, convo =>
+                removeMemberFromConvoView(convo, data.member.did, log.rev),
+              )
+              // Refetch so the server can refill the curated members list.
+              void queryClient.invalidateQueries({
+                queryKey: CONVO_KEY(log.convoId),
+              })
+              debouncedRefetch()
             }
           } else if (ChatBskyConvoDefs.isLogMemberJoin(log)) {
             const data = log.message.data
@@ -497,7 +530,14 @@ export function ListConvosProviderInner({
                     ? list
                     : list.concat(newMember),
                 )
+                mutateConvoView(log.convoId, convo =>
+                  addMemberToConvoView(convo, newMember, log.rev),
+                )
               }
+              void queryClient.invalidateQueries({
+                queryKey: CONVO_KEY(log.convoId),
+              })
+              debouncedRefetch()
             }
           } else if (ChatBskyConvoDefs.isLogMemberLeave(log)) {
             const data = log.message.data
@@ -510,6 +550,13 @@ export function ListConvosProviderInner({
               mutateMembers(log.convoId, list =>
                 list.filter(m => m.did !== data.member.did),
               )
+              mutateConvoView(log.convoId, convo =>
+                removeMemberFromConvoView(convo, data.member.did, log.rev),
+              )
+              void queryClient.invalidateQueries({
+                queryKey: CONVO_KEY(log.convoId),
+              })
+              debouncedRefetch()
             }
           } else if (ChatBskyConvoDefs.isLogRemoveReaction(log)) {
             queryClient.setQueriesData(
@@ -693,6 +740,50 @@ function optimisticUpdate(
         chatId === convo.id ? updateFn(convo) : convo,
       ),
     })),
+  }
+}
+
+function removeMemberFromConvoView(
+  convo: ChatBskyConvoDefs.ConvoView,
+  did: string,
+  rev: string,
+): ChatBskyConvoDefs.ConvoView {
+  const nextMembers = convo.members.filter(m => m.did !== did)
+  const wasInCuratedList = nextMembers.length !== convo.members.length
+  if (!ChatBskyConvoDefs.isGroupConvo(convo.kind)) {
+    return wasInCuratedList ? {...convo, members: nextMembers, rev} : convo
+  }
+  return {
+    ...convo,
+    rev,
+    members: nextMembers,
+    kind: {
+      ...convo.kind,
+      memberCount: Math.max(0, convo.kind.memberCount - 1),
+    },
+  }
+}
+
+function addMemberToConvoView(
+  convo: ChatBskyConvoDefs.ConvoView,
+  member: ChatBskyActorDefs.ProfileViewBasic,
+  rev: string,
+): ChatBskyConvoDefs.ConvoView {
+  const alreadyInCuratedList = convo.members.some(m => m.did === member.did)
+  const nextMembers = alreadyInCuratedList
+    ? convo.members
+    : convo.members.concat(member)
+  if (!ChatBskyConvoDefs.isGroupConvo(convo.kind)) {
+    return {...convo, members: nextMembers, rev}
+  }
+  return {
+    ...convo,
+    rev,
+    members: nextMembers,
+    kind: {
+      ...convo.kind,
+      memberCount: convo.kind.memberCount + 1,
+    },
   }
 }
 

--- a/src/state/queries/messages/list-conversations.tsx
+++ b/src/state/queries/messages/list-conversations.tsx
@@ -1,5 +1,6 @@
 import {createContext, useCallback, useContext, useEffect, useMemo} from 'react'
 import {
+  type ChatBskyActorDefs,
   ChatBskyConvoDefs,
   type ChatBskyConvoListConvos,
   moderateProfile,
@@ -19,7 +20,9 @@ import {useMessagesEventBus} from '#/state/messages/events'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useAgent, useSession} from '#/state/session'
 import {parseConvoView} from '#/components/dms/util'
+import * as bsky from '#/types/bsky'
 import {useLeftConvos} from './leave-conversation'
+import {listConvoMembersQueryKey} from './list-convo-members'
 
 const DEFAULT_LIMIT = 10
 export const UNREAD_LIMIT = 20
@@ -137,6 +140,21 @@ export function ListConvosProviderInner({
     const unsub = messagesBus.on(
       events => {
         if (events.type !== 'logs') return
+
+        function mutateMembers(
+          convoId: string,
+          fn: (
+            members: ChatBskyActorDefs.ProfileViewBasic[],
+          ) => ChatBskyActorDefs.ProfileViewBasic[],
+        ) {
+          queryClient.setQueryData<ChatBskyActorDefs.ProfileViewBasic[]>(
+            listConvoMembersQueryKey(convoId),
+            old => {
+              if (!old) return // query doesn't exist yet, skip
+              return fn(old)
+            },
+          )
+        }
 
         for (const log of events.logs) {
           if (ChatBskyConvoDefs.isLogBeginConvo(log)) {
@@ -431,6 +449,68 @@ export function ListConvosProviderInner({
                   rev: log.rev,
                 })),
             )
+          } else if (ChatBskyConvoDefs.isLogAddMember(log)) {
+            const data = log.message.data
+            if (
+              bsky.dangerousIsType<ChatBskyConvoDefs.SystemMessageDataAddMember>(
+                data,
+                ChatBskyConvoDefs.isSystemMessageDataAddMember,
+              )
+            ) {
+              const newMember = log.relatedProfiles.find(
+                r => r.did === data.member.did,
+              )
+              if (newMember) {
+                mutateMembers(log.convoId, list =>
+                  list.some(m => m.did === newMember.did)
+                    ? list
+                    : list.concat(newMember),
+                )
+              }
+            }
+          } else if (ChatBskyConvoDefs.isLogRemoveMember(log)) {
+            const data = log.message.data
+            if (
+              bsky.dangerousIsType<ChatBskyConvoDefs.SystemMessageDataRemoveMember>(
+                data,
+                ChatBskyConvoDefs.isSystemMessageDataRemoveMember,
+              )
+            ) {
+              mutateMembers(log.convoId, list =>
+                list.filter(m => m.did !== data.member.did),
+              )
+            }
+          } else if (ChatBskyConvoDefs.isLogMemberJoin(log)) {
+            const data = log.message.data
+            if (
+              bsky.dangerousIsType<ChatBskyConvoDefs.SystemMessageDataMemberJoin>(
+                data,
+                ChatBskyConvoDefs.isSystemMessageDataMemberJoin,
+              )
+            ) {
+              const newMember = log.relatedProfiles.find(
+                r => r.did === data.member.did,
+              )
+              if (newMember) {
+                mutateMembers(log.convoId, list =>
+                  list.some(m => m.did === newMember.did)
+                    ? list
+                    : list.concat(newMember),
+                )
+              }
+            }
+          } else if (ChatBskyConvoDefs.isLogMemberLeave(log)) {
+            const data = log.message.data
+            if (
+              bsky.dangerousIsType<ChatBskyConvoDefs.SystemMessageDataMemberLeave>(
+                data,
+                ChatBskyConvoDefs.isSystemMessageDataMemberLeave,
+              )
+            ) {
+              mutateMembers(log.convoId, list =>
+                list.filter(m => m.did !== data.member.did),
+              )
+            }
           } else if (ChatBskyConvoDefs.isLogRemoveReaction(log)) {
             queryClient.setQueriesData(
               {queryKey: [RQKEY_ROOT]},

--- a/src/state/queries/messages/list-conversations.tsx
+++ b/src/state/queries/messages/list-conversations.tsx
@@ -478,21 +478,34 @@ export function ListConvosProviderInner({
                 r => r.did === data.member.did,
               )
               if (newMember) {
+                // If the optimistic add already added them, skip the
+                // memberCount bump to avoid double-counting.
+                const alreadyKnownMember =
+                  queryClient
+                    .getQueryData<
+                      ChatBskyActorDefs.ProfileViewBasic[]
+                    >(listConvoMembersQueryKey(log.convoId))
+                    ?.some(m => m.did === newMember.did) ?? false
                 mutateMembers(log.convoId, list =>
                   list.some(m => m.did === newMember.did)
                     ? list
                     : list.concat(newMember),
                 )
                 mutateConvoView(log.convoId, convo =>
-                  addMemberToConvoView(convo, newMember, log.rev),
+                  addMemberToConvoView(
+                    convo,
+                    newMember,
+                    log.rev,
+                    alreadyKnownMember,
+                  ),
                 )
               }
-              // Refetch so the server can refresh the curated members list.
-              void queryClient.invalidateQueries({
-                queryKey: CONVO_KEY(log.convoId),
-              })
-              debouncedRefetch()
             }
+            // Refetch so the server can refresh the curated members list.
+            void queryClient.invalidateQueries({
+              queryKey: CONVO_KEY(log.convoId),
+            })
+            debouncedRefetch()
           } else if (ChatBskyConvoDefs.isLogRemoveMember(log)) {
             const data = log.message.data
             if (
@@ -501,11 +514,24 @@ export function ListConvosProviderInner({
                 ChatBskyConvoDefs.isSystemMessageDataRemoveMember,
               )
             ) {
+              // If the optimistic remove already dropped them from the full
+              // list, skip the memberCount decrement to avoid double-counting.
+              const alreadyRemovedMember =
+                queryClient
+                  .getQueryData<
+                    ChatBskyActorDefs.ProfileViewBasic[]
+                  >(listConvoMembersQueryKey(log.convoId))
+                  ?.some(m => m.did === data.member.did) === false
               mutateMembers(log.convoId, list =>
                 list.filter(m => m.did !== data.member.did),
               )
               mutateConvoView(log.convoId, convo =>
-                removeMemberFromConvoView(convo, data.member.did, log.rev),
+                removeMemberFromConvoView(
+                  convo,
+                  data.member.did,
+                  log.rev,
+                  alreadyRemovedMember,
+                ),
               )
               // Refetch so the server can refill the curated members list.
               void queryClient.invalidateQueries({
@@ -525,20 +551,31 @@ export function ListConvosProviderInner({
                 r => r.did === data.member.did,
               )
               if (newMember) {
+                const alreadyKnownMember =
+                  queryClient
+                    .getQueryData<
+                      ChatBskyActorDefs.ProfileViewBasic[]
+                    >(listConvoMembersQueryKey(log.convoId))
+                    ?.some(m => m.did === newMember.did) ?? false
                 mutateMembers(log.convoId, list =>
                   list.some(m => m.did === newMember.did)
                     ? list
                     : list.concat(newMember),
                 )
                 mutateConvoView(log.convoId, convo =>
-                  addMemberToConvoView(convo, newMember, log.rev),
+                  addMemberToConvoView(
+                    convo,
+                    newMember,
+                    log.rev,
+                    alreadyKnownMember,
+                  ),
                 )
               }
-              void queryClient.invalidateQueries({
-                queryKey: CONVO_KEY(log.convoId),
-              })
-              debouncedRefetch()
             }
+            void queryClient.invalidateQueries({
+              queryKey: CONVO_KEY(log.convoId),
+            })
+            debouncedRefetch()
           } else if (ChatBskyConvoDefs.isLogMemberLeave(log)) {
             const data = log.message.data
             if (
@@ -547,11 +584,22 @@ export function ListConvosProviderInner({
                 ChatBskyConvoDefs.isSystemMessageDataMemberLeave,
               )
             ) {
+              const alreadyRemovedMember =
+                queryClient
+                  .getQueryData<
+                    ChatBskyActorDefs.ProfileViewBasic[]
+                  >(listConvoMembersQueryKey(log.convoId))
+                  ?.some(m => m.did === data.member.did) === false
               mutateMembers(log.convoId, list =>
                 list.filter(m => m.did !== data.member.did),
               )
               mutateConvoView(log.convoId, convo =>
-                removeMemberFromConvoView(convo, data.member.did, log.rev),
+                removeMemberFromConvoView(
+                  convo,
+                  data.member.did,
+                  log.rev,
+                  alreadyRemovedMember,
+                ),
               )
               void queryClient.invalidateQueries({
                 queryKey: CONVO_KEY(log.convoId),
@@ -747,6 +795,7 @@ function removeMemberFromConvoView(
   convo: ChatBskyConvoDefs.ConvoView,
   did: string,
   rev: string,
+  alreadyRemovedMember: boolean,
 ): ChatBskyConvoDefs.ConvoView {
   const nextMembers = convo.members.filter(m => m.did !== did)
   const wasInCuratedList = nextMembers.length !== convo.members.length
@@ -759,7 +808,9 @@ function removeMemberFromConvoView(
     members: nextMembers,
     kind: {
       ...convo.kind,
-      memberCount: Math.max(0, convo.kind.memberCount - 1),
+      memberCount: alreadyRemovedMember
+        ? convo.kind.memberCount
+        : Math.max(0, convo.kind.memberCount - 1),
     },
   }
 }
@@ -768,6 +819,7 @@ function addMemberToConvoView(
   convo: ChatBskyConvoDefs.ConvoView,
   member: ChatBskyActorDefs.ProfileViewBasic,
   rev: string,
+  alreadyKnownMember: boolean,
 ): ChatBskyConvoDefs.ConvoView {
   const alreadyInCuratedList = convo.members.some(m => m.did === member.did)
   const nextMembers = alreadyInCuratedList
@@ -782,7 +834,9 @@ function addMemberToConvoView(
     members: nextMembers,
     kind: {
       ...convo.kind,
-      memberCount: convo.kind.memberCount + 1,
+      memberCount: alreadyKnownMember
+        ? convo.kind.memberCount
+        : convo.kind.memberCount + 1,
     },
   }
 }

--- a/src/state/queries/messages/list-convo-members.ts
+++ b/src/state/queries/messages/list-convo-members.ts
@@ -1,19 +1,16 @@
-import {useEffect} from 'react'
-import {type ChatBskyActorDefs, ChatBskyConvoDefs} from '@atproto/api'
-import {type QueryClient, useQuery, useQueryClient} from '@tanstack/react-query'
+import {type ChatBskyActorDefs} from '@atproto/api'
+import {type QueryClient, useQuery} from '@tanstack/react-query'
 
 import {DM_SERVICE_HEADERS} from '#/lib/constants'
-import {useMessagesEventBus} from '#/state/messages/events'
 import {STALE} from '#/state/queries'
 import {createQueryKey} from '#/state/queries/util'
 import {useAgent} from '#/state/session'
-import * as bsky from '#/types/bsky'
 
 const RQKEY_ROOT = 'listConvoMembers'
 export const listConvoMembersQueryKey = (convoId: string) =>
   createQueryKey(RQKEY_ROOT, {convoId})
 
-// group chat size is 50, so should fetch the whole list in one go
+// Group chat size is at least 50, so should fetch the whole list in one go
 const LIMIT = 50
 
 export function useListConvoMembersQuery({
@@ -24,94 +21,6 @@ export function useListConvoMembersQuery({
   placeholderData?: ChatBskyActorDefs.ProfileViewBasic[]
 }) {
   const agent = useAgent()
-  const queryClient = useQueryClient()
-  const messagesBus = useMessagesEventBus()
-
-  useEffect(() => {
-    const unsub = messagesBus.on(
-      ev => {
-        if (ev.type !== 'logs') return
-
-        function mutateList(
-          fn: (
-            update: ChatBskyActorDefs.ProfileViewBasic[],
-          ) => ChatBskyActorDefs.ProfileViewBasic[],
-        ) {
-          queryClient.setQueryData<ChatBskyActorDefs.ProfileViewBasic[]>(
-            listConvoMembersQueryKey(convoId),
-            old => {
-              if (!old) return // query doesn't exist yet, skip
-              return fn(old)
-            },
-          )
-        }
-
-        for (const log of ev.logs) {
-          if (ChatBskyConvoDefs.isLogAddMember(log)) {
-            const data = log.message.data
-            if (
-              bsky.dangerousIsType<ChatBskyConvoDefs.SystemMessageDataAddMember>(
-                data,
-                ChatBskyConvoDefs.isSystemMessageDataAddMember,
-              )
-            ) {
-              const newMember = log.relatedProfiles.find(
-                r => r.did === data.member.did,
-              )
-              if (newMember) {
-                mutateList(list =>
-                  list.some(m => m.did === newMember.did)
-                    ? list
-                    : list.concat(newMember),
-                )
-              }
-            }
-          } else if (ChatBskyConvoDefs.isLogRemoveMember(log)) {
-            const data = log.message.data
-            if (
-              bsky.dangerousIsType<ChatBskyConvoDefs.SystemMessageDataRemoveMember>(
-                data,
-                ChatBskyConvoDefs.isSystemMessageDataRemoveMember,
-              )
-            ) {
-              mutateList(list => list.filter(m => m.did !== data.member.did))
-            }
-          } else if (ChatBskyConvoDefs.isLogMemberJoin(log)) {
-            const data = log.message.data
-            if (
-              bsky.dangerousIsType<ChatBskyConvoDefs.SystemMessageDataMemberJoin>(
-                data,
-                ChatBskyConvoDefs.isSystemMessageDataMemberJoin,
-              )
-            ) {
-              const newMember = log.relatedProfiles.find(
-                r => r.did === data.member.did,
-              )
-              if (newMember) {
-                mutateList(list =>
-                  list.some(m => m.did === newMember.did)
-                    ? list
-                    : list.concat(newMember),
-                )
-              }
-            }
-          } else if (ChatBskyConvoDefs.isLogMemberLeave(log)) {
-            const data = log.message.data
-            if (
-              bsky.dangerousIsType<ChatBskyConvoDefs.SystemMessageDataMemberLeave>(
-                data,
-                ChatBskyConvoDefs.isSystemMessageDataMemberLeave,
-              )
-            ) {
-              mutateList(list => list.filter(m => m.did !== data.member.did))
-            }
-          }
-        }
-      },
-      {convoId},
-    )
-    return () => unsub()
-  }, [convoId, messagesBus, queryClient])
 
   return useQuery({
     queryKey: listConvoMembersQueryKey(convoId),


### PR DESCRIPTION
Moves the member events out of `list-convo-members.ts` and into `list-conversations.tsx`, which is always mounted. Follow-up to #10624.

Tested by adding and removing a member from a group chat in one window (owner), and confirming the events were handled in another (member).