### PR TITLE
Fix feed scroll reset on device rotation

### DIFF
--- a/src/view/com/util/List.tsx
+++ b/src/view/com/util/List.tsx
@@ -147,17 +147,19 @@ let List = forwardRef<ListMethods, ListProps>(
       )
     }
 
-    let contentOffset
     if (headerOffset != null) {
       style = addStyle(style, {
         paddingTop: headerOffset,
       })
-      contentOffset = {x: 0, y: headerOffset * -1}
     }
 
     return (
       <FlatList_INTERNAL
         showsVerticalScrollIndicator // overridable
+        // Anchor the currently-visible item across content relayouts so that
+        // changing the viewport size (e.g. device rotation) doesn't lose the
+        // scroll position as items reflow to the new width.
+        maintainVisibleContentPosition={{minIndexForVisible: 0}}
         onViewableItemsChanged={onViewableItemsChanged}
         viewabilityConfig={viewabilityConfig}
         {...props}
@@ -170,7 +172,6 @@ let List = forwardRef<ListMethods, ListProps>(
           ...props.scrollIndicatorInsets,
         }}
         indicatorStyle={t.scheme === 'dark' ? 'white' : 'black'}
-        contentOffset={contentOffset}
         refreshControl={refreshControl}
         onScroll={scrollHandler}
         scrollsToTop={scrollsToTop}

--- a/src/view/com/util/List.tsx
+++ b/src/view/com/util/List.tsx
@@ -156,10 +156,6 @@ let List = forwardRef<ListMethods, ListProps>(
     return (
       <FlatList_INTERNAL
         showsVerticalScrollIndicator // overridable
-        // Anchor the currently-visible item across content relayouts so that
-        // changing the viewport size (e.g. device rotation) doesn't lose the
-        // scroll position as items reflow to the new width.
-        maintainVisibleContentPosition={{minIndexForVisible: 0}}
         onViewableItemsChanged={onViewableItemsChanged}
         viewabilityConfig={viewabilityConfig}
         {...props}


### PR DESCRIPTION
## Why

Viewing an image in the lightbox in landscape and returning to portrait yanks the feed back to the top (the symptom in APP-2039). More generally, any viewport size change (orientation, etc.) snaps the feed's scroll position to the top. Orientation is normally locked to portrait, so the lightbox is the main place this surfaces today.

This is an **iOS-only** bug — the mechanism below is specific to how the iOS ScrollView re-applies `contentOffset` on relayout.

## What

The shared `List` component (`src/view/com/util/List.tsx`) passed `contentOffset={{x: 0, y: -headerOffset}}` to the underlying `Animated.FlatList`. This was originally paired with a matching `contentInset={{top: headerOffset}}` (web PR #230) so the first render sat flush under the floating header. PR #2216 swapped the inset for a `paddingTop` style but left the offset behind — dead on initial render since (a negative offset with no inset clamps to 0, and there's no `scrollToOverflowEnabled`).

On rotation, though, its *value* changes because `headerOffset` is partly derived from the top safe-area inset (observed: -153 portrait vs -91 landscape). When the value changes, iOS re-applies it to the native ScrollView as an absolute scroll, snapping the list.

Fix: remove the dead `contentOffset` prop (and the local that built it). The `paddingTop` style already handles header spacing.

> [!NOTE]
> An earlier version of this PR also added `maintainVisibleContentPosition` to anchor the visible post as items reflow to the new width. That's been dropped to keep the change narrow — it touches every list's relayout behavior app-wide, and for the lightbox case all that matters is returning to the original scroll position, which removing `contentOffset` achieves. The position may be momentarily off while rotated, but it restores correctly.

## Test plan

Temporarily unlocked orientation and logged the live scroll offset on a scrolled feed, then rotated (iOS):
- **Before:** offset went e.g. `3149 → -153 → 0` (reset to top).
- **After:** offset is preserved across the rotation, so returning from a landscape lightbox lands back at the original position.

Resolves APP-2315. Related: APP-2039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)