### PR TITLE
Add Leave chat button to settings for chat owners

### DIFF
--- a/src/screens/Messages/ConversationSettings/index.tsx
+++ b/src/screens/Messages/ConversationSettings/index.tsx
@@ -473,6 +473,7 @@ function SettingsHeader({
             a.justify_center,
             a.gap_2xl,
             a.pt_2xl,
+            a.flex_wrap,
           ]}>
           <SettingsButton
             color={convo.view.muted ? 'negative_subtle' : 'secondary'}
@@ -638,6 +639,7 @@ function SettingsButton({
       </Button>
       <Text
         numberOfLines={1}
+        maxFontSizeMultiplier={2.5}
         style={[
           a.text_xs,
           a.font_medium,

--- a/src/screens/Messages/ConversationSettings/index.tsx
+++ b/src/screens/Messages/ConversationSettings/index.tsx
@@ -539,7 +539,7 @@ function SettingsHeader({
             />
           ) : null}
           <SettingsButton
-            disabled={!isReady || isLeaving}
+            disabled={!isReady || isLeaving || (isOwner && isLocking)}
             icon={ArrowBoxLeftIcon}
             label={l`Leave this group chat`}
             text={l`Leave`}

--- a/src/screens/Messages/ConversationSettings/index.tsx
+++ b/src/screens/Messages/ConversationSettings/index.tsx
@@ -538,15 +538,17 @@ function SettingsHeader({
               onPress={reportControl.open}
             />
           ) : null}
-          <SettingsButton
-            disabled={!isReady || isLeaving || (isOwner && isLocking)}
-            icon={ArrowBoxLeftIcon}
-            label={l`Leave this group chat`}
-            text={l`Leave`}
-            onPress={
-              isOwner ? leaveAndLockChatPrompt.open : leaveChatPrompt.open
-            }
-          />
+          {!isOwner || (isOwner && lockStatus !== 'locked-permanently') ? (
+            <SettingsButton
+              disabled={!isReady || isLeaving || (isOwner && isLocking)}
+              icon={ArrowBoxLeftIcon}
+              label={l`Leave this group chat`}
+              text={l`Leave`}
+              onPress={
+                isOwner ? leaveAndLockChatPrompt.open : leaveChatPrompt.open
+              }
+            />
+          ) : null}
         </View>
       </View>
       <EditNamePrompt
@@ -576,7 +578,6 @@ function SettingsHeader({
       <LeaveAndLockChatPrompt
         control={leaveAndLockChatPrompt}
         groupName={groupName}
-        lockedPermanently={lockStatus === 'locked-permanently'}
         onConfirm={() => {
           void leaveAndLockConvo()
         }}

--- a/src/screens/Messages/ConversationSettings/index.tsx
+++ b/src/screens/Messages/ConversationSettings/index.tsx
@@ -538,17 +538,15 @@ function SettingsHeader({
               onPress={reportControl.open}
             />
           ) : null}
-          {!isOwner || (isOwner && lockStatus !== 'locked-permanently') ? (
-            <SettingsButton
-              disabled={!isReady || isLeaving || (isOwner && isLocking)}
-              icon={ArrowBoxLeftIcon}
-              label={l`Leave this group chat`}
-              text={l`Leave`}
-              onPress={
-                isOwner ? leaveAndLockChatPrompt.open : leaveChatPrompt.open
-              }
-            />
-          ) : null}
+          <SettingsButton
+            disabled={!isReady || isLeaving || (isOwner && isLocking)}
+            icon={ArrowBoxLeftIcon}
+            label={l`Leave this group chat`}
+            text={l`Leave`}
+            onPress={
+              isOwner ? leaveAndLockChatPrompt.open : leaveChatPrompt.open
+            }
+          />
         </View>
       </View>
       <EditNamePrompt

--- a/src/screens/Messages/ConversationSettings/index.tsx
+++ b/src/screens/Messages/ConversationSettings/index.tsx
@@ -576,6 +576,7 @@ function SettingsHeader({
       <LeaveAndLockChatPrompt
         control={leaveAndLockChatPrompt}
         groupName={groupName}
+        lockedPermanently={lockStatus === 'locked-permanently'}
         onConfirm={() => {
           void leaveAndLockConvo()
         }}

--- a/src/screens/Messages/ConversationSettings/index.tsx
+++ b/src/screens/Messages/ConversationSettings/index.tsx
@@ -58,7 +58,12 @@ import {InviteLinkDialog} from '../components/InviteLinkDialog'
 import {AddMembersLink} from './AddMembersLink'
 import {Member, MemberPlaceholder} from './Member'
 import {MembersAndRequests} from './MembersAndRequests'
-import {EditNamePrompt, LeaveChatPrompt, LockChatPrompt} from './prompts'
+import {
+  EditNamePrompt,
+  LeaveAndLockChatPrompt,
+  LeaveChatPrompt,
+  LockChatPrompt,
+} from './prompts'
 
 type Item =
   | {type: 'MEMBERS_AND_REQUESTS'; key: string}
@@ -375,33 +380,48 @@ function SettingsHeader({
     },
   )
 
-  const {mutate: lockConvo, isPending: isLocking} = useLockConvo(
-    convo.view.id,
-    {
-      onSuccess: data => {
-        if (!ChatBskyConvoDefs.isGroupConvo(data.convo.kind)) return
-        if (data.convo.kind.lockStatus === 'locked') {
-          Toast.show(l({message: 'Group chat locked', context: 'toast'}))
-        } else {
-          Toast.show(l({message: 'Group chat unlocked', context: 'toast'}))
-        }
-      },
-      onError: (e, {lock}) => {
-        if (lock) {
-          logger.error('Failed to lock group chat', {message: e})
-          Toast.show(l`Failed to lock group chat`, {type: 'error'})
-        } else {
-          logger.error('Failed to unlock group chat', {message: e})
-          Toast.show(l`Failed to unlock group chat`, {type: 'error'})
-        }
-      },
+  const {
+    mutate: lockConvo,
+    mutateAsync: lockConvoAsync,
+    isPending: isLocking,
+  } = useLockConvo(convo.view.id, {
+    onSuccess: data => {
+      if (!ChatBskyConvoDefs.isGroupConvo(data.convo.kind)) return
+      if (data.convo.kind.lockStatus === 'locked') {
+        Toast.show(l({message: 'Group chat locked', context: 'toast'}))
+      } else {
+        Toast.show(l({message: 'Group chat unlocked', context: 'toast'}))
+      }
     },
-  )
+    onError: (e, {lock}) => {
+      if (lock) {
+        logger.error('Failed to lock group chat', {message: e})
+        Toast.show(l`Failed to lock group chat`, {type: 'error'})
+      } else {
+        logger.error('Failed to unlock group chat', {message: e})
+        Toast.show(l`Failed to unlock group chat`, {type: 'error'})
+      }
+    },
+  })
+
+  const leaveAndLockConvo = async () => {
+    try {
+      if (lockStatus === 'unlocked') {
+        await lockConvoAsync({lock: true})
+      }
+    } catch {
+      // Handled by onError in useLockConvo
+      return
+    }
+    // Owners can only leave a locked chat
+    leaveConvo()
+  }
 
   const inviteLinkDialog = Dialog.useDialogControl()
   const editNamePrompt = Prompt.usePromptControl()
   const lockChatPrompt = Prompt.usePromptControl()
   const leaveChatPrompt = Prompt.usePromptControl()
+  const leaveAndLockChatPrompt = Prompt.usePromptControl()
   const reportControl = Prompt.usePromptControl()
   const deleteControl = Prompt.usePromptControl()
 
@@ -518,15 +538,15 @@ function SettingsHeader({
               onPress={reportControl.open}
             />
           ) : null}
-          {!isOwner ? (
-            <SettingsButton
-              disabled={!isReady || isLeaving}
-              icon={ArrowBoxLeftIcon}
-              label={l`Leave this group chat`}
-              text={l`Leave`}
-              onPress={leaveChatPrompt.open}
-            />
-          ) : null}
+          <SettingsButton
+            disabled={!isReady || isLeaving}
+            icon={ArrowBoxLeftIcon}
+            label={l`Leave this group chat`}
+            text={l`Leave`}
+            onPress={
+              isOwner ? leaveAndLockChatPrompt.open : leaveChatPrompt.open
+            }
+          />
         </View>
       </View>
       <EditNamePrompt
@@ -552,6 +572,13 @@ function SettingsHeader({
         control={leaveChatPrompt}
         groupName={groupName}
         onConfirm={leaveConvo}
+      />
+      <LeaveAndLockChatPrompt
+        control={leaveAndLockChatPrompt}
+        groupName={groupName}
+        onConfirm={() => {
+          void leaveAndLockConvo()
+        }}
       />
       {reportSubjectDid ? (
         <>

--- a/src/screens/Messages/ConversationSettings/index.tsx
+++ b/src/screens/Messages/ConversationSettings/index.tsx
@@ -385,8 +385,9 @@ function SettingsHeader({
     mutateAsync: lockConvoAsync,
     isPending: isLocking,
   } = useLockConvo(convo.view.id, {
-    onSuccess: data => {
+    onSuccess: (data, {silent}) => {
       if (!ChatBskyConvoDefs.isGroupConvo(data.convo.kind)) return
+      if (silent) return
       if (data.convo.kind.lockStatus === 'locked') {
         Toast.show(l({message: 'Group chat locked', context: 'toast'}))
       } else {
@@ -407,7 +408,7 @@ function SettingsHeader({
   const leaveAndLockConvo = async () => {
     try {
       if (lockStatus === 'unlocked') {
-        await lockConvoAsync({lock: true})
+        await lockConvoAsync({lock: true, silent: true})
       }
     } catch {
       // Handled by onError in useLockConvo

--- a/src/screens/Messages/ConversationSettings/prompts.tsx
+++ b/src/screens/Messages/ConversationSettings/prompts.tsx
@@ -124,6 +124,30 @@ export function LeaveChatPrompt({
   )
 }
 
+export function LeaveAndLockChatPrompt({
+  control,
+  groupName,
+  onConfirm,
+}: {
+  control: Dialog.DialogOuterProps['control']
+  groupName: string
+  onConfirm: () => void
+}) {
+  const {t: l} = useLingui()
+
+  return (
+    <Prompt.Basic
+      control={control}
+      title={l`Are you sure you want to leave ${groupName}?`}
+      description={l`Leaving this chat will lock it permanently and you will not be able to rejoin.`}
+      confirmButtonCta={l`Leave group chat`}
+      confirmButtonColor="negative"
+      cancelButtonCta={l`Cancel`}
+      onConfirm={onConfirm}
+    />
+  )
+}
+
 export function BlockMemberPrompt({
   control,
   onConfirm,

--- a/src/screens/Messages/ConversationSettings/prompts.tsx
+++ b/src/screens/Messages/ConversationSettings/prompts.tsx
@@ -127,10 +127,12 @@ export function LeaveChatPrompt({
 export function LeaveAndLockChatPrompt({
   control,
   groupName,
+  lockedPermanently,
   onConfirm,
 }: {
   control: Dialog.DialogOuterProps['control']
   groupName: string
+  lockedPermanently: boolean
   onConfirm: () => void
 }) {
   const {t: l} = useLingui()
@@ -139,7 +141,11 @@ export function LeaveAndLockChatPrompt({
     <Prompt.Basic
       control={control}
       title={l`Are you sure you want to leave ${groupName}?`}
-      description={l`Leaving this chat will lock it permanently and you will not be able to rejoin.`}
+      description={
+        lockedPermanently
+          ? l`You won’t be able to rejoin.`
+          : l`Leaving this chat will lock it permanently and you won’t be able to rejoin.`
+      }
       confirmButtonCta={l`Leave group chat`}
       confirmButtonColor="negative"
       cancelButtonCta={l`Cancel`}

--- a/src/screens/Messages/ConversationSettings/prompts.tsx
+++ b/src/screens/Messages/ConversationSettings/prompts.tsx
@@ -127,12 +127,10 @@ export function LeaveChatPrompt({
 export function LeaveAndLockChatPrompt({
   control,
   groupName,
-  lockedPermanently,
   onConfirm,
 }: {
   control: Dialog.DialogOuterProps['control']
   groupName: string
-  lockedPermanently: boolean
   onConfirm: () => void
 }) {
   const {t: l} = useLingui()
@@ -141,11 +139,7 @@ export function LeaveAndLockChatPrompt({
     <Prompt.Basic
       control={control}
       title={l`Are you sure you want to leave ${groupName}?`}
-      description={
-        lockedPermanently
-          ? l`You won’t be able to rejoin.`
-          : l`Leaving this chat will lock it permanently and you won’t be able to rejoin.`
-      }
+      description={l`Leaving this chat will lock it permanently and you won’t be able to rejoin.`}
       confirmButtonCta={l`Leave group chat`}
       confirmButtonColor="negative"
       cancelButtonCta={l`Cancel`}

--- a/src/state/queries/messages/lock-conversation.ts
+++ b/src/state/queries/messages/lock-conversation.ts
@@ -14,15 +14,21 @@ export function useLockConvo(
     onSuccess,
     onError,
   }: {
-    onSuccess?: (data: ChatBskyConvoLockConvo.OutputSchema) => void
-    onError?: (error: Error, variables: {lock: boolean}) => void
+    onSuccess?: (
+      data: ChatBskyConvoLockConvo.OutputSchema,
+      variables: {lock: boolean; silent?: boolean},
+    ) => void
+    onError?: (
+      error: Error,
+      variables: {lock: boolean; silent?: boolean},
+    ) => void
   },
 ) {
   const queryClient = useQueryClient()
   const agent = useAgent()
 
   return useMutation({
-    mutationFn: async ({lock}: {lock: boolean}) => {
+    mutationFn: async ({lock}: {lock: boolean; silent?: boolean}) => {
       if (!convoId) throw new Error('No convoId provided')
       if (lock) {
         const {data} = await agent.chat.bsky.convo.lockConvo(
@@ -51,8 +57,8 @@ export function useLockConvo(
         }
       })
     },
-    onSuccess: data => {
-      onSuccess?.(data)
+    onSuccess: (data, variables) => {
+      onSuccess?.(data, variables)
     },
     onError: (e, variables, context) => {
       if (convoId && context) {


### PR DESCRIPTION
This is already present for chat members, but not owners. The distinction is that a chat must be locked before a chat owner can leave it, and when a chat owner leaves the chat is permanently locked.

https://github.com/user-attachments/assets/2bfb2f2f-bf56-4592-91ba-631174fefffc