### PR TITLE
Use square icons for labellers in Automation Label preview card

### DIFF
--- a/src/screens/Settings/AutomationLabelSettings.tsx
+++ b/src/screens/Settings/AutomationLabelSettings.tsx
@@ -123,7 +123,11 @@ export function AutomationLabelSettingsScreen({}: Props) {
                   paddingRight: 20, // helps visually center
                 },
               ]}>
-              <UserAvatar size={42} avatar={profile.avatar} type="user" />
+              <UserAvatar
+                size={42}
+                avatar={profile.avatar}
+                type={profile.associated?.labeler ? 'labeler' : 'user'}
+              />
               <View>
                 <View style={[a.flex_row, a.align_baseline]}>
                   <View style={[a.flex_row, a.align_center, a.gap_xs]}>


### PR DESCRIPTION
Currently the Automation Label settings page will always use a circular icon for the example display

This doesn't really fit as every other instance across the app will use square borders for labellers instead 🐙