### PR TITLE
Add plural formatting for error toast

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -210,7 +210,9 @@ function useAddImagesWithCap(
       if (result.status === 'full') {
         Toast.show(
           l({
-            message: `You can only add up to ${MAX_GALLERY_IMAGES} images per post`,
+            message: `You can only add up to ${plural(MAX_GALLERY_IMAGES, {
+              other: '# images',
+            })} per post`,
             comment:
               'Toast shown when the user tries to add more images but the post gallery is already at the cap',
           }),


### PR DESCRIPTION
This PR proposes adding plural formatting for the error toast at `src/view/com/composer/Composer.tsx:213`:

```ts
// Before
message: `You can only add up to ${MAX_GALLERY_IMAGES} images per post`,

// After
message: `You can only add up to ${plural(MAX_GALLERY_IMAGES, {
  other: '# images',
})} per post`,
```

Only the `other` category is needed since the value is a constant that's never 1.