### PR TITLE
[Chat] Centralize conversation report-subject resolution

### DIFF
--- a/src/components/dms/ConvoMenu.tsx
+++ b/src/components/dms/ConvoMenu.tsx
@@ -129,12 +129,7 @@ let ConvoMenu = ({
             }}
             control={reportControl}
             onAfterSubmit={() => {
-              const sender = convo.members.find(
-                member => member.did === latestReportableMessage.sender.did,
-              )
-              if (sender) {
-                unstableCacheProfileView(queryClient, sender)
-              }
+              unstableCacheProfileView(queryClient, profile)
               blockOrDeleteControl.open()
             }}
           />

--- a/src/components/dms/ConvoMenu.tsx
+++ b/src/components/dms/ConvoMenu.tsx
@@ -1,6 +1,6 @@
 import {memo, useCallback} from 'react'
 import {Keyboard, View} from 'react-native'
-import {ChatBskyConvoDefs, type ModerationCause} from '@atproto/api'
+import {type ModerationCause} from '@atproto/api'
 import {Trans, useLingui} from '@lingui/react/macro'
 import {useNavigation} from '@react-navigation/native'
 import {useQueryClient} from '@tanstack/react-query'
@@ -16,13 +16,18 @@ import {
   unstableCacheProfileView,
   useProfileBlockMutationQueue,
 } from '#/state/queries/profile'
+import {useSession} from '#/state/session'
 import {type ViewStyleProp} from '#/alf'
 import {atoms as a} from '#/alf'
 import {Button, ButtonIcon} from '#/components/Button'
+import {AfterReportConversationDialog} from '#/components/dms/AfterReportConversationDialog'
 import {AfterReportDialog} from '#/components/dms/AfterReportDialog'
 import {BlockedByListDialog} from '#/components/dms/BlockedByListDialog'
 import {LeaveConvoPrompt} from '#/components/dms/LeaveConvoPrompt'
-import {ReportConversationDialog} from '#/components/dms/ReportConversationDialog'
+import {
+  type ConvoWithDetails,
+  getConvoReportSubject,
+} from '#/components/dms/util'
 import {ArrowBoxLeft_Stroke2_Corner0_Rounded as ArrowBoxLeftIcon} from '#/components/icons/ArrowBoxLeft'
 import {Bubble_Stroke2_Corner2_Rounded as BubbleIcon} from '#/components/icons/Bubble'
 import {DotGrid3x1_Stroke2_Corner0_Rounded as DotsHorizontalIcon} from '#/components/icons/DotGrid'
@@ -39,7 +44,6 @@ import {ReportDialog} from '#/components/moderation/ReportDialog'
 import * as Prompt from '#/components/Prompt'
 import * as Toast from '#/components/Toast'
 import type * as bsky from '#/types/bsky'
