### PR TITLE
Fix Android crash when sharing unreadable media into the app

### DIFF
--- a/modules/expo-receive-android-intents/android/src/main/java/xyz/blueskyweb/app/exporeceiveandroidintents/ExpoReceiveAndroidIntentsModule.kt
+++ b/modules/expo-receive-android-intents/android/src/main/java/xyz/blueskyweb/app/exporeceiveandroidintents/ExpoReceiveAndroidIntentsModule.kt
@@ -119,17 +119,15 @@ class ExpoReceiveAndroidIntentsModule : Module() {
     uris: List<Uri>,
     text: String?,
   ) {
-    var allParams = ""
+    // Some URIs we receive may be unreadable (revoked permission, deleted file,
+    // a provider that rejects the read). Skip those rather than crashing the
+    // whole app, since this runs synchronously on the module init path.
+    val allParams =
+      uris
+        .mapNotNull { uri -> getImageInfo(uri) }
+        .joinToString(",") { info -> buildUriData(info) }
 
-    uris.forEachIndexed { index, uri ->
-      val info = getImageInfo(uri)
-      val params = buildUriData(info)
-      allParams = "${allParams}$params"
-
-      if (index < uris.count() - 1) {
-        allParams = "$allParams,"
-      }
-    }
+    if (allParams.isEmpty()) return
 
     val encodedUris = URLEncoder.encode(allParams, "UTF-8")
     val encodedText = text?.let { URLEncoder.encode(it, "UTF-8") }
@@ -158,9 +156,16 @@ class ExpoReceiveAndroidIntentsModule : Module() {
     }
     val file = createFile(extension)
 
-    val out = FileOutputStream(file)
-    appContext.currentActivity?.contentResolver?.openInputStream(uri)?.use {
-      it.copyTo(out)
+    // The URI may be unreadable (revoked permission, deleted file, or a
+    // provider that rejects the read). Bail rather than crashing the whole
+    // app, since this runs synchronously on the module init path.
+    try {
+      FileOutputStream(file).use { out ->
+        val input = appContext.currentActivity?.contentResolver?.openInputStream(uri) ?: return
+        input.use { it.copyTo(out) }
+      }
+    } catch (e: Exception) {
+      return
     }
 
     val info = getVideoInfo(uri) ?: return
@@ -176,8 +181,15 @@ class ExpoReceiveAndroidIntentsModule : Module() {
     }
   }
 
-  private fun getImageInfo(uri: Uri): Map<String, Any> {
-    val bitmap = MediaStore.Images.Media.getBitmap(appContext.currentActivity?.contentResolver, uri)
+  private fun getImageInfo(uri: Uri): Map<String, Any>? {
+    val bitmap =
+      try {
+        MediaStore.Images.Media.getBitmap(appContext.currentActivity?.contentResolver, uri)
+      } catch (e: Exception) {
+        // The URI may be unreadable (revoked permission, deleted file, or a
+        // provider that rejects the read). Skip this image rather than crash.
+        return null
+      } ?: return null
     // We have to save this so that we can access it later when uploading the image.
     // createTempFile will automatically place a unique string between "img" and "temp.jpeg"
     val file = createFile("jpeg")
@@ -195,10 +207,18 @@ class ExpoReceiveAndroidIntentsModule : Module() {
 
   private fun getVideoInfo(uri: Uri): Map<String, Any>? {
     val retriever = MediaMetadataRetriever()
-    retriever.setDataSource(appContext.currentActivity, uri)
-
-    val width = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)?.toIntOrNull()
-    val height = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)?.toIntOrNull()
+    val width: Int?
+    val height: Int?
+    try {
+      retriever.setDataSource(appContext.currentActivity, uri)
+      width = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)?.toIntOrNull()
+      height = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)?.toIntOrNull()
+    } catch (e: Exception) {
+      // The URI may be unreadable or not a valid media source. Skip rather than crash.
+      return null
+    } finally {
+      retriever.release()
+    }
 
     if (width == null || height == null) {
       return null


### PR DESCRIPTION
## What

Fixes a crash on Android when an image or video is shared into Bluesky via the system share sheet and the underlying `content://` URI can't be read.

## Root cause

`handleIntent` runs synchronously on the Expo module init path (`OnCreate` -> `getConstants` on the React bridge thread). When `MediaStore.Images.Media.getBitmap` threw a `FileNotFoundException` for an unreadable URI, nothing caught it and it propagated up through the bridge, crashing the whole app at launch rather than just failing the share.

```
JavascriptException ... readExceptionWithFileNotFoundExceptionFromParcel
  at ...MediaStore$Images$Media.getBitmap
  at ...ExpoReceiveAndroidIntentsModule.getImageInfo (ExpoReceiveAndroidIntentsModule.kt:180)
  at ...handleImageIntents
  at ...OnCreate ... getConstants
```

A URI can be unreadable for a few reasons: the temporary read-permission grant didn't survive how we consume it during init/relaunch, the source app handed us a URI we don't have access to, or the backing file was moved/deleted.

The video path had the same latent crash via the file copy (`openInputStream`) and `MediaMetadataRetriever.setDataSource`.

## Changes

- `getImageInfo` now returns nullable and wraps `getBitmap` in try/catch, returning `null` on failure.
- `handleImageIntents` drops images that fail to process (`mapNotNull`) and bails early if none succeed, so we don't fire an empty compose intent.
- `handleVideoIntents` wraps the file copy in try/catch and bails on failure.
- `getVideoInfo` wraps `setDataSource`/`extractMetadata` in try/catch, and now releases the `MediaMetadataRetriever` in a `finally` (it was never freed before).

The JS consumer (`useIntentHandler.ts`) already filters malformed parts, so partial success degrades gracefully - readable images still open in the composer.

## Testing

Native Kotlin change - not covered by `pnpm test`/`typecheck`/`lint`. Should be validated with an Android build:
- Share multiple images where one is unreadable -> composer opens with the readable ones, no crash.
- Share a single unreadable image/video -> no crash, share is silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)