### PR TITLE
Fix video size error showing 100 MB for users with 300 MB upload limit

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1917,6 +1917,10 @@ function ComposerFooter({
   const t = useTheme()
   const {t: l} = useLingui()
   const {gtPhone} = useBreakpoints()
+  const ax = useAnalytics()
+  const enableLargeVideoUploads = ax.features.enabled(
+    ax.features.LargeVideoUploads,
+  )
   /*
    * Once we've allowed a certain type of asset to be selected, we don't allow
    * other types of media to be selected.
@@ -2033,6 +2037,7 @@ function ComposerFooter({
                 selectedAssetsCount={selectedAssetsCount}
                 onSelectAssets={onSelectAssets}
                 autoOpen={openGallery}
+                enableLargeVideoUploads={enableLargeVideoUploads}
               />
               <OpenCameraBtn
                 disabled={media?.type === 'images' ? isMaxImages : !!media}

--- a/src/view/com/composer/SelectMediaButton.tsx
+++ b/src/view/com/composer/SelectMediaButton.tsx
@@ -5,7 +5,11 @@ import {type ImagePickerAsset} from 'expo-image-picker'
 import {msg, plural} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 
-import {VIDEO_MAX_DURATION_MS, VIDEO_MAX_SIZE} from '#/lib/constants'
+import {
+  VIDEO_MAX_DURATION_MS,
+  VIDEO_MAX_SIZE,
+  VIDEO_MAX_SIZE_REDUCED,
+} from '#/lib/constants'
 import {
   usePhotoLibraryPermission,
   useVideoLibraryPermission,
@@ -28,6 +32,12 @@ export type SelectMediaButtonProps = {
    */
   allowedAssetTypes: AssetType | undefined
   selectedAssetsCount: number
+  /**
+   * Whether the user has the larger (300 MB) video upload limit enabled. Used
+   * to validate file size at selection time and to show the correct limit in
+   * error messages.
+   */
+  enableLargeVideoUploads: boolean
   onSelectAssets: (props: {
     type: AssetType
     assets: ImagePickerAsset[]
@@ -231,11 +241,16 @@ async function processImagePickerAssets(
   {
     selectionCountRemaining,
     allowedAssetTypes,
+    enableLargeVideoUploads,
   }: {
     selectionCountRemaining: number
     allowedAssetTypes: AssetType | undefined
+    enableLargeVideoUploads: boolean
   },
 ) {
+  const maxVideoSize = enableLargeVideoUploads
+    ? VIDEO_MAX_SIZE
+    : VIDEO_MAX_SIZE_REDUCED
   /*
    * A deduped set of error codes, which we'll use later
    */
@@ -289,7 +304,7 @@ async function processImagePickerAssets(
        * to filter out large files on web. On native, we compress these anyway,
        * so we only check on web.
        */
-      if (IS_WEB && asset.fileSize && asset.fileSize > VIDEO_MAX_SIZE) {
+      if (IS_WEB && asset.fileSize && asset.fileSize > maxVideoSize) {
         errors.add(SelectedAssetError.FileTooBig)
         continue
       }
@@ -308,7 +323,7 @@ async function processImagePickerAssets(
        * to filter out large files on web. On native, we compress GIFs as
        * videos anyway, so we only check on web.
        */
-      if (IS_WEB && asset.fileSize && asset.fileSize > VIDEO_MAX_SIZE) {
+      if (IS_WEB && asset.fileSize && asset.fileSize > maxVideoSize) {
         errors.add(SelectedAssetError.FileTooBig)
         continue
       }
@@ -381,6 +396,7 @@ export function SelectMediaButton({
   selectedAssetsCount,
   onSelectAssets,
   autoOpen,
+  enableLargeVideoUploads,
 }: SelectMediaButtonProps) {
   const {_} = useLingui()
   const {requestPhotoAccessIfNeeded} = usePhotoLibraryPermission()
@@ -400,7 +416,10 @@ export function SelectMediaButton({
       } = await processImagePickerAssets(rawAssets, {
         selectionCountRemaining,
         allowedAssetTypes,
+        enableLargeVideoUploads,
       })
+
+      const videoSize = enableLargeVideoUploads ? 300 : 100
 
       /*
        * Convert error codes to user-friendly messages.
@@ -431,7 +450,7 @@ export function SelectMediaButton({
             msg`You can only select one GIF at a time.`,
           ),
           [SelectedAssetError.FileTooBig]: _(
-            msg`One or more of your selected files are too large. Maximum size is 100 MB.`,
+            msg`One or more of your selected files are too large. Maximum size is ${videoSize} MB.`,
           ),
         }[error]
       })
@@ -446,7 +465,13 @@ export function SelectMediaButton({
         errors,
       })
     },
-    [_, onSelectAssets, selectionCountRemaining, allowedAssetTypes],
+    [
+      _,
+      onSelectAssets,
+      selectionCountRemaining,
+      allowedAssetTypes,
+      enableLargeVideoUploads,
+    ],
   )
 
   const onPressSelectMedia = useCallback(async () => {

--- a/src/view/com/composer/SelectMediaButton.tsx
+++ b/src/view/com/composer/SelectMediaButton.tsx
@@ -450,7 +450,7 @@ export function SelectMediaButton({
             msg`You can only select one GIF at a time.`,
           ),
           [SelectedAssetError.FileTooBig]: _(
-            msg`One or more of your selected files are too large. Maximum size is ${videoSize} MB.`,
+            msg`One or more of your selected files are too large. Maximum size is ${videoSize} MB.`,
           ),
         }[error]
       })


### PR DESCRIPTION
> [!IMPORTANT]
> **Claude Code analyzed this issue and wrote the PR and much of the description.**
>
> **Although it passes CI, I have not tested the fix.**

## Issue

If a user has the `LargeVideoUploads` flag enabled and tries to upload a video file larger than 300 MB on web, they get this confusing error message referring to the 100 MB limit:

<img width="400" alt="IMG_8975" src="https://github.com/user-attachments/assets/95e4c8a0-4097-402a-b5b8-4540ba332c52" />

A selected video's file size is validated in three places:

1. **Compression** (`getCompressErrorMessage`) ✅ flag-aware
2. **Upload** (`getUploadErrorMessage`) ✅ flag-aware
3. **Selection time** (`SelectMediaButton.tsx`) ❌ **not** flag-aware

This PR is a follow-up to #10497 to update the third place.

The confusing error message comes from the earliest check, which runs the moment you pick a file on web. In `src/view/com/composer/SelectMediaButton.tsx`, `processImagePickerAssets` had two problems:

- The size threshold compared against `VIDEO_MAX_SIZE` (300 MB) unconditionally, ignoring the feature flag entirely.
- The `FileTooBig` error string was **hardcoded** to `Maximum size is 100 MB.`

So a flag-enabled user picking a video over 300 MB correctly tripped the 300 MB threshold but got a message that said 100 MB. (As a bonus bug, users *without* the flag were allowed to select up to 300 MB at this stage, only failing later during compression/upload.)

The root cause is that `SelectMediaButton` had no access to the `large_video_uploads` flag — it was only passed to the later compression/upload steps.

## Fix

Threaded the existing `LargeVideoUploads` flag into the selection-time validation:

- **`SelectMediaButton.tsx`** — added an `enableLargeVideoUploads` prop, used it to pick `VIDEO_MAX_SIZE` (300 MB) vs `VIDEO_MAX_SIZE_REDUCED` (100 MB) for the threshold, and interpolated the matching number into the error message (`Maximum size is ${videoSize} MB.`), mirroring the wording approach already used in `video.ts`.
- **`Composer.tsx`** — `ComposerFooter` (which renders the button) now reads the flag via the existing `useAnalytics()` hook and passes it down.

This fixes both the misleading message and the threshold mismatch for non-flagged users.

## Test plan (on web)

- With the flag **off**, a 100–300 MB video is now rejected at selection with "Maximum size is 100 MB"
- With the flag **on**, a 100–300 MB video is accepted and a >300 MB video shows "Maximum size is 300 MB".