### PR TITLE
Allow GIF/video pasting on native.

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1434,9 +1434,8 @@ let ComposerPost = memo(function ComposerPost({
     async (uri: string) => {
       if (
         uri.startsWith('data:video/') ||
-        (IS_WEB && uri.startsWith('data:image/gif'))
+        uri.startsWith('data:image/gif')
       ) {
-        if (IS_NATIVE) return // web only
         const [mimeType] = uri.slice('data:'.length).split(';')
         if (!SUPPORTED_MIME_TYPES.includes(mimeType as SupportedMimeTypes)) {
           Toast.show(l`Unsupported video type: ${mimeType}`, {


### PR DESCRIPTION
GIF support was added in https://github.com/bluesky-social/social-app/issues/1047 but https://github.com/bluesky-social/social-app/pull/6433 included the comment "of course, since we are not going to add support for uploading gifs on native quite yet, this isnt something to worry about for now unless you feel so inclined (fwiw, i think it would work as is if we allowed pasting them no?)". I would like to be able to paste GIFs on native, so this is a request for that by removing the IS_WEB/IS_NATIVE check from `onPhotoPasted`