### PR TITLE
Transpile `@atproto/api` package for older browser support

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,7 @@ function patchSourceMapFilter(rules, pathPattern) {
 
 module.exports = async function (env, argv) {
   env.babel = {
-    dangerouslyAddModulePathsToTranspile: ['@bsky.app/expo'],
+    dangerouslyAddModulePathsToTranspile: ['@bsky.app/expo', '@atproto/api'],
   }
   let config = await createExpoWebpackConfigAsync(env, argv)
   config = withAlias(config, {


### PR DESCRIPTION
The `@atproto` packages were recently upgraded to Node.js v22 but mobile Safari < v16.4 doesn’t support ES2022 syntax and the site fails to load. This PR adds `@atproto/api` to the Webpack config so that it gets transpiled to supported syntax.

<img width="964" height="197" alt="bundle" src="https://github.com/user-attachments/assets/2c43e0f6-b48b-4cee-9cb0-8d89a03e8dc7" />