-import {AfterReportConversationDialog} from './AfterReportConversationDialog'
 
 let ConvoMenu = ({
   convo,
@@ -49,10 +53,9 @@ let ConvoMenu = ({
   showMarkAsRead,
   hideTrigger,
   blockInfo,
-  latestReportableMessage,
   style,
 }: {
-  convo: ChatBskyConvoDefs.ConvoView
+  convo: ConvoWithDetails
   profile: Shadow<bsky.profile.AnyProfileView>
   control?: Menu.MenuControlProps
   currentScreen: 'list' | 'conversation'
@@ -62,19 +65,20 @@ let ConvoMenu = ({
     listBlocks: ModerationCause[]
     userBlock?: ModerationCause
   }
-  latestReportableMessage?: ChatBskyConvoDefs.MessageView
   style?: ViewStyleProp['style']
 }): React.ReactNode => {
   const {t: l} = useLingui()
   const queryClient = useQueryClient()
+  const {currentAccount} = useSession()
 
   const leaveConvoControl = Prompt.usePromptControl()
   const reportControl = Prompt.usePromptControl()
   const blockedByListControl = Prompt.usePromptControl()
-  const blockOrDeleteControl = Prompt.usePromptControl()
-  const deleteControl = Prompt.usePromptControl()
+  const afterReportControl = Prompt.usePromptControl()
 
   const {listBlocks} = blockInfo
+
+  const reportSubject = getConvoReportSubject(convo, currentAccount?.did)
 
   return (
     <>
@@ -108,6 +112,7 @@ let ConvoMenu = ({
             showMarkAsRead={showMarkAsRead}
             blockInfo={blockInfo}
             convo={convo}
+            canReport={!!reportSubject}
             leaveConvoControl={leaveConvoControl}
             reportControl={reportControl}
             blockedByListControl={blockedByListControl}
@@ -116,49 +121,37 @@ let ConvoMenu = ({
       </Menu.Root>
       <LeaveConvoPrompt
         control={leaveConvoControl}
-        convoId={convo.id}
+        convoId={convo.view.id}
         currentScreen={currentScreen}
       />
-      {latestReportableMessage ? (
-        <>
-          <ReportDialog
-            subject={{
-              view: 'convo',
-              convoId: convo.id,
-              message: latestReportableMessage,
-            }}
-            control={reportControl}
-            onAfterSubmit={() => {
-              unstableCacheProfileView(queryClient, profile)
-              blockOrDeleteControl.open()
-            }}
-          />
-          <AfterReportDialog
-            control={blockOrDeleteControl}
-            currentScreen={currentScreen}
-            params={{
-              convoId: convo.id,
-              did: latestReportableMessage.sender.did,
-            }}
-          />
-        </>
+      {reportSubject && (
+        <ReportDialog
+          subject={reportSubject}
+          control={reportControl}
+          onAfterSubmit={() => {
+            unstableCacheProfileView(queryClient, profile)
+            afterReportControl.open()
+          }}
+        />
+      )}
+      {convo.kind === 'group' ? (
+        <AfterReportConversationDialog
+          control={afterReportControl}
+          currentScreen={currentScreen}
+          params={{
+            convoId: convo.view.id,
+            did: profile.did,
+          }}
+        />
       ) : (
-        <>
-          <ReportConversationDialog
-            control={reportControl}
-            convoId={convo.id}
-            did={profile.did}
-            onAfterSubmit={deleteControl.open}
-          />
-          <AfterReportConversationDialog
-            control={deleteControl}
-            currentScreen={currentScreen}
-            params={{
-              convoId: convo.id,
-              did: profile.did,
-            }}
-          />
-        </>
+        <AfterReportDialog
+          control={afterReportControl}
+          currentScreen={currentScreen}
+          params={{
+            convoId: convo.view.id,
+            did: profile.did,
+          }}
+        />
       )}
       <BlockedByListDialog
         control={blockedByListControl}
@@ -172,14 +165,16 @@ ConvoMenu = memo(ConvoMenu)
 function MenuContent({
   convo: initialConvo,
   profile,
+  canReport,
   showMarkAsRead,
   blockInfo,
   leaveConvoControl,
   reportControl,
   blockedByListControl,
 }: {
-  convo: ChatBskyConvoDefs.ConvoView
+  convo: ConvoWithDetails
   profile: Shadow<bsky.profile.AnyProfileView>
+  canReport: boolean
   showMarkAsRead?: boolean
   blockInfo: {
     listBlocks: ModerationCause[]
@@ -196,9 +191,9 @@ function MenuContent({
   const {listBlocks, userBlock} = blockInfo
   const isBlocking = userBlock || !!listBlocks.length
   const isDeletedAccount = profile.handle === 'missing.invalid'
-  const isGroupConvo = ChatBskyConvoDefs.isGroupConvo(initialConvo.kind)
+  const isGroupConvo = initialConvo.kind === 'group'
 
-  const convoId = initialConvo.id
+  const convoId = initialConvo.view.id
   const {data: convo} = useConvoQuery({convoId})
 
   const onNavigateToProfile = useCallback(() => {
@@ -294,15 +289,17 @@ function MenuContent({
             </Menu.ItemText>
           </Menu.Item>
         )}
-        <Menu.Item
-          destructive
-          label={l`Report conversation`}
-          onPress={reportControl.open}>
-          <Menu.ItemIcon icon={Flag} />
-          <Menu.ItemText>
-            <Trans>Report conversation</Trans>
-          </Menu.ItemText>
-        </Menu.Item>
+        {canReport && (
+          <Menu.Item
+            destructive
+            label={l`Report conversation`}
+            onPress={reportControl.open}>
+            <Menu.ItemIcon icon={Flag} />
+            <Menu.ItemText>
+              <Trans>Report conversation</Trans>
+            </Menu.ItemText>
+          </Menu.Item>
+        )}
       </Menu.Group>
       <Menu.Divider />
       <Menu.Group>

--- a/src/components/dms/MessagesListHeader.tsx
+++ b/src/components/dms/MessagesListHeader.tsx
@@ -1,10 +1,6 @@
 import {useMemo} from 'react'
 import {View} from 'react-native'
-import {
-  ChatBskyConvoDefs,
-  moderateProfile,
-  type ModerationOpts,
-} from '@atproto/api'
+import {moderateProfile, type ModerationOpts} from '@atproto/api'
 import {useLingui} from '@lingui/react/macro'
 
 import {createSanitizedDisplayName} from '#/lib/moderation/create-sanitized-display-name'
@@ -12,7 +8,6 @@ import {makeProfileLink} from '#/lib/routes/links'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {useProfileShadow} from '#/state/cache/profile-shadow'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
-import {useSession} from '#/state/session'
 import {PreviewableUserAvatar} from '#/view/com/util/UserAvatar'
 import {useIsWithinSplitView} from '#/screens/Messages/components/splitView/context'
 import {atoms as a, useTheme, web} from '#/alf'
@@ -88,7 +83,6 @@ function ProfileHeaderReady({
 }) {
   const t = useTheme()
   const {t: l} = useLingui()
-  const {currentAccount} = useSession()
   const profile = useProfileShadow(convo.primaryMember)
 
   const moderation = moderateProfile(profile, moderationOpts)
@@ -109,12 +103,6 @@ function ProfileHeaderReady({
     ? l`Deleted Account`
     : createSanitizedDisplayName(profile, true, moderation.ui('displayName'))
   const handle = isDeletedAccount ? null : sanitizeHandle(profile.handle, '@')
-
-  const latestReportableMessage =
-    ChatBskyConvoDefs.isMessageView(convo.view.lastMessage) &&
-    convo.view.lastMessage.sender?.did !== currentAccount?.did
-      ? convo.view.lastMessage
-      : undefined
 
   return (
     <Wrapper
@@ -151,11 +139,10 @@ function ProfileHeaderReady({
       }
       settings={
         <ConvoMenu
-          convo={convo.view}
+          convo={convo}
           profile={profile}
           currentScreen="conversation"
           blockInfo={blockInfo}
-          latestReportableMessage={latestReportableMessage}
         />
       }
     />

--- a/src/components/dms/util.ts
+++ b/src/components/dms/util.ts
@@ -10,6 +10,7 @@ import {EMOJI_REACTION_LIMIT} from '#/lib/constants'
 import {logger} from '#/logger'
 import {type Shadow} from '#/state/cache/profile-shadow'
 import {type ConvoState, ConvoStatus} from '#/state/messages/convo/types'
+import {type ReportSubject} from '#/components/moderation/ReportDialog/types'
 import * as bsky from '#/types/bsky'
 
 export const MESSAGE_GAP_THRESHOLD_MS = 60 * 60 * 1000
@@ -239,4 +240,42 @@ export function parseConvoView(
     logger.warn('Unknown convo kind: ' + JSON.stringify(convoView.kind))
     return null
   }
+}
+
+/**
+ * Resolves the report subject for a conversation-level "Report conversation"
+ * action (as opposed to reporting an individual message, which always reports
+ * that message + its sender).
+ *
+ * - group: always report the whole convo, targeting the owner. Returns null if
+ *   the owner has left, in which case there is nothing to report against.
+ * - direct: report the last reportable message if there is one (i.e. the last
+ *   message exists and wasn't sent by us), otherwise report the whole convo
+ *   targeting the other user.
+ */
+export function getConvoReportSubject(
+  convo: ConvoWithDetails,
+  ownDid: string | undefined,
+): ReportSubject | null {
+  if (convo.kind === 'group') {
+    if (!convo.primaryMember) return null
+    return {convoId: convo.view.id, did: convo.primaryMember.did}
+  }
+
+  const lastMessage = convo.view.lastMessage
+  const reportableMessage =
+    ChatBskyConvoDefs.isMessageView(lastMessage) &&
+    lastMessage.sender?.did !== ownDid
+      ? lastMessage
+      : null
+
+  if (reportableMessage) {
+    return {
+      view: 'convo',
+      convoId: convo.view.id,
+      message: reportableMessage,
+    }
+  }
+
+  return {convoId: convo.view.id, did: convo.primaryMember.did}
 }

--- a/src/screens/Messages/components/ChatListItem.tsx
+++ b/src/screens/Messages/components/ChatListItem.tsx
@@ -307,19 +307,12 @@ function BaseChatItem({
     isDeletedAccount ||
     (convo.kind === 'group' && convo.details.lockStatus !== 'unlocked')
 
-  const {
-    lastMessage,
-    LastMessageIcon,
-    lastMessageSentAt,
-    latestReportableMessage,
-  } = useMemo(() => {
+  const {lastMessage, LastMessageIcon, lastMessageSentAt} = useMemo(() => {
     let lastMessage = l`No messages yet`
 
     let LastMessageIcon: React.ComponentType<SVGIconProps> | null = null
 
     let lastMessageSentAt: string | null = null
-
-    let latestReportableMessage: ChatBskyConvoDefs.MessageView | undefined
 
     // Deleted message
     if (ChatBskyConvoDefs.isDeletedMessageView(convo.view.lastMessage)) {
@@ -340,7 +333,6 @@ function BaseChatItem({
       if (info) {
         lastMessage = info.message ?? lastMessage
         lastMessageSentAt = info.sentAt
-        latestReportableMessage = info.reportableMessage
       }
     }
 
@@ -385,7 +377,6 @@ function BaseChatItem({
       lastMessage,
       LastMessageIcon,
       lastMessageSentAt,
-      latestReportableMessage,
     }
   }, [l, convo, currentAccount?.did, isDeletedAccount, i18n])
 
@@ -663,7 +654,7 @@ function BaseChatItem({
           {/* TODO: Allow showing menu for groups where the owner has left! */}
           {showMenu && primaryProfile && (
             <ConvoMenu
-              convo={convo.view}
+              convo={convo}
               profile={primaryProfile}
               control={menuControl}
               currentScreen="list"
@@ -681,7 +672,6 @@ function BaseChatItem({
                     !gtMobile || showActions || menuControl.isOpen ? 1 : 0,
                 },
               ]}
-              latestReportableMessage={latestReportableMessage}
             />
           )}
 

--- a/src/screens/Messages/components/ChatStatusInfo.tsx
+++ b/src/screens/Messages/components/ChatStatusInfo.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useMemo} from 'react'
 import {View} from 'react-native'
 import {LinearGradient} from 'expo-linear-gradient'
-import {ChatBskyConvoDefs, moderateProfile} from '@atproto/api'
+import {moderateProfile} from '@atproto/api'
 import {Trans, useLingui} from '@lingui/react/macro'
 
 import {createSanitizedDisplayName} from '#/lib/moderation/create-sanitized-display-name'
@@ -33,12 +33,6 @@ export function ChatStatusInfo({convoState}: {convoState: ActiveConvoStates}) {
   // if we ever allow someone other than the owner to invite people, this will need to change
   const otherUser = convoState.convo.primaryMember
 
-  const lastMessage = ChatBskyConvoDefs.isMessageView(
-    convoState.convo.view.lastMessage,
-  )
-    ? convoState.convo.view.lastMessage
-    : null
-
   if (!moderationOpts) {
     return null
   }
@@ -64,9 +58,9 @@ export function ChatStatusInfo({convoState}: {convoState: ActiveConvoStates}) {
       <View style={[a.flex_row, a.gap_md, a.w_full, otherUser && a.pt_sm]}>
         {otherUser && (
           <RejectMenu
-            label={lastMessage ? l`Block or report` : l`Block`}
+            label={l`Block or report`}
             icon={true}
-            convo={convoState.convo.view}
+            convo={convoState.convo}
             profile={otherUser}
             color="negative_subtle"
             size="large"

--- a/src/screens/Messages/components/IncomingRequestListItem.tsx
+++ b/src/screens/Messages/components/IncomingRequestListItem.tsx
@@ -72,7 +72,7 @@ export function IncomingRequestListItem({
                   <AcceptChatButton convo={convo.view} currentScreen="list" />
                 ) : null}
                 <RejectMenu
-                  convo={convo.view}
+                  convo={convo}
                   profile={convo.primaryMember}
                   showDeleteConvo
                   currentScreen="list"

--- a/src/screens/Messages/components/RequestButtons.tsx
+++ b/src/screens/Messages/components/RequestButtons.tsx
@@ -26,6 +26,7 @@ import {
   useEmailDialogControl,
 } from '#/components/dialogs/EmailDialog'
 import {AfterReportDialog} from '#/components/dms/AfterReportDialog'
+import {type ConvoWithDetails} from '#/components/dms/util'
 import {ArrowBoxLeft_Stroke2_Corner0_Rounded as LeaveIcon} from '#/components/icons/ArrowBoxLeft'
 import {Check_Stroke2_Corner0_Rounded as CheckIcon} from '#/components/icons/Check'
 import {CircleX_Stroke2_Corner0_Rounded} from '#/components/icons/CircleX'
@@ -49,7 +50,7 @@ export function RejectMenu({
 }: Omit<ButtonProps, 'onPress' | 'children' | 'label'> & {
   label?: string
   icon?: boolean
-  convo: ChatBskyConvoDefs.ConvoView
+  convo: ConvoWithDetails
   profile: ChatBskyActorDefs.ProfileViewBasic
   showDeleteConvo?: boolean
   currentScreen: 'list' | 'conversation'
@@ -59,7 +60,7 @@ export function RejectMenu({
   const navigation = useNavigation<NavigationProp>()
   const queryClient = useQueryClient()
 
-  const {mutate: leaveConvo} = useLeaveConvo(convo.id, {
+  const {mutate: leaveConvo} = useLeaveConvo(convo.view.id, {
     onMutate: () => {
       if (currentScreen === 'conversation') {
         navigation.dispatch(StackActions.pop())
@@ -110,8 +111,8 @@ export function RejectMenu({
   const reportControl = useDialogControl()
   const blockOrDeleteControl = useDialogControl()
 
-  const lastMessage = ChatBskyConvoDefs.isMessageView(convo.lastMessage)
-    ? convo.lastMessage
+  const lastMessage = ChatBskyConvoDefs.isMessageView(convo.view.lastMessage)
+    ? convo.view.lastMessage
     : null
 
   return (
@@ -152,51 +153,47 @@ export function RejectMenu({
               </Menu.ItemText>
               <Menu.ItemIcon icon={PersonXIcon} />
             </Menu.Item>
-            {/* note: last message will almost certainly be defined, since you can't
-              delete messages for other people and it's impossible for a convo on this
-              screen to have a message sent by you */}
-            {lastMessage && (
-              <Menu.Item
-                label={l`Report conversation`}
-                onPress={reportControl.open}>
-                <Menu.ItemText>
-                  <Trans>Report conversation</Trans>
-                </Menu.ItemText>
-                <Menu.ItemIcon icon={FlagIcon} />
-              </Menu.Item>
-            )}
+            <Menu.Item
+              label={l`Report conversation`}
+              onPress={reportControl.open}>
+              <Menu.ItemText>
+                <Trans>Report conversation</Trans>
+              </Menu.ItemText>
+              <Menu.ItemIcon icon={FlagIcon} />
+            </Menu.Item>
           </Menu.Group>
         </Menu.Outer>
       </Menu.Root>
-      {lastMessage && (
-        <>
-          <ReportDialog
-            subject={{
-              view: 'convo',
-              convoId: convo.id,
-              message: lastMessage,
-            }}
-            control={reportControl}
-            onAfterSubmit={() => {
-              const sender = convo.members.find(
-                member => member.did === lastMessage.sender.did,
-              )
-              if (sender) {
-                unstableCacheProfileView(queryClient, sender)
+
+      <ReportDialog
+        subject={
+          lastMessage
+            ? {
+                view: 'convo',
+                convoId: convo.view.id,
+                message: lastMessage,
               }
-              blockOrDeleteControl.open()
-            }}
-          />
-          <AfterReportDialog
-            control={blockOrDeleteControl}
-            currentScreen={currentScreen}
-            params={{
-              convoId: convo.id,
-              did: lastMessage.sender.did,
-            }}
-          />
-        </>
-      )}
+            : {
+                convoId: convo.view.id,
+                did: profile.did,
+              }
+        }
+        control={reportControl}
+        onAfterSubmit={() => {
+          if (profile) {
+            unstableCacheProfileView(queryClient, profile)
+          }
+          blockOrDeleteControl.open()
+        }}
+      />
+      <AfterReportDialog
+        control={blockOrDeleteControl}
+        currentScreen={currentScreen}
+        params={{
+          convoId: convo.view.id,
+          did: profile.did,
+        }}
+      />
     </>
   )
 }

--- a/src/screens/Messages/components/RequestButtons.tsx
+++ b/src/screens/Messages/components/RequestButtons.tsx
@@ -180,9 +180,7 @@ export function RejectMenu({
         }
         control={reportControl}
         onAfterSubmit={() => {
-          if (profile) {
-            unstableCacheProfileView(queryClient, profile)
-          }
+          unstableCacheProfileView(queryClient, profile)
           blockOrDeleteControl.open()
         }}
       />

--- a/src/screens/Messages/components/RequestButtons.tsx
+++ b/src/screens/Messages/components/RequestButtons.tsx
@@ -14,6 +14,7 @@ import {
   unstableCacheProfileView,
   useProfileBlockMutationQueue,
 } from '#/state/queries/profile'
+import {useSession} from '#/state/session'
 import {
   Button,
   ButtonIcon,
@@ -25,8 +26,12 @@ import {
   EmailDialogScreenID,
   useEmailDialogControl,
 } from '#/components/dialogs/EmailDialog'
+import {AfterReportConversationDialog} from '#/components/dms/AfterReportConversationDialog'
 import {AfterReportDialog} from '#/components/dms/AfterReportDialog'
-import {type ConvoWithDetails} from '#/components/dms/util'
+import {
+  type ConvoWithDetails,
+  getConvoReportSubject,
+} from '#/components/dms/util'
 import {ArrowBoxLeft_Stroke2_Corner0_Rounded as LeaveIcon} from '#/components/icons/ArrowBoxLeft'
 import {Check_Stroke2_Corner0_Rounded as CheckIcon} from '#/components/icons/Check'
 import {CircleX_Stroke2_Corner0_Rounded} from '#/components/icons/CircleX'
@@ -56,6 +61,7 @@ export function RejectMenu({
   currentScreen: 'list' | 'conversation'
 }) {
   const {t: l} = useLingui()
+  const {currentAccount} = useSession()
   const shadowedProfile = useProfileShadow(profile)
   const navigation = useNavigation<NavigationProp>()
   const queryClient = useQueryClient()
@@ -111,9 +117,7 @@ export function RejectMenu({
   const reportControl = useDialogControl()
   const blockOrDeleteControl = useDialogControl()
 
-  const lastMessage = ChatBskyConvoDefs.isMessageView(convo.view.lastMessage)
-    ? convo.view.lastMessage
-    : null
+  const reportSubject = getConvoReportSubject(convo, currentAccount?.did)
 
   return (
     <>
@@ -165,33 +169,35 @@ export function RejectMenu({
         </Menu.Outer>
       </Menu.Root>
 
-      <ReportDialog
-        subject={
-          lastMessage
-            ? {
-                view: 'convo',
-                convoId: convo.view.id,
-                message: lastMessage,
-              }
-            : {
-                convoId: convo.view.id,
-                did: profile.did,
-              }
-        }
-        control={reportControl}
-        onAfterSubmit={() => {
-          unstableCacheProfileView(queryClient, profile)
-          blockOrDeleteControl.open()
-        }}
-      />
-      <AfterReportDialog
-        control={blockOrDeleteControl}
-        currentScreen={currentScreen}
-        params={{
-          convoId: convo.view.id,
-          did: profile.did,
-        }}
-      />
+      {reportSubject && (
+        <ReportDialog
+          subject={reportSubject}
+          control={reportControl}
+          onAfterSubmit={() => {
+            unstableCacheProfileView(queryClient, profile)
+            blockOrDeleteControl.open()
+          }}
+        />
+      )}
+      {convo.kind === 'group' ? (
+        <AfterReportConversationDialog
+          control={blockOrDeleteControl}
+          currentScreen={currentScreen}
+          params={{
+            convoId: convo.view.id,
+            did: profile.did,
+          }}
+        />
+      ) : (
+        <AfterReportDialog
+          control={blockOrDeleteControl}
+          currentScreen={currentScreen}
+          params={{
+            convoId: convo.view.id,
+            did: profile.did,
+          }}
+        />
+      )}
     </>
   )
 }


### PR DESCRIPTION
## Summary

Conversation-level reporting (the "Report conversation" action, distinct from reporting an individual message) was wired up independently at every surface, and each derived its report subject slightly differently. This started as "let empty group invites be reported" and grew into unifying the logic.

Adds a single helper, `getConvoReportSubject(convo, ownDid)` in `src/components/dms/util.ts`, used at every conversation-level report surface:

- **Group** → always report the whole convo, targeting the **owner** (`convoRef`). Returns `null` if the owner has left (nothing to report against), in which case the Report item is hidden.
- **Direct** → report the last **reportable** message if there is one (exists + not sent by us) as a `messageRef`; otherwise report the whole convo targeting the other user (`convoRef`).
- **Message context menu** (reporting a specific message) is unchanged.

The after-report dialog is now routed by convo kind everywhere: group → "Block and leave" (`AfterReportConversationDialog`), direct → "Block and delete" (`AfterReportDialog`).

## Why

- Removes the `lastMessage` gate so empty group invites can be reported.
- Fixes the inconsistency where `ConvoMenu` blocked `profile.did` on the no-message path but `latestReportableMessage.sender.did` on the message path — in a group opened from the chat-list row those differed, causing a wasted profile cache-prime and a brief loading flicker on the post-report block step. The block target is now uniformly `primaryMember.did`.
- `RejectMenu` previously reported your own last message as the subject (no `isFromMe` exclusion) and always showed the "delete" dialog even for group invites. Both are now consistent with the rest of the app.

## Surfaces touched

- `ConvoMenu` (chat-list row + direct convo header) — now takes `ConvoWithDetails`, drops the `latestReportableMessage` prop, resolves the subject internally.
- `RejectMenu` (request list + invite-in-conversation) — uses the helper, routes the after-dialog by kind.
- `ChatListItem` / `MessagesListHeader` — pass the parsed convo, drop the now-unused `latestReportableMessage` plumbing.

`ConversationSettings` (group-only) already did exactly the helper's group-branch behavior, so it's left as-is.

## Test plan

- `pnpm typecheck` + `pnpm lint` pass.
- Manual matrix:
  - Direct, last message from other user → "Report this conversation", `messageRef`, "Block and delete".
  - Direct, last message is mine / no messages → `convoRef` targeting other user, "Block and delete".
  - Group, any state → `convoRef` targeting owner, "Block and leave".
  - Group, owner has left → Report item hidden.
  - No profile-loading flicker on the post-report block step for group chats opened from the chat-list row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)