### PR TITLE
Paginate group chat members list

### DIFF
--- a/src/components/dms/AddMembersFlow.tsx
+++ b/src/components/dms/AddMembersFlow.tsx
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useReducer,
@@ -131,15 +132,33 @@ export function AddMembersFlow({
     isFetching: isAutocompleteFetching,
   } = useActorAutocompleteQuery(searchText, true, 12)
   const {data: follows} = useProfileFollowsQuery(currentAccount?.did)
-  const {data: memberListData = [], isPending: isMemberListPending} =
-    useListConvoMembersQuery({
-      convoId: convo.view.id,
-      placeholderData: convo.members,
-    })
+  const {
+    data: memberListPages,
+    isPending: isMemberListPending,
+    hasNextPage: hasMoreMembers,
+    isFetchingNextPage: isFetchingMoreMembers,
+    fetchNextPage: fetchMoreMembers,
+  } = useListConvoMembersQuery({
+    convoId: convo.view.id,
+    placeholderData: convo.members,
+  })
+  // We need the full member set so we can filter them out of search/follow
+  // results. Auto-fetch all pages on mount.
+  useEffect(() => {
+    if (hasMoreMembers && !isFetchingMoreMembers) {
+      void fetchMoreMembers()
+    }
+  }, [hasMoreMembers, isFetchingMoreMembers, fetchMoreMembers])
   const memberDidSet = useMemo(
-    () => new Set(memberListData.map(profile => profile.did)),
-    [memberListData],
+    () =>
+      new Set(
+        memberListPages?.pages.flatMap(page =>
+          page.members.map(profile => profile.did),
+        ) ?? [],
+      ),
+    [memberListPages],
   )
+  const isMemberListLoading = isMemberListPending || hasMoreMembers
 
   const [{groupChatDids, groupChatProfiles}, dispatch] = useReducer(reducer, {
     groupChatDids: [],
@@ -161,7 +180,7 @@ export function AddMembersFlow({
   )
 
   const items = useMemo<Item[]>(() => {
-    if (isMemberListPending) {
+    if (isMemberListLoading) {
       // Still fetching chat member DIDs for filtering, so force the loading state.
       return []
     }
@@ -247,7 +266,7 @@ export function AddMembersFlow({
     follows,
     isAutocompleteFetching,
     isError,
-    isMemberListPending,
+    isMemberListLoading,
     l,
     memberDidSet,
     searchText,
@@ -480,7 +499,7 @@ export function AddMembersFlow({
         ListHeaderComponent={listHeader}
         stickyHeaderIndices={[0]}
         ListEmptyComponent={
-          isMemberListPending || isAutocompleteFetching ? (
+          isMemberListLoading || isAutocompleteFetching ? (
             <View style={[a.flex_1, a.align_center, a.justify_center]}>
               <Loader size="xl" />
             </View>

--- a/src/screens/Messages/ConversationSettings/index.tsx
+++ b/src/screens/Messages/ConversationSettings/index.tsx
@@ -186,10 +186,19 @@ function GroupSettings({
   const primaryMember = convo.primaryMember
   const isOwner = !!primaryMember && primaryMember.did === currentAccount?.did
 
-  const {data: memberListData = [], refetch} = useListConvoMembersQuery({
+  const {
+    data: memberListPages,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isError: isMemberListError,
+  } = useListConvoMembersQuery({
     convoId: convo.view.id,
     placeholderData: convo.members,
   })
+  const memberListData =
+    memberListPages?.pages.flatMap(page => page.members) ?? []
 
   const {data: joinRequestsData, hasNextPage: hasMoreRequests} =
     useListJoinRequestsQuery({
@@ -281,6 +290,15 @@ function GroupSettings({
     setIsPTRing(false)
   }
 
+  const onEndReached = async () => {
+    if (isFetchingNextPage || !hasNextPage || isMemberListError) return
+    try {
+      await fetchNextPage()
+    } catch (err) {
+      logger.error('Failed to load more group chat members', {message: err})
+    }
+  }
+
   return (
     <List
       data={items}
@@ -303,6 +321,8 @@ function GroupSettings({
       windowSize={11}
       refreshing={isPTRing}
       onRefresh={() => void onRefresh()}
+      onEndReached={() => void onEndReached()}
+      onEndReachedThreshold={2}
     />
   )
 }

--- a/src/state/queries/messages/add-group-members.ts
+++ b/src/state/queries/messages/add-group-members.ts
@@ -1,6 +1,7 @@
 import {
   type ChatBskyActorDefs,
   ChatBskyConvoDefs,
+  type ChatBskyConvoGetConvoMembers,
   type ChatBskyConvoListConvos,
   type ChatBskyGroupAddMembers,
 } from '@atproto/api'
@@ -58,7 +59,7 @@ export function useAddGroupMembers(
         InfiniteData<ChatBskyConvoListConvos.OutputSchema>
       >({queryKey: [CONVO_LIST_KEY]})
       const prevMemberList = queryClient.getQueryData<
-        ChatBskyActorDefs.ProfileViewBasic[]
+        InfiniteData<ChatBskyConvoGetConvoMembers.OutputSchema>
       >(listConvoMembersQueryKey(convoId))
 
       const addedBy: ChatBskyActorDefs.ProfileViewBasic | undefined = myProfile
@@ -120,13 +121,17 @@ export function useAddGroupMembers(
         }
       })
 
-      queryClient.setQueryData<ChatBskyActorDefs.ProfileViewBasic[]>(
-        listConvoMembersQueryKey(convoId),
-        prev => {
-          if (!prev) return
-          return [...prev, ...optimisticMembers]
-        },
-      )
+      queryClient.setQueryData<
+        InfiniteData<ChatBskyConvoGetConvoMembers.OutputSchema>
+      >(listConvoMembersQueryKey(convoId), prev => {
+        if (!prev?.pages) return prev
+        const pages = prev.pages.map((page, i) =>
+          i === prev.pages.length - 1
+            ? {...page, members: [...page.members, ...optimisticMembers]}
+            : page,
+        )
+        return {...prev, pages}
+      })
 
       return {prevConvo, prevListEntries, prevMemberList}
     },

--- a/src/state/queries/messages/join-requests.ts
+++ b/src/state/queries/messages/join-requests.ts
@@ -1,5 +1,5 @@
 import {
-  type ChatBskyActorDefs,
+  type ChatBskyConvoGetConvoMembers,
   type ChatBskyGroupApproveJoinRequest,
   type ChatBskyGroupListJoinRequests,
   type ChatBskyGroupRejectJoinRequest,
@@ -77,21 +77,28 @@ export function useJoinRequestMutation<A extends JoinRequestAction>(
         }
       })
 
-      let prevMembers: ChatBskyActorDefs.ProfileViewBasic[] | undefined
+      let prevMembers:
+        | InfiniteData<ChatBskyConvoGetConvoMembers.OutputSchema>
+        | undefined
       if (action === 'approve' && requestedByProfile) {
         const membersKey = listConvoMembersQueryKey(convoId)
         prevMembers =
-          queryClient.getQueryData<ChatBskyActorDefs.ProfileViewBasic[]>(
-            membersKey,
+          queryClient.getQueryData<
+            InfiniteData<ChatBskyConvoGetConvoMembers.OutputSchema>
+          >(membersKey)
+        queryClient.setQueryData<
+          InfiniteData<ChatBskyConvoGetConvoMembers.OutputSchema>
+        >(membersKey, prev => {
+          if (!prev?.pages) return prev
+          if (prev.pages.some(page => page.members.some(m => m.did === member)))
+            return prev
+          const pages = prev.pages.map((page, i) =>
+            i === prev.pages.length - 1
+              ? {...page, members: [...page.members, requestedByProfile]}
+              : page,
           )
-        queryClient.setQueryData<ChatBskyActorDefs.ProfileViewBasic[]>(
-          membersKey,
-          prev => {
-            if (!prev) return prev
-            if (prev.some(m => m.did === member)) return prev
-            return [...prev, requestedByProfile]
-          },
-        )
+          return {...prev, pages}
+        })
       }
 
       return {prevRequests, prevMembers}

--- a/src/state/queries/messages/list-conversations.tsx
+++ b/src/state/queries/messages/list-conversations.tsx
@@ -2,6 +2,7 @@ import {createContext, useCallback, useContext, useEffect, useMemo} from 'react'
 import {
   type ChatBskyActorDefs,
   ChatBskyConvoDefs,
+  type ChatBskyConvoGetConvoMembers,
   type ChatBskyConvoListConvos,
   moderateProfile,
   type ModerationOpts,
@@ -148,13 +149,19 @@ export function ListConvosProviderInner({
             members: ChatBskyActorDefs.ProfileViewBasic[],
           ) => ChatBskyActorDefs.ProfileViewBasic[],
         ) {
-          queryClient.setQueryData<ChatBskyActorDefs.ProfileViewBasic[]>(
-            listConvoMembersQueryKey(convoId),
-            old => {
-              if (!old) return // query doesn't exist yet, skip
-              return fn(old)
-            },
-          )
+          queryClient.setQueryData<
+            InfiniteData<ChatBskyConvoGetConvoMembers.OutputSchema>
+          >(listConvoMembersQueryKey(convoId), old => {
+            if (!old?.pages) return
+            const flat = old.pages.flatMap(page => page.members)
+            const next = fn(flat)
+            return {
+              ...old,
+              pages: old.pages.map((page, i) =>
+                i === 0 ? {...page, members: next} : {...page, members: []},
+              ),
+            }
+          })
         }
 
         function mutateConvoView(
@@ -186,9 +193,10 @@ export function ListConvosProviderInner({
           const alreadyKnownMember =
             queryClient
               .getQueryData<
-                ChatBskyActorDefs.ProfileViewBasic[]
+                InfiniteData<ChatBskyConvoGetConvoMembers.OutputSchema>
               >(listConvoMembersQueryKey(convoId))
-              ?.some(m => m.did === did) ?? false
+              ?.pages.some(page => page.members.some(m => m.did === did)) ??
+            false
           mutateMembers(convoId, list =>
             list.some(m => m.did === did) ? list : list.concat(newMember),
           )
@@ -207,9 +215,10 @@ export function ListConvosProviderInner({
           const alreadyRemovedMember =
             queryClient
               .getQueryData<
-                ChatBskyActorDefs.ProfileViewBasic[]
+                InfiniteData<ChatBskyConvoGetConvoMembers.OutputSchema>
               >(listConvoMembersQueryKey(convoId))
-              ?.some(m => m.did === did) === false
+              ?.pages.some(page => page.members.some(m => m.did === did)) ===
+            false
           mutateMembers(convoId, list => list.filter(m => m.did !== did))
           mutateConvoView(convoId, convo =>
             removeMemberFromConvoView(convo, did, rev, alreadyRemovedMember),

--- a/src/state/queries/messages/list-convo-members.ts
+++ b/src/state/queries/messages/list-convo-members.ts
@@ -1,5 +1,12 @@
-import {type ChatBskyActorDefs} from '@atproto/api'
-import {type QueryClient, useQuery} from '@tanstack/react-query'
+import {
+  type ChatBskyActorDefs,
+  type ChatBskyConvoGetConvoMembers,
+} from '@atproto/api'
+import {
+  type InfiniteData,
+  type QueryClient,
+  useInfiniteQuery,
+} from '@tanstack/react-query'
 
 import {DM_SERVICE_HEADERS} from '#/lib/constants'
 import {STALE} from '#/state/queries'
@@ -10,8 +17,9 @@ const RQKEY_ROOT = 'listConvoMembers'
 export const listConvoMembersQueryKey = (convoId: string) =>
   createQueryKey(RQKEY_ROOT, {convoId})
 
-// Group chat size is at least 50, so should fetch the whole list in one go
-const LIMIT = 50
+const LIMIT = 25
+
+type Page = ChatBskyConvoGetConvoMembers.OutputSchema
 
 export function useListConvoMembersQuery({
   convoId,
@@ -22,25 +30,24 @@ export function useListConvoMembersQuery({
 }) {
   const agent = useAgent()
 
-  return useQuery({
+  return useInfiniteQuery<Page>({
     queryKey: listConvoMembersQueryKey(convoId),
-    queryFn: async () => {
-      const members = []
-      let cursor
-
-      do {
-        const {data} = await agent.chat.bsky.convo.getConvoMembers(
-          {convoId, cursor, limit: LIMIT},
-          {headers: DM_SERVICE_HEADERS},
-        )
-        members.push(...data.members)
-        cursor = data.cursor
-      } while (cursor)
-
-      return members
+    queryFn: async ({pageParam}) => {
+      const {data} = await agent.chat.bsky.convo.getConvoMembers(
+        {convoId, cursor: pageParam as string | undefined, limit: LIMIT},
+        {headers: DM_SERVICE_HEADERS},
+      )
+      return data
     },
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: lastPage => lastPage.cursor,
     staleTime: STALE.MINUTES.THIRTY,
-    placeholderData,
+    placeholderData: placeholderData
+      ? {
+          pages: [{members: placeholderData, cursor: undefined}],
+          pageParams: [undefined],
+        }
+      : undefined,
   })
 }
 
@@ -48,16 +55,16 @@ export function* findAllProfilesInQueryData(
   queryClient: QueryClient,
   did: string,
 ): Generator<ChatBskyActorDefs.ProfileViewBasic, void> {
-  const queryDatas = queryClient.getQueriesData<
-    ChatBskyActorDefs.ProfileViewBasic[]
-  >({
+  const queryDatas = queryClient.getQueriesData<InfiniteData<Page>>({
     queryKey: [RQKEY_ROOT],
   })
   for (const [_queryKey, queryData] of queryDatas) {
     if (!queryData) continue
-    for (const member of queryData) {
-      if (member.did === did) {
-        yield member
+    for (const page of queryData.pages) {
+      for (const member of page.members) {
+        if (member.did === did) {
+          yield member
+        }
       }
     }
   }

--- a/src/state/queries/messages/remove-from-group.ts
+++ b/src/state/queries/messages/remove-from-group.ts
@@ -1,6 +1,6 @@
 import {
-  type ChatBskyActorDefs,
   ChatBskyConvoDefs,
+  type ChatBskyConvoGetConvoMembers,
   type ChatBskyConvoListConvos,
   type ChatBskyGroupRemoveMembers,
 } from '@atproto/api'
@@ -49,7 +49,7 @@ export function useRemoveFromGroupChat(
         InfiniteData<ChatBskyConvoListConvos.OutputSchema>
       >({queryKey: [CONVO_LIST_KEY]})
       const prevMemberList = queryClient.getQueryData<
-        ChatBskyActorDefs.ProfileViewBasic[]
+        InfiniteData<ChatBskyConvoGetConvoMembers.OutputSchema>
       >(listConvoMembersQueryKey(convoId))
 
       queryClient.setQueryData<ChatBskyConvoDefs.ConvoView>(
@@ -102,13 +102,18 @@ export function useRemoveFromGroupChat(
         }
       })
 
-      queryClient.setQueryData<ChatBskyActorDefs.ProfileViewBasic[]>(
-        listConvoMembersQueryKey(convoId),
-        prev => {
-          if (!prev) return
-          return prev.filter(m => !members.includes(m.did))
-        },
-      )
+      queryClient.setQueryData<
+        InfiniteData<ChatBskyConvoGetConvoMembers.OutputSchema>
+      >(listConvoMembersQueryKey(convoId), prev => {
+        if (!prev?.pages) return prev
+        return {
+          ...prev,
+          pages: prev.pages.map(page => ({
+            ...page,
+            members: page.members.filter(m => !members.includes(m.did)),
+          })),
+        }
+      })
 
       return {prevConvo, prevListEntries, prevMemberList}
     },


### PR DESCRIPTION
This avoids hard-coding the limit to 50 in the client so that we can potentially increase it later without an app update.