### PR TITLE
[Chat] Fix navigation stacking on messages links in split view

### DIFF
--- a/src/screens/Messages/ChatList.tsx
+++ b/src/screens/Messages/ChatList.tsx
@@ -451,6 +451,12 @@ export function Header({
   const {gtMobile} = useBreakpoints()
   const requireEmailVerification = useRequireEmailVerification()
   const leftConvos = useLeftConvos()
+  const {isWithinSplitView} = useIsWithinSplitView()
+
+  // In split view, the left column (and this header) stays mounted while the
+  // right column shows the selected route. Pushing would stack duplicate routes
+  // on repeated clicks, so navigate instead to dedupe by route + params.
+  const action = isWithinSplitView ? 'navigate' : 'push'
 
   const {data: unreadInboxData, hasNextPage: hasMoreRequests} =
     useListConvosQuery({
@@ -494,9 +500,11 @@ export function Header({
               count={inboxAllConvos.length}
               more={hasMoreRequests}
               variant="solid"
+              action={action}
             />
             <Link
               to="/messages/settings"
+              action={action}
               label={l`Chat settings`}
               size="small"
               color="secondary"

--- a/src/screens/Messages/components/ChatListItem.tsx
+++ b/src/screens/Messages/components/ChatListItem.tsx
@@ -481,6 +481,9 @@ function BaseChatItem({
 
           <Link
             to={`/messages/${convo.view.id}`}
+            // In split view, this list stays mounted alongside the open convo,
+            // so push would stack duplicate routes on repeated clicks.
+            action={isWithinSplitView ? 'navigate' : 'push'}
             label={title}
             accessibilityHint={accessibilityHint}
             accessibilityActions={

--- a/src/screens/Messages/components/InboxRequests.tsx
+++ b/src/screens/Messages/components/InboxRequests.tsx
@@ -11,10 +11,12 @@ export function InboxRequests({
   count,
   more,
   variant,
+  action,
 }: {
   count: number
   more: boolean
   variant?: 'ghost' | 'solid'
+  action?: 'push' | 'navigate'
 }) {
   const {t: l} = useLingui()
 
@@ -41,6 +43,7 @@ export function InboxRequests({
         <Link
           label={label}
           to="/messages/inbox"
+          action={action}
           size="small"
           variant={unread ? 'solid' : 'ghost'}
           color={unread ? 'primary_subtle' : 'secondary'}
@@ -66,6 +69,7 @@ export function InboxRequests({
         <Link
           label={label}
           to="/messages/inbox"
+          action={action}
           color={unread ? 'primary_subtle' : 'secondary'}
           size="small">
           <ButtonIcon icon={InboxIcon} />


### PR DESCRIPTION
## Bug

> Clicking on "Requests" button on web stacks up navigation states. Click 3 times on "Requests", now you have to click 3 times "←" to actually go back. The same is true if you click multiple times in a convo on the list.

## Root cause

On web with a wide viewport, `MessagesSplitViewLayout` renders a persistent left column (the chat list + its header) alongside a right column showing the currently-routed screen. The left column never unmounts, so the Requests button, Chat settings link, and conversation rows stay clickable the whole time.

The `Link` component defaults to `action='push'`, which dispatches `StackActions.push`. So every repeated click pushes another `MessagesInbox` / `MessagesConversation` onto the stack, and the back arrow has to pop each one individually.

Outside split view this isn't an issue: the list unmounts when you navigate away, so you can't keep clicking the same button.

## Fix

Switch these links from `push` to `navigate` **only when within split view**. `navigate` dedupes by route name + params (and pops back to an existing match), so repeated clicks no longer stack. Behavior outside split view is unchanged.

- `InboxRequests` gains an `action` prop, threaded into both variants
- `ChatList` `Header` passes `navigate` to the Requests button and Chat settings link when in split view
- `ChatListItem` conversation rows use `navigate` when in split view

## Test plan

- [ ] On wide web (split view active), click "Requests" several times → still one back press to return to chats
- [ ] Click the same conversation several times → no stacking
- [ ] Click Chat settings several times → no stacking
- [ ] Narrow web / native: navigation behaves as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)