### PR TITLE
Fix invalid `zero` plural category and add plural formatting

### DIFF
--- a/src/screens/Messages/JoinRequests.tsx
+++ b/src/screens/Messages/JoinRequests.tsx
@@ -428,7 +428,7 @@ function Header({
           ) : (
             <Plural
               value={count}
-              zero="No requests to join"
+              _0="No requests to join"
               one="# request to join"
               other="# requests to join"
             />

--- a/src/screens/Messages/JoinRequests.tsx
+++ b/src/screens/Messages/JoinRequests.tsx
@@ -411,7 +411,6 @@ function Header({
   count?: number
   hasMoreRequests?: boolean
 }) {
-  const {t: l} = useLingui()
   return (
     <Layout.Header.Outer>
       <Layout.Header.BackButton />
@@ -420,11 +419,11 @@ function Header({
           {count === undefined ? (
             <Trans>Requests to join</Trans>
           ) : hasMoreRequests ? (
-            l({
-              message: `${count}+ requests to join`,
-              comment:
-                'Displayed when there are more requests to join a group chat than have been loaded',
-            })
+            <Plural
+              value={count}
+              other="#+ requests to join"
+              comment="Displayed when there are more requests to join a group chat than have been loaded"
+            />
           ) : (
             <Plural
               value={count}


### PR DESCRIPTION
> [!IMPORTANT]
> **Claude Code analyzed this issue and wrote the PR and much of the description.**
>
> **Although it passes CI, I have not tested the fix.**

## Context

<img width="600" alt="IMG_9079" src="https://github.com/user-attachments/assets/0d7a8670-af7c-448f-aa48-2d180d6e0b62" />

Crowdin reports a syntax error for the string extracted from `src/screens/Messages/JoinRequests.tsx:429`:

> The plural case `zero` is not valid in this locale at line 1 col 17

The `<Plural>` component currently uses a `zero` prop:

```tsx
<Plural
  value={count}
  zero="No requests to join"
  one="# request to join"
  other="# requests to join"
/>
```

`zero` is a CLDR **plural category**, not an exact-value match. It only exists in certain locales (e.g. Arabic, Welsh, Latvian). The source locale here is English, whose CLDR rules only define `one` and `other` – so `zero` is invalid and Crowdin (which validates against the source locale) rejects it. At runtime the intent is "show this text when count is exactly 0", which in ICU MessageFormat is the literal selector `=0`, not the `zero` category.

Lingui's `<Plural>` component maps the `=N` exact selectors to props named `_N`. So `=0` is expressed as the `_0` prop.

## Change

In `src/screens/Messages/JoinRequests.tsx` (around line 429), rename the `zero` prop to `_0`:

```tsx
<Plural
  value={count}
  _0="No requests to join"
  one="# request to join"
  other="# requests to join"
/>
```

This produces the ICU message `{count, plural, =0 {No requests to join} one {# request to join} other {# requests to join}}`, which is valid in all locales and preserves the existing behavior (the 0 case is still shown when `count === 0`).

At runtime in English the `zero` category never matches (`en` has no `zero`), so a count of exactly 0 would fall through to `other` and render "0 requests to join" instead of "No requests to join". With `_0` (`=0` exact match), `count === 0` now renders the intended "No requests to join".

Also, this PR proposes adding plural formatting to the `${count}+ requests to join` string so that it can be correctly localized in all languages.

## Test plan

- [ ] Functional check: the header should read "No requests to join" when there are zero pending requests, "1 request to join" for one, and "N requests to join" for more.