### PR TITLE
fix: add scroll-to-top for Profile Starter Packs and use shared query invalidation

### DIFF
--- a/src/components/StarterPack/ProfileStarterPacks.tsx
+++ b/src/components/StarterPack/ProfileStarterPacks.tsx
@@ -12,6 +12,7 @@ import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
 import {useNavigation} from '@react-navigation/native'
+import {useQueryClient} from '@tanstack/react-query'
 
 import {useGenerateStarterPackMutation} from '#/lib/generate-starterpack'
 import {useBottomBarOffset} from '#/lib/hooks/useBottomBarOffset'
@@ -20,7 +21,10 @@ import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
 import {type NavigationProp} from '#/lib/routes/types'
 import {parseStarterPackUri} from '#/lib/strings/starter-pack'
 import {logger} from '#/logger'
-import {useActorStarterPacksQuery} from '#/state/queries/actor-starter-packs'
+import {
+  invalidateActorStarterPacksQuery,
+  useActorStarterPacksQuery,
+} from '#/state/queries/actor-starter-packs'
 import {
   EmptyState,
   type EmptyStateButtonProps,
@@ -36,7 +40,7 @@ import {Loader} from '#/components/Loader'
 import * as Prompt from '#/components/Prompt'
 import {Default as StarterPackCard} from '#/components/StarterPack/StarterPackCard'
 import {Text} from '#/components/Typography'
-import {IS_IOS} from '#/env'
+import {IS_IOS, IS_NATIVE} from '#/env'
 
 interface SectionRef {
   scrollToTop: () => void
@@ -113,8 +117,22 @@ export function ProfileStarterPacks({
     return <Empty />
   }, [_, emptyStateMessage, emptyStateButton, emptyStateIcon])
 
+  const queryClient = useQueryClient()
+
+  const onScrollToTop = useCallback(() => {
+    scrollElRef.current?.scrollToOffset({
+      animated: IS_NATIVE,
+      offset: -headerOffset,
+    })
+
+    void invalidateActorStarterPacksQuery({
+      queryClient,
+      did,
+    })
+  }, [scrollElRef, queryClient, headerOffset, did])
+
   useImperativeHandle(ref, () => ({
-    scrollToTop: () => {},
+    scrollToTop: onScrollToTop,
   }))
 
   const onRefresh = useCallback(async () => {

--- a/src/view/com/feeds/ProfileFeedgens.tsx
+++ b/src/view/com/feeds/ProfileFeedgens.tsx
@@ -20,8 +20,9 @@ import {useQueryClient} from '@tanstack/react-query'
 
 import {cleanError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
+import {invalidateActorStarterPacksQuery} from '#/state/queries/actor-starter-packs'
 import {usePreferencesQuery} from '#/state/queries/preferences'
-import {RQKEY, useProfileFeedgensQuery} from '#/state/queries/profile-feedgens'
+import {useProfileFeedgensQuery} from '#/state/queries/profile-feedgens'
 import {useSession} from '#/state/session'
 import {EmptyState} from '#/view/com/util/EmptyState'
 import {ErrorMessage} from '#/view/com/util/error/ErrorMessage'
@@ -114,7 +115,10 @@ export function ProfileFeedgens({
       animated: IS_NATIVE,
       offset: -headerOffset,
     })
-    queryClient.invalidateQueries({queryKey: RQKEY(did)})
+    invalidateActorStarterPacksQuery({
+      queryClient,
+      did,
+    })
   }, [scrollElRef, queryClient, headerOffset, did])
 
   useImperativeHandle(ref, () => ({

--- a/src/view/com/lists/ProfileLists.tsx
+++ b/src/view/com/lists/ProfileLists.tsx
@@ -20,8 +20,9 @@ import {useQueryClient} from '@tanstack/react-query'
 
 import {cleanError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
+import {invalidateActorStarterPacksQuery} from '#/state/queries/actor-starter-packs'
 import {usePreferencesQuery} from '#/state/queries/preferences'
-import {RQKEY, useProfileListsQuery} from '#/state/queries/profile-lists'
+import {useProfileListsQuery} from '#/state/queries/profile-lists'
 import {useSession} from '#/state/session'
 import {EmptyState} from '#/view/com/util/EmptyState'
 import {ErrorMessage} from '#/view/com/util/error/ErrorMessage'
@@ -114,7 +115,10 @@ export function ProfileLists({
       animated: IS_NATIVE,
       offset: -headerOffset,
     })
-    queryClient.invalidateQueries({queryKey: RQKEY(did)})
+    invalidateActorStarterPacksQuery({
+      queryClient,
+      did,
+    })
   }, [scrollElRef, queryClient, headerOffset, did])
 
   useImperativeHandle(ref, () => ({


### PR DESCRIPTION
### Summary

Fixes an issue where the Starter Packs tab in Profile did not scroll back to the top when reselecting the active tab, unlike other profile sections.

### Problem

Most profile tabs already support scroll-to-top behavior through section refs and soft reset handling.

Starter Packs exposed a scrollToTop() ref but the visible content was not updating as expected, causing inconsistent navigation behavior across profile tabs.

### Changes
Hooked Starter Packs into the existing scroll-to-top flow.
Triggered list scroll using the forwarded scroll reference.
Invalidated Starter Packs query after scroll to ensure refreshed content state.

### Result

Starter Packs now behaves consistently with other profile tabs:

Reselect active tab → scroll to top
Content refresh behavior remains aligned with other profile sections

### Testing
Open Profile → Starter Packs
Scroll down
Reselect active tab / trigger soft reset
Verify list returns to top
Verify data refresh still works correctly


### Reproduction (Before Fix)

https://github.com/user-attachments/assets/109cda62-ec27-4daa-8191-7cb782c0af12

### Result (After Fix)

https://github.com/user-attachments/assets/52864858-1fb2-4dd3-94cc-464ba49b8b79

