### PR TITLE
Hide accept button for locked chats

### DIFF
--- a/src/screens/Messages/components/RequestListItem.tsx
+++ b/src/screens/Messages/components/RequestListItem.tsx
@@ -28,6 +28,9 @@ export function RequestListItem({
   const isDeletedAccount =
     !convo.primaryMember || convo.primaryMember.handle === 'missing.invalid'
 
+  const canAcceptRequest =
+    convo.kind === 'direct' || convo.details.lockStatus === 'unlocked'
+
   return (
     <View style={[a.relative, a.flex_1]}>
       <ChatListItem convo={convo.view} showMenu={false}>
@@ -65,7 +68,9 @@ export function RequestListItem({
             ]}>
             {convo.primaryMember && !isDeletedAccount ? (
               <>
-                <AcceptChatButton convo={convo.view} currentScreen="list" />
+                {canAcceptRequest ? (
+                  <AcceptChatButton convo={convo.view} currentScreen="list" />
+                ) : null}
                 <RejectMenu
                   convo={convo.view}
                   profile={convo.primaryMember}


### PR DESCRIPTION
You can’t accept a request to join a locked chat.

<img width="402" height="874" alt="locked" src="https://github.com/user-attachments/assets/e21f96b9-7783-4c22-8ae8-caea07ba6987" />
