### PR TITLE
[Android] Fix horizontal swipes being cancelled when leaving bounds

### DIFF
--- a/src/view/shell/BlockDrawerGesture.tsx
+++ b/src/view/shell/BlockDrawerGesture.tsx
@@ -4,6 +4,8 @@ import {Gesture, GestureDetector} from 'react-native-gesture-handler'
 
 export function BlockDrawerGesture({children}: {children: React.ReactNode}) {
   const drawerGesture = useContext(DrawerGestureContext) ?? Gesture.Native() // noop for web
-  const scrollGesture = Gesture.Native().blocksExternalGesture(drawerGesture)
+  let scrollGesture = Gesture.Native()
+    .shouldCancelWhenOutside(false) // for some reason defaults to true on Android
+    .blocksExternalGesture(drawerGesture)
   return <GestureDetector gesture={scrollGesture}>{children}</GestureDetector>
 }


### PR DESCRIPTION
All scrollviews wrapped in `BlockDrawerGesture` on android were really finnicky, because they'd stop the moment the swipe goes out of bounds. in particular, this is really painful for the pager tab bar.

The solution: turns out the RNGH docs are incorrect, `shouldCancelWhenOutside()` defaults to `true` on Android for some godforsaken reason. Solution: manually set it to `false`

https://docs.swmansion.com/react-native-gesture-handler/docs/legacy-gestures/pan-gesture/#shouldcancelwhenoutsidevalue-boolean