### PR TITLE
Android share intent: logging + temp file cleanup

### DIFF
--- a/modules/expo-receive-android-intents/android/src/main/java/xyz/blueskyweb/app/exporeceiveandroidintents/ExpoReceiveAndroidIntentsModule.kt
+++ b/modules/expo-receive-android-intents/android/src/main/java/xyz/blueskyweb/app/exporeceiveandroidintents/ExpoReceiveAndroidIntentsModule.kt
@@ -6,12 +6,15 @@ import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
+import android.util.Log
 import androidx.core.net.toUri
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import java.io.File
 import java.io.FileOutputStream
 import java.net.URLEncoder
+
+private const val TAG = "ExpoReceiveAndroidIntents"
 
 enum class AttachmentType {
   IMAGE,
@@ -165,6 +168,7 @@ class ExpoReceiveAndroidIntentsModule : Module() {
         input.use { it.copyTo(out) }
       }
     } catch (e: Exception) {
+      Log.w(TAG, "Failed to copy shared video to cache", e)
       return
     }
 
@@ -188,6 +192,7 @@ class ExpoReceiveAndroidIntentsModule : Module() {
       } catch (e: Exception) {
         // The URI may be unreadable (revoked permission, deleted file, or a
         // provider that rejects the read). Skip this image rather than crash.
+        Log.w(TAG, "Failed to read shared image", e)
         return null
       } ?: return null
     // We have to save this so that we can access it later when uploading the image.
@@ -215,6 +220,7 @@ class ExpoReceiveAndroidIntentsModule : Module() {
       height = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)?.toIntOrNull()
     } catch (e: Exception) {
       // The URI may be unreadable or not a valid media source. Skip rather than crash.
+      Log.w(TAG, "Failed to read shared video metadata", e)
       return null
     } finally {
       retriever.release()

--- a/modules/expo-receive-android-intents/android/src/main/java/xyz/blueskyweb/app/exporeceiveandroidintents/ExpoReceiveAndroidIntentsModule.kt
+++ b/modules/expo-receive-android-intents/android/src/main/java/xyz/blueskyweb/app/exporeceiveandroidintents/ExpoReceiveAndroidIntentsModule.kt
@@ -164,15 +164,25 @@ class ExpoReceiveAndroidIntentsModule : Module() {
     // app, since this runs synchronously on the module init path.
     try {
       FileOutputStream(file).use { out ->
-        val input = appContext.currentActivity?.contentResolver?.openInputStream(uri) ?: return
+        val input =
+          appContext.currentActivity?.contentResolver?.openInputStream(uri)
+            ?: run {
+              file.delete()
+              return
+            }
         input.use { it.copyTo(out) }
       }
     } catch (e: Exception) {
       Log.w(TAG, "Failed to copy shared video to cache", e)
+      file.delete()
       return
     }
 
-    val info = getVideoInfo(uri) ?: return
+    val info =
+      getVideoInfo(uri) ?: run {
+        file.delete()
+        return
+      }
 
     val encodedText = text?.let { URLEncoder.encode(it, "UTF-8") }
 
@@ -198,10 +208,16 @@ class ExpoReceiveAndroidIntentsModule : Module() {
     // We have to save this so that we can access it later when uploading the image.
     // createTempFile will automatically place a unique string between "img" and "temp.jpeg"
     val file = createFile("jpeg")
-    val out = FileOutputStream(file)
-    bitmap.compress(Bitmap.CompressFormat.JPEG, 100, out)
-    out.flush()
-    out.close()
+    try {
+      FileOutputStream(file).use { out ->
+        bitmap.compress(Bitmap.CompressFormat.JPEG, 100, out)
+        out.flush()
+      }
+    } catch (e: Exception) {
+      Log.w(TAG, "Failed to write shared image to cache", e)
+      file.delete()
+      return null
+    }
 
     return mapOf(
       "width" to bitmap.width,


### PR DESCRIPTION
Follow-ups to the Android share intent crash fix (#10674).

## What changed

- **Logging:** the three catch blocks in `ExpoReceiveAndroidIntentsModule` previously discarded exceptions entirely. Added `Log.w(TAG, ..., e)` at each catch site so unexpected failure modes (OOM on large bitmaps, truncated streams, etc.) surface in Logcat during user-reported issues. Crash-isolation behavior is unchanged.
- **Temp file cleanup:** `createFile` writes to the cache dir before the copy/compress attempt, so the bail-out paths left an orphan temp file behind. Delete the file on each failure path (no input stream, copy/write throws, `getVideoInfo` returns null). Also wrapped the image write in a `use {}` block so the stream is closed if compress throws. The success path keeps the file, since its path is passed to the compose intent downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)