### PR TITLE
Switch `sonner-native` patch to target ESM source

### DIFF
--- a/patches/sonner-native@0.21.0.patch
+++ b/patches/sonner-native@0.21.0.patch
@@ -1,22 +1,39 @@
-diff --git a/lib/commonjs/toast.js b/lib/commonjs/toast.js
-index 121816a452339c1088aeba87928ff63a0bdacca5..47e74bce47323201f0bb4e5ed9dc55b373c07b97 100644
---- a/lib/commonjs/toast.js
-+++ b/lib/commonjs/toast.js
-@@ -264,7 +264,7 @@ const Toast = exports.Toast = /*#__PURE__*/React.forwardRef(({
+diff --git a/lib/module/toast.js b/lib/module/toast.js
+index be089f3ff23017a6844e2010cedc547729e198aa..c2dd0fa2df93f929c33bf2bcc3e6f921941fa006 100644
+--- a/lib/module/toast.js
++++ b/lib/module/toast.js
+@@ -1,8 +1,8 @@
+ "use strict";
+ 
+ import * as React from 'react';
+-import { ActivityIndicator, Pressable, Text, View } from 'react-native';
+-import Animated, { useAnimatedStyle, useSharedValue, withRepeat, withTiming } from 'react-native-reanimated';
++import { ActivityIndicator, Pressable, Text, View, Platform } from 'react-native';
++import Animated, { useAnimatedStyle, useSharedValue, withRepeat, withTiming, FadeOut } from 'react-native-reanimated';
+ import { ANIMATION_DURATION, useToastLayoutAnimations } from "./animations.js";
+ import { toastDefaultValues } from "./constants.js";
+ import { useToastContext } from "./context.js";
+@@ -258,7 +258,10 @@ export const Toast = /*#__PURE__*/React.forwardRef(({
        ...toastSwipeHandlerProps,
-       children: /*#__PURE__*/(0, _jsxRuntime.jsx)(_reactNativeReanimated.default.View, {
+       children: /*#__PURE__*/_jsx(Animated.View, {
          entering: entering,
 -        exiting: exiting,
-+        exiting: _reactNative.Platform.OS === 'android' ? undefined : exiting,
++        exiting: Platform.select({
++          android: undefined,
++          default: exiting
++        }),
          children: jsx
        })
      });
-@@ -274,7 +274,7 @@ const Toast = exports.Toast = /*#__PURE__*/React.forwardRef(({
-     children: /*#__PURE__*/(0, _jsxRuntime.jsx)(_reactNativeReanimated.default.View, {
+@@ -268,7 +271,10 @@ export const Toast = /*#__PURE__*/React.forwardRef(({
+     children: /*#__PURE__*/_jsx(Animated.View, {
        style: [unstyled ? undefined : elevationStyle, defaultStyles.toast, toastStyleCtx, styles?.toast, style, wiggleAnimationStyle],
        entering: entering,
 -      exiting: exiting,
-+      exiting: _reactNative.Platform.OS === 'android' ? undefined : exiting,
-       children: /*#__PURE__*/(0, _jsxRuntime.jsxs)(_reactNative.View, {
++      exiting: Platform.select({
++        android: undefined,
++        default: exiting
++      }),
+       children: /*#__PURE__*/_jsxs(View, {
          style: [defaultStyles.toastContent, toastContentStyleCtx, styles?.toastContent],
-         children: [promiseOptions || variant === 'loading' ? 'loading' in icons ? icons.loading : /*#__PURE__*/(0, _jsxRuntime.jsx)(_reactNative.ActivityIndicator, {}) : icon ? /*#__PURE__*/(0, _jsxRuntime.jsx)(_reactNative.View, {
+         children: [promiseOptions || variant === 'loading' ? 'loading' in icons ? icons.loading : /*#__PURE__*/_jsx(ActivityIndicator, {}) : icon ? /*#__PURE__*/_jsx(View, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,7 +235,7 @@ patchedDependencies:
   react-native-uitextview@1.4.0: 62de26caadfc39d1bdff204cdc03a705c0cd343999825e06d8c0c120de06cc99
   react-native-view-shot@4.0.3: a2457dc30a82cc8c21f371a6f860d9396d450a2a1b4265b1a4ee13bdb24d3268
   react-native@0.81.5: 2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194
-  sonner-native@0.21.0: a07ea00b9f97634a402875e49a5231407e82733dd49c5dbc230afc3d1bc7dcf5
+  sonner-native@0.21.0: 4bcd0da0fec32e943460e6e788a9e4adf601b507d2dfd0c8246a6c8c74d8f638
 
 importers:
 
@@ -693,7 +693,7 @@ importers:
         version: 2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       sonner-native:
         specifier: 0.21.0
-        version: 0.21.0(patch_hash=a07ea00b9f97634a402875e49a5231407e82733dd49c5dbc230afc3d1bc7dcf5)(4e42d15c94c2c56af69d343a007eb893)
+        version: 0.21.0(patch_hash=4bcd0da0fec32e943460e6e788a9e4adf601b507d2dfd0c8246a6c8c74d8f638)(4e42d15c94c2c56af69d343a007eb893)
       tippy.js:
         specifier: ^6.3.7
         version: 6.3.7
@@ -18539,7 +18539,7 @@ snapshots:
       uuid: 8.3.2
       websocket-driver: 0.7.4
 
-  sonner-native@0.21.0(patch_hash=a07ea00b9f97634a402875e49a5231407e82733dd49c5dbc230afc3d1bc7dcf5)(4e42d15c94c2c56af69d343a007eb893):
+  sonner-native@0.21.0(patch_hash=4bcd0da0fec32e943460e6e788a9e4adf601b507d2dfd0c8246a6c8c74d8f638)(4e42d15c94c2c56af69d343a007eb893):
     dependencies:
       react: 19.1.0
       react-native: 0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)


### PR DESCRIPTION
#9092 stopped working as it started resolving the ESM version instead of the CJS version, I'm guessing due to #10543 enabling `unstable_enablePackageExports` in the Metro settings.

Easy fix: apply the same patch to the ESM version 