### PR TITLE
[Chat] Sync single-convo cache on chat lock firehose events

### DIFF
--- a/src/state/queries/messages/list-conversations.tsx
+++ b/src/state/queries/messages/list-conversations.tsx
@@ -418,67 +418,34 @@ export function ListConvosProviderInner({
                 })),
             )
           } else if (ChatBskyConvoDefs.isLogLockConvo(log)) {
-            queryClient.setQueriesData(
-              {queryKey: [RQKEY_ROOT]},
-              (old?: ConvoListQueryData) =>
-                optimisticUpdate(log.convoId, old, convo => {
-                  if (ChatBskyConvoDefs.isGroupConvo(convo.kind)) {
-                    return {
-                      ...convo,
-                      kind: {
-                        ...convo.kind,
-                        lockStatus: 'locked',
-                      },
-                      rev: log.rev,
-                    }
-                  }
-                  return {
+            mutateConvoView(log.convoId, convo =>
+              ChatBskyConvoDefs.isGroupConvo(convo.kind)
+                ? {
                     ...convo,
+                    kind: {...convo.kind, lockStatus: 'locked'},
                     rev: log.rev,
                   }
-                }),
+                : {...convo, rev: log.rev},
             )
           } else if (ChatBskyConvoDefs.isLogUnlockConvo(log)) {
-            queryClient.setQueriesData(
-              {queryKey: [RQKEY_ROOT]},
-              (old?: ConvoListQueryData) =>
-                optimisticUpdate(log.convoId, old, convo => {
-                  if (ChatBskyConvoDefs.isGroupConvo(convo.kind)) {
-                    return {
-                      ...convo,
-                      kind: {
-                        ...convo.kind,
-                        lockStatus: 'unlocked',
-                      },
-                      rev: log.rev,
-                    }
-                  }
-                  return {
+            mutateConvoView(log.convoId, convo =>
+              ChatBskyConvoDefs.isGroupConvo(convo.kind)
+                ? {
                     ...convo,
+                    kind: {...convo.kind, lockStatus: 'unlocked'},
                     rev: log.rev,
                   }
-                }),
+                : {...convo, rev: log.rev},
             )
           } else if (ChatBskyConvoDefs.isLogLockConvoPermanently(log)) {
-            queryClient.setQueriesData(
-              {queryKey: [RQKEY_ROOT]},
-              (old?: ConvoListQueryData) =>
-                optimisticUpdate(log.convoId, old, convo => {
-                  if (ChatBskyConvoDefs.isGroupConvo(convo.kind)) {
-                    return {
-                      ...convo,
-                      kind: {
-                        ...convo.kind,
-                        lockStatus: 'locked-permanently',
-                      },
-                      rev: log.rev,
-                    }
-                  }
-                  return {
+            mutateConvoView(log.convoId, convo =>
+              ChatBskyConvoDefs.isGroupConvo(convo.kind)
+                ? {
                     ...convo,
+                    kind: {...convo.kind, lockStatus: 'locked-permanently'},
                     rev: log.rev,
                   }
-                }),
+                : {...convo, rev: log.rev},
             )
           } else if (
             ChatBskyConvoDefs.isLogCreateJoinLink(log) ||


### PR DESCRIPTION
## Summary

Live lock-state updates from the chat firehose only reached the **conversation list**, not an **open group chat**. When a group you were actively viewing got locked/unlocked via a firehose event, the composer footer (`ChatLocked` / `ChatEnded`) didn't switch live, and the agent's internal `lockStatus` (used for reaction-gating) stayed stale - both only caught up on a refetch (e.g. leaving and re-entering the chat).

## Cause

There are two separate caches for a convo:
- `convo-list` - the conversation list
- `convo` (`CONVO_KEY`) - the single convo, read by the open chat screen

The three firehose lock handlers (`isLogLockConvo`, `isLogUnlockConvo`, `isLogLockConvoPermanently`) in `list-conversations.tsx` only wrote the `convo-list` cache via `setQueriesData`. They never touched `CONVO_KEY`, so the `ConvoProvider` subscription that calls `convo.updateLockStatus()` (gated on the `convo` query key) never fired, and the footer (which reads `CONVO_KEY` directly) never updated.

## Fix

Route the three lock handlers through the existing `mutateConvoView` helper, which writes **both** the single-convo and convo-list caches - the same pattern the member-change handlers already use. This fires the `ConvoProvider` subscription (fixing the agent's `lockStatus`) and flips the footer live.

## Test plan

- [ ] Open a group chat on two clients. Lock it from client A; verify client B's composer switches to the locked footer live, without leaving the chat.
- [ ] Unlock and verify it reverts live.
- [ ] Permanently lock and verify the "chat ended" footer appears live.
- [ ] Confirm the conversation list still reflects lock state changes as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)