### PR TITLE
Fix duplicate haptic feedback when liking posts

### DIFF
--- a/src/components/PostControls/index.tsx
+++ b/src/components/PostControls/index.tsx
@@ -11,7 +11,6 @@ import {useLingui} from '@lingui/react/macro'
 
 import {CountWheel} from '#/lib/custom-animations/CountWheel'
 import {AnimatedLikeIcon} from '#/lib/custom-animations/LikeIcon'
-import {useHaptics} from '#/lib/haptics'
 import {useOpenComposer} from '#/lib/hooks/useOpenComposer'
 import {type Shadow} from '#/state/cache/types'
 import {useFeedFeedbackContext} from '#/state/feed-feedback'
@@ -93,7 +92,6 @@ let PostControls = ({
   const requireAuth = useRequireAuth()
   const {sendInteraction} = useFeedFeedbackContext()
   const {captureAction} = useProgressGuideControls()
-  const playHaptic = useHaptics()
   const isBlocked = Boolean(
     post.author.viewer?.blocking ||
     post.author.viewer?.blockedBy ||
@@ -116,7 +114,6 @@ let PostControls = ({
     try {
       setHasLikeIconBeenToggled(true)
       if (!post.viewer?.like) {
-        playHaptic('Light')
         sendInteraction({
           item: post.uri,
           event: 'app.bsky.feed.defs#interactionLike',


### PR DESCRIPTION
This has been bothering me for a long time: on Android, liking a post felt like it produced two separate haptic taps. Once I noticed it, I could not un-notice it, so I finally dug into the post controls and found that the like path was indeed triggering haptics from two places.

## Summary

This removes an extra haptic trigger from the post like handler.

`PostControlButton` already plays light haptic feedback when the like button is pressed. The like handler in `PostControls` was also playing another light haptic only when creating a like, which made liking a post trigger haptic feedback twice. Unliking did not have the same issue because that extra handler-side haptic only ran in the `!post.viewer?.like` branch.

I reproduced and manually verified the behavior on Android. The duplicate call is in shared post-control code, but I have not verified whether the same double feedback was noticeable on iOS.

## Root cause

The like action originally had its own haptic feedback before post controls were consolidated around `PostControlButton`. Later, `PostControlButton` became the shared base button for post controls and added press-level haptic feedback. The legacy like-specific haptic call remained in `PostControls`, so pressing Like called haptics from both places.

## Fix

Keep the centralized post-control button haptic behavior and remove the duplicate like-specific call.

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test --runInBand`
- `pnpm prettier --check src/components/PostControls/index.tsx`
- Android: manually verified on a debug build that liking a post now triggers haptic feedback once instead of twice.
- iOS: not tested locally.