### PR TITLE
[Chat] Fix stale reactions dialog after removing a reaction

### DIFF
--- a/src/components/dms/MessageOverlays.tsx
+++ b/src/components/dms/MessageOverlays.tsx
@@ -125,6 +125,22 @@ export function MessageOverlays({children}: {children: React.ReactNode}) {
     [openDeleteMessage, openReportMessage, openReactions],
   )
 
+  // `reactionsTarget` is a snapshot from when the dialog was opened. Read the
+  // live message out of the convo items so optimistic reaction changes (e.g.
+  // "Tap to remove") are reflected in the dialog without closing it first.
+  const reactionsMessage = useMemo(() => {
+    if (!reactionsTarget) return null
+    for (const item of convo.items) {
+      if (
+        (item.type === 'message' || item.type === 'pending-message') &&
+        item.message.id === reactionsTarget.id
+      ) {
+        return item.message
+      }
+    }
+    return reactionsTarget
+  }, [convo.items, reactionsTarget])
+
   const reportSubject = reportTarget
     ? ({
         view: 'message',
@@ -153,11 +169,11 @@ export function MessageOverlays({children}: {children: React.ReactNode}) {
           onClose={() => setAfterReportTarget(null)}
         />
       )}
-      {reactionsTarget && (
+      {reactionsMessage && (
         <ReactionsDialog
           control={reactionsControl}
           relatedProfiles={convo.relatedProfiles}
-          message={reactionsTarget}
+          message={reactionsMessage}
           onClose={() => setReactionsTarget(null)}
         />
       )}


### PR DESCRIPTION
## Bug

Removing a reaction from the detailed reactions view shows "Tap to remove", fires the removal request, but keeps showing the reaction in the list. It's unclear whether the removal worked until you close and reopen the dialog.

## Cause

When the reactions dialog was hoisted into `MessageOverlays`, the message it renders became a snapshot captured in `useState` (`reactionsTarget`) at open time. `convo.removeReaction()` optimistically updates the *live* convo state and re-renders subscribers, but the dialog kept rendering the frozen snapshot, so the removed reaction lingered until the dialog closed and the snapshot was discarded.

## Fix

`MessageOverlays` already subscribes to the live convo via `useConvoActive()`. Derive the message to render by looking it up by `id` in `convo.items`, falling back to the snapshot if not found. Optimistic add/remove now flow straight into the dialog.

## Test plan

- [ ] Open the reactions detail view on a message you've reacted to
- [ ] Tap your reaction ("Tap to remove") and confirm it disappears from the list immediately
- [ ] Confirm the dialog still auto-closes when removing your only reaction, and the active emoji tab switches to "All" when its last reaction is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)