### PR TITLE
Prime convo query cache

### DIFF
--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -9,6 +9,7 @@ import {
   type ChatBskyGroupDefs,
 } from '@atproto/api'
 import {XRPCError} from '@atproto/api'
+import {type QueryClient} from '@tanstack/react-query'
 import {EventEmitter} from 'eventemitter3'
 import {nanoid} from 'nanoid/non-secure'
 
@@ -39,6 +40,7 @@ import {
 } from '#/state/messages/convo/types'
 import {type MessagesEventBus} from '#/state/messages/events/agent'
 import {type MessagesEventBusError} from '#/state/messages/events/types'
+import {precacheConvoQuery} from '#/state/queries/messages/conversation'
 import {
   type ConvoWithDetails,
   type GroupConvoMember,
@@ -84,6 +86,7 @@ export class Convo {
 
   private agent: AtpAgent
   private events: MessagesEventBus
+  private queryClient: QueryClient
   private senderUserDid: string
 
   private status: ConvoStatus = ConvoStatus.Uninitialized
@@ -133,6 +136,7 @@ export class Convo {
     this.convoId = params.convoId
     this.agent = params.agent
     this.events = params.events
+    this.queryClient = params.queryClient
     this.senderUserDid = params.agent.assertDid
 
     if (params.placeholderData) {
@@ -523,6 +527,7 @@ export class Convo {
       for (const member of this.convo.members) {
         this.relatedProfiles.set(member.did, member)
       }
+      precacheConvoQuery(this.queryClient, this.convo.view)
     }
   }
 
@@ -534,6 +539,7 @@ export class Convo {
       for (const member of this.convo.members) {
         this.relatedProfiles.set(member.did, member)
       }
+      precacheConvoQuery(this.queryClient, this.convo.view)
     }
   }
 

--- a/src/state/messages/convo/index.tsx
+++ b/src/state/messages/convo/index.tsx
@@ -90,6 +90,7 @@ export function ConvoProvider({
       convoId,
       agent,
       events,
+      queryClient,
       placeholderData: placeholder ? {convo: placeholder} : undefined,
     })
   })

--- a/src/state/messages/convo/types.ts
+++ b/src/state/messages/convo/types.ts
@@ -6,6 +6,7 @@ import {
   type ChatBskyConvoDefs,
   type ChatBskyConvoSendMessage,
 } from '@atproto/api'
+import {type QueryClient} from '@tanstack/react-query'
 
 import {type MessagesEventBus} from '#/state/messages/events/agent'
 import {type ConvoWithDetails} from '#/components/dms/util'
@@ -14,6 +15,7 @@ export type ConvoParams = {
   convoId: string
   agent: BskyAgent
   events: MessagesEventBus
+  queryClient: QueryClient
   placeholderData?: {
     convo: ChatBskyConvoDefs.ConvoView
   }


### PR DESCRIPTION
A direct URL hit on web to conversation settings mounts `MessagesConversationSettings` without going through `Conversation.tsx`, so `useConvoQuery` is never mounted, so `RQKEY(convoId)` is empty, so `updateConvoOptimistic`’s `if (!prev) return` silently drops both the `onMutate` write and the `onSuccess` write. The agent fetches via its own internal call and never seeds the React Query cache, so the subscriber never fires for `joinLink` changes. 

By priming the cache, this PR fixes all mutations that go through `updateConvoOptimistic`, such as enabling or disabling an invite link.