### PR TITLE
Fix scrollbar behaviour in splitview

### DIFF
--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -345,7 +345,7 @@ function ListImpl<ItemT>(
         style,
         disableFullWindowScroll && {
           flex: 1,
-          overflowY: 'scroll',
+          overflowY: isWithinSplitView ? 'auto' : 'scroll',
         },
       ]}
       ref={nativeRef as unknown as React.RefObject<View>}>


### PR DESCRIPTION
Uses `overflowY: auto` when in split view