### PR TITLE
Reduce iOS memory pressure in lightbox, composer, GIF picker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import '#/logger/sentry/setup'
 
 import {Fragment, useEffect, useState} from 'react'
+import {DeviceEventEmitter} from 'react-native'
 import {GestureHandlerRootView} from 'react-native-gesture-handler'
 import {KeyboardProvider as KeyboardControllerProvider} from 'react-native-keyboard-controller'
 import {
   initialWindowMetrics,
   SafeAreaProvider,
 } from 'react-native-safe-area-context'
+import {Image} from 'expo-image'
 import * as ScreenOrientation from 'expo-screen-orientation'
 import * as SplashScreen from 'expo-splash-screen'
 import * as SystemUI from 'expo-system-ui'
@@ -140,6 +142,16 @@ function InnerApp() {
       })
     })
   }, [l])
+
+  // Respond to iOS memory warnings before the OS jetsams us. expo-image trims
+  // its own cache on warning, but explicitly clearing it gives the GC a stronger
+  // hint and frees decoded bitmaps no longer in active use.
+  useEffect(() => {
+    const sub = DeviceEventEmitter.addListener('memoryWarning', () => {
+      void Image.clearMemoryCache()
+    })
+    return () => sub.remove()
+  }, [])
 
   return (
     <Alf theme={theme}>

--- a/src/components/Lightbox/pager/ImagePager.tsx
+++ b/src/components/Lightbox/pager/ImagePager.tsx
@@ -249,8 +249,21 @@ function ImageView({
   const [isDragging, setIsDragging] = useState(false)
   const [showControls, setShowControls] = useState(true)
   const [isAltExpanded, setIsAltExpanded] = useState(false)
+  const [hasFullyOpened, setHasFullyOpened] = useState(false)
   const dismissSwipeTranslateY = useSharedValue(0)
   const isFlyingAway = useSharedValue(false)
+
+  // Hold the neighbor window at 0 until the open animation completes, so we
+  // only decode the active image during the most memory-constrained moment.
+  // Mirrors the orientation-unlock gate below.
+  useAnimatedReaction(
+    () => openProgress.get() === 1,
+    isOpen => {
+      if (isOpen) {
+        runOnJS(setHasFullyOpened)(true)
+      }
+    },
+  )
 
   const containerStyle = useAnimatedStyle(() => {
     if (openProgress.get() < 1) {
@@ -415,7 +428,7 @@ function ImageView({
         style={styles.pager}>
         {images.map((imageSrc, i) => (
           <View key={`${i}-${imageSrc.uri}`}>
-            {Math.abs(i - imageIndex) <= 1 ? (
+            {Math.abs(i - imageIndex) <= (hasFullyOpened ? 1 : 0) ? (
               <LightboxImage
                 onTap={onTap}
                 onZoom={onZoom}

--- a/src/components/Lightbox/pager/ImagePager.tsx
+++ b/src/components/Lightbox/pager/ImagePager.tsx
@@ -256,6 +256,9 @@ function ImageView({
   // Hold the neighbor window at 0 until the open animation completes, so we
   // only decode the active image during the most memory-constrained moment.
   // Mirrors the orientation-unlock gate below.
+  // Hold the neighbor window at 0 until the open animation completes, so we
+  // only decode the active image during the most memory-constrained moment.
+  // Mirrors the orientation-unlock gate below.
   useAnimatedReaction(
     () => openProgress.get() === 1,
     isOpen => {
@@ -264,6 +267,14 @@ function ImageView({
       }
     },
   )
+
+  // On a rotation remount openProgress is already 1, so the reaction above
+  // never sees a change; seed the flag directly for that case.
+  useEffect(() => {
+    if (openProgress.get() === 1) {
+      setHasFullyOpened(true)
+    }
+  }, [openProgress])
 
   const containerStyle = useAnimatedStyle(() => {
     if (openProgress.get() < 1) {

--- a/src/components/Lightbox/pager/ImagePager.tsx
+++ b/src/components/Lightbox/pager/ImagePager.tsx
@@ -415,22 +415,24 @@ function ImageView({
         style={styles.pager}>
         {images.map((imageSrc, i) => (
           <View key={`${i}-${imageSrc.uri}`}>
-            <LightboxImage
-              onTap={onTap}
-              onZoom={onZoom}
-              imageSrc={imageSrc}
-              onRequestClose={handleRequestClose}
-              isScrollViewBeingDragged={isDragging}
-              showControls={showControls}
-              safeAreaRef={safeAreaRef}
-              isScaled={isScaled}
-              isFlyingAway={isFlyingAway}
-              isActive={i === imageIndex}
-              dismissSwipeTranslateY={dismissSwipeTranslateY}
-              openProgress={openProgress}
-              thumbRects={thumbRects}
-              imageIndex={i}
-            />
+            {Math.abs(i - imageIndex) <= 1 ? (
+              <LightboxImage
+                onTap={onTap}
+                onZoom={onZoom}
+                imageSrc={imageSrc}
+                onRequestClose={handleRequestClose}
+                isScrollViewBeingDragged={isDragging}
+                showControls={showControls}
+                safeAreaRef={safeAreaRef}
+                isScaled={isScaled}
+                isFlyingAway={isFlyingAway}
+                isActive={i === imageIndex}
+                dismissSwipeTranslateY={dismissSwipeTranslateY}
+                openProgress={openProgress}
+                thumbRects={thumbRects}
+                imageIndex={i}
+              />
+            ) : null}
           </View>
         ))}
       </PagerView>

--- a/src/features/gifPicker/components/GifPickerItem.tsx
+++ b/src/features/gifPicker/components/GifPickerItem.tsx
@@ -52,6 +52,8 @@ export function GifPickerItem({
           accessibilityLabel={gif.title}
           accessibilityHint=""
           cachePolicy="none"
+          priority="low"
+          recyclingKey={gif.id}
           accessibilityIgnoresInvertColors
         />
       )}


### PR DESCRIPTION
## Summary

Three changes aimed at reducing iOS `WatchdogTermination` (jetsam) crashes. Hypothesis-driven from breadcrumb analysis of 10 recent events; needs TestFlight validation before claiming rate impact.

**Lightbox pager windowing** (`src/components/Lightbox/pager/ImagePager.tsx`)
Multi-image post lightbox previously mounted every page's `LightboxImage` simultaneously, so opening a 4-image post would kick off 4 fullsize decodes at once. Now renders only the current ±1 pages; far-away pages are placeholders. The current page is always rendered, so swipe-to-close and animations are unaffected. The neighbor at ±1 is pre-loaded so adjacent swipes are still instant; only swiping >1 page incurs a brief load.

Targets the pattern seen in events ending with `UIPageViewController` mount → 3-5 `feed_fullsize` fetches in <1s → kill.

**Global memory warning handler** (`src/App.native.tsx`)
Subscribes to RN's `memoryWarning` event (backed by `UIApplicationDidReceiveMemoryWarningNotification` on iOS) and calls `Image.clearMemoryCache()`. Currently we ignore these warnings entirely — one captured event shows 5 LOW_MEMORY breadcrumbs over 14 seconds before jetsam with no response from us. This gives the GC an explicit chance to reclaim before the OS does it for us.

**GIF picker item Image tweaks** (`src/features/gifPicker/components/GifPickerItem.tsx`)
Minor: `priority=\"low\"` + `recyclingKey={gif.id}`. This is _not_ the real fix the GIF picker needs — that requires restructuring the masonry from one big FlatList row into per-row virtualization, which is bigger than this PR. Worth its own follow-up issue.

## Known follow-ups

Things I deliberately left out of this PR:
- **GIF picker masonry virtualization** — the real fix for the GIF picker OOM pattern (event with ~30 animated GIFs in a BottomSheet).
- **Composer image downsampling** — PHPicker returns 12MP photos and we render the preview at ~250px; decoding the full resolution is wasteful.

## Test plan

- [ ] Open a 4-image post lightbox, swipe through all images, close. Confirm no visible regression.
- [ ] Open multi-image post lightbox on a low-memory device (e.g. iPhone 8/SE) — should no longer crash on open.
- [ ] Use composer with a picked image + a link card, leave open for 30s. No regression in preview rendering.
- [ ] Open GIF picker, scroll through search results. No regression in scroll perf or load times.