### PR TITLE
Add "fingerprint changed" label to PRs with native changes

### DIFF
--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -156,3 +156,17 @@ jobs:
         with:
           header: fingerprint-diff
           delete: true
+
+      - name: 🏷️ Label as fingerprint changed
+        if: ${{ steps.fingerprint.outputs.includes-changes }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr edit "$PR_NUMBER" --add-label "bot: fingerprint changed"
+
+      - name: 🏷️ Remove fingerprint changed label
+        if: ${{ !steps.fingerprint.outputs.includes-changes }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr edit "$PR_NUMBER" --remove-label "bot: fingerprint changed" || true

--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -162,7 +162,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh pr edit "$PR_NUMBER" --add-label "bot: fingerprint changed"
+        run: gh pr edit "$PR_NUMBER" --add-label "bot: fingerprint changed" || true
 
       - name: 🏷️ Remove fingerprint changed label
         if: ${{ !steps.fingerprint.outputs.includes-changes }}


### PR DESCRIPTION
The `fingerprint-native` job already posts a comment when a PR introduces OTA-breaking native changes, but it doesn't label the PR. This adds the existing `bot: fingerprint changed` label on top of that comment, and removes it again when a later push clears the change.

The repo originally had this labeling (added in #3212, a copy of Expo's `pr-labeler.yml`) but it was dropped in #3406 during a refactor of the comment steps over to `marocchino/sticky-pull-request-comment`. The label definitions were never removed, so they're still available.

Notes:
- Only `bot: fingerprint changed` is applied. PRs without native changes are left unlabelled (we don't add `bot: fingerprint compatible`).
- Keyed off the action's `includes-changes` output, which is only true for autolinking-affecting changes - so it matches the comment logic in the same job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)