### PR TITLE
Show image count badge on in-feed carousel

### DIFF
--- a/src/components/Lightbox/chrome/PagerDots.web.tsx
+++ b/src/components/Lightbox/chrome/PagerDots.web.tsx
@@ -1,5 +1,4 @@
 import {StyleSheet, View} from 'react-native'
-import {BlurView} from 'expo-blur'
 
 type Props = {
   count: number
@@ -14,37 +13,35 @@ export function PagerDots({count, activeIndex}: Props) {
   if (count <= 1) return null
   return (
     <View style={styles.root}>
-      <BlurView intensity={20} tint="dark" style={styles.inner}>
-        {Array.from({length: count}).map((_, i) => {
-          const isActive = i === activeIndex
-          return (
-            <View
-              key={i}
-              style={[
-                isActive ? styles.active : styles.inactive,
-                isActive ? styles.activeDot : styles.inactiveDot,
-              ]}
-            />
-          )
-        })}
-      </BlurView>
+      {Array.from({length: count}).map((_, i) => {
+        const isActive = i === activeIndex
+        return (
+          <View
+            key={i}
+            style={[
+              isActive ? styles.active : styles.inactive,
+              isActive ? styles.activeDot : styles.inactiveDot,
+            ]}
+          />
+        )
+      })}
     </View>
   )
 }
 
 const styles = StyleSheet.create({
   root: {
-    borderRadius: 999,
-    overflow: 'hidden',
-  },
-  inner: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
     gap: GAP,
     paddingHorizontal: 10,
     paddingVertical: 6,
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    borderRadius: 999,
+    backgroundColor: 'rgba(0, 0, 0, 0.75)',
+    // @ts-expect-error web-only
+    backdropFilter: 'blur(8px)',
+    WebkitBackdropFilter: 'blur(8px)',
   },
   activeDot: {
     width: ACTIVE,

--- a/src/components/images/Gallery/index.tsx
+++ b/src/components/images/Gallery/index.tsx
@@ -490,21 +490,22 @@ function GalleryImage({
               style={[
                 a.absolute,
                 a.justify_center,
+                a.rounded_sm,
+                a.p_xs,
+                t.atoms.bg_contrast_25,
                 {
-                  top: a.p_sm.padding,
-                  right: a.p_sm.padding,
-                  paddingHorizontal: 6,
-                  paddingVertical: 2,
-                  borderRadius: 999,
-                  backgroundColor: 'rgba(0, 0, 0, 0.6)',
+                  top: a.p_xs.padding,
+                  right: a.p_xs.padding,
+                  opacity: 0.8,
+                },
+                largeAltBadge && {
+                  padding: 6,
                 },
               ]}>
               <Text
                 style={[
                   a.font_bold,
-                  a.text_xs,
-                  a.leading_tight,
-                  {color: '#fff'},
+                  largeAltBadge ? a.text_xs : {fontSize: 8},
                 ]}>
                 {index + 1}/{imageCount}
               </Text>

--- a/src/components/images/Gallery/index.tsx
+++ b/src/components/images/Gallery/index.tsx
@@ -405,7 +405,8 @@ function GalleryCounter({
             backgroundColor: 'rgba(0, 0, 0, 0.6)',
           },
         ]}>
-        <Text style={[a.font_bold, a.text_xs, a.leading_tight, {color: '#fff'}]}>
+        <Text
+          style={[a.font_bold, a.text_xs, a.leading_tight, {color: '#fff'}]}>
           {currentIndex + 1}/{imageCount}
         </Text>
       </View>

--- a/src/components/images/Gallery/index.tsx
+++ b/src/components/images/Gallery/index.tsx
@@ -165,6 +165,13 @@ export function Gallery({
   const containerRefsRef = useRef<Map<number, AnimatedRef<any>>>(new Map())
   const thumbDimsRef = useRef<Map<number, Dimensions>>(new Map())
   const currentIndexRef = useRef(0)
+  /*
+   * Reactive mirror of currentIndexRef for the numbering badge. The ref drives
+   * scroll/keyboard logic without re-rendering; this state only updates when
+   * the index actually changes (once per image, not per scroll frame), so the
+   * badge stays live and cheap.
+   */
+  const [currentIndex, setCurrentIndexState] = useState(0)
 
   const emitSwipeMetric = useMemo(
     () =>
@@ -182,6 +189,7 @@ export function Gallery({
     const prev = currentIndexRef.current
     if (prev !== index) {
       currentIndexRef.current = index
+      setCurrentIndexState(index)
       emitSwipeMetric(prev, index)
     }
   }
@@ -348,7 +356,66 @@ export function Gallery({
           }}
         />
       </BlockDrawerGesture>
+
+      {!hideBadges && images.length > 1 ? (
+        <GalleryCounter
+          currentIndex={currentIndex}
+          imageCount={images.length}
+        />
+      ) : null}
     </View>
+  )
+}
+
+/*
+ * Top-right "{n}/{total}" badge for the in-feed carousel. The visible pill is
+ * decorative (accessible={false}) since the digits are redundant for screen
+ * reader users.
+ *
+ * On native, screen reader users never reach this carousel branch - the Gallery
+ * renders a separate per-image stack early when screenReaderEnabled is true,
+ * and each slide there is labelled "Image N of M". So the live region only
+ * needs to exist on web, where screenReaderEnabled is always false and the
+ * carousel is the only branch. There we announce position changes via a
+ * visually-hidden aria-live region.
+ */
+function GalleryCounter({
+  currentIndex,
+  imageCount,
+}: {
+  currentIndex: number
+  imageCount: number
+}) {
+  const {t: l} = useLingui()
+
+  return (
+    <>
+      <View
+        accessible={false}
+        pointerEvents="none"
+        style={[
+          a.absolute,
+          a.justify_center,
+          {
+            top: a.p_xs.padding,
+            right: a.p_xs.padding,
+            paddingHorizontal: 6,
+            paddingVertical: 2,
+            borderRadius: 999,
+            backgroundColor: 'rgba(0, 0, 0, 0.6)',
+          },
+        ]}>
+        <Text style={[a.font_bold, a.text_xs, a.leading_tight, {color: '#fff'}]}>
+          {currentIndex + 1}/{imageCount}
+        </Text>
+      </View>
+
+      {IS_WEB ? (
+        <View aria-live="polite" style={a.sr_only}>
+          <Text>{l`Image ${currentIndex + 1} of ${imageCount}`}</Text>
+        </View>
+      ) : null}
+    </>
   )
 }
 

--- a/src/components/images/Gallery/index.tsx
+++ b/src/components/images/Gallery/index.tsx
@@ -165,13 +165,6 @@ export function Gallery({
   const containerRefsRef = useRef<Map<number, AnimatedRef<any>>>(new Map())
   const thumbDimsRef = useRef<Map<number, Dimensions>>(new Map())
   const currentIndexRef = useRef(0)
-  /*
-   * Reactive mirror of currentIndexRef for the numbering badge. The ref drives
-   * scroll/keyboard logic without re-rendering; this state only updates when
-   * the index actually changes (once per image, not per scroll frame), so the
-   * badge stays live and cheap.
-   */
-  const [currentIndex, setCurrentIndexState] = useState(0)
 
   const emitSwipeMetric = useMemo(
     () =>
@@ -189,7 +182,6 @@ export function Gallery({
     const prev = currentIndexRef.current
     if (prev !== index) {
       currentIndexRef.current = index
-      setCurrentIndexState(index)
       emitSwipeMetric(prev, index)
     }
   }
@@ -356,67 +348,7 @@ export function Gallery({
           }}
         />
       </BlockDrawerGesture>
-
-      {!hideBadges && images.length > 1 ? (
-        <GalleryCounter
-          currentIndex={currentIndex}
-          imageCount={images.length}
-        />
-      ) : null}
     </View>
-  )
-}
-
-/*
- * Top-right "{n}/{total}" badge for the in-feed carousel. The visible pill is
- * decorative (accessible={false}) since the digits are redundant for screen
- * reader users.
- *
- * On native, screen reader users never reach this carousel branch - the Gallery
- * renders a separate per-image stack early when screenReaderEnabled is true,
- * and each slide there is labelled "Image N of M". So the live region only
- * needs to exist on web, where screenReaderEnabled is always false and the
- * carousel is the only branch. There we announce position changes via a
- * visually-hidden aria-live region.
- */
-function GalleryCounter({
-  currentIndex,
-  imageCount,
-}: {
-  currentIndex: number
-  imageCount: number
-}) {
-  const {t: l} = useLingui()
-
-  return (
-    <>
-      <View
-        accessible={false}
-        pointerEvents="none"
-        style={[
-          a.absolute,
-          a.justify_center,
-          {
-            top: a.p_xs.padding,
-            right: a.p_xs.padding,
-            paddingHorizontal: 6,
-            paddingVertical: 2,
-            borderRadius: 999,
-            backgroundColor: 'rgba(0, 0, 0, 0.6)',
-          },
-        ]}>
-        <Text
-          style={[a.font_bold, a.text_xs, a.leading_tight, {color: '#fff'}]}>
-          {currentIndex + 1}/{imageCount}
-        </Text>
-      </View>
-
-      {IS_WEB ? (
-        <View aria-live="polite" style={a.sr_only}>
-          <Text>{l`Image ${currentIndex + 1} of ${imageCount}`}</Text>
-        </View>
-      ) : null}
-    </>
   )
 }
 
@@ -550,6 +482,34 @@ function GalleryImage({
             }}
             useAppleWebpCodec
           />
+
+          {!hideBadges && imageCount > 1 ? (
+            <View
+              accessible={false}
+              pointerEvents="none"
+              style={[
+                a.absolute,
+                a.justify_center,
+                {
+                  top: a.p_sm.padding,
+                  right: a.p_sm.padding,
+                  paddingHorizontal: 6,
+                  paddingVertical: 2,
+                  borderRadius: 999,
+                  backgroundColor: 'rgba(0, 0, 0, 0.6)',
+                },
+              ]}>
+              <Text
+                style={[
+                  a.font_bold,
+                  a.text_xs,
+                  a.leading_tight,
+                  {color: '#fff'},
+                ]}>
+                {index + 1}/{imageCount}
+              </Text>
+            </View>
+          ) : null}
 
           {(hasAlt || isCropped) && !hideBadges ? (
             <View


### PR DESCRIPTION
## Summary

A top complaint about the carousel rollout was that it's hard to tell how many images are in a set, especially when the next image isn't peeking from the right edge. This adds a persistent "{n}/{total}" badge (e.g. "3/10") to the top-right of the in-feed carousel, visible on all platforms.

- Mirrors the existing `currentIndexRef` into reactive state, updated only when the index actually changes — the badge stays live without re-rendering on every scroll frame.
- Styling follows the Lightbox `PagerDots` pattern (white bold text, rounded). It sits on a translucent dark pill so it stays legible over arbitrary in-feed images (PagerDots itself can skip the backing because the lightbox provides a dark scrim).
- Hidden in quote posts (`hideBadges`) and for single images.
- Accessibility: a web `aria-live="polite"` region announces position changes; native screen-reader users continue to get the existing per-image stacked layout (each image already labelled "Image N of M"), so the carousel branch isn't reached there.

## Test plan

- [ ] iOS / Android / web: post with >1 image shows the "1/10" badge top-right, updating to "2/10", "3/10"… as you swipe/scroll.
- [ ] Badge does not appear on single-image posts or quote-post galleries.
- [ ] Web: count updates via keyboard arrows and click-drag.
- [ ] VoiceOver/TalkBack: per-image position is announced.

> No Figma design exists for the badge yet; styling follows the PagerDots pattern by decision. Placement/treatment can be refined when designs land.

[APP-2285](https://linear.app/blueskyweb/issue/APP-2285/carousel-show-numbering-badges-eg-310-on-photos)
