### PR TITLE
Add time-to-live (TTL) to blocks and mutes

### DIFF
--- a/src/components/PostControls/PostMenu/PostMenuItems.tsx
+++ b/src/components/PostControls/PostMenu/PostMenuItems.tsx
@@ -1,4 +1,4 @@
-import {memo, useMemo} from 'react'
+import {memo, useMemo, useState} from 'react'
 import {
   Platform,
   type PressableProps,
@@ -33,6 +33,10 @@ import {logger} from '#/logger'
 import {type Shadow} from '#/state/cache/post-shadow'
 import {useProfileShadow} from '#/state/cache/profile-shadow'
 import {useFeedFeedbackContext} from '#/state/feed-feedback'
+import {
+  calculateExpiresAt,
+  type ModerationTimeoutDuration,
+} from '#/state/moderation-timeouts'
 import {
   useHiddenPosts,
   useHiddenPostsApi,
@@ -92,6 +96,7 @@ import {
   ReportDialog,
   useReportDialogControl,
 } from '#/components/moderation/ReportDialog'
+import {TimeoutSelectDialog} from '#/components/moderation/TimeoutSelectDialog'
 import * as Prompt from '#/components/Prompt'
 import * as Toast from '#/components/Toast'
 import {useAnalytics} from '#/analytics'
@@ -141,13 +146,18 @@ let PostMenuItems = ({
   })
   const navigation = useNavigation<NavigationProp>()
   const {mutedWordsDialogControl} = useGlobalDialogsControlContext()
-  const blockPromptControl = useDialogControl()
   const reportDialogControl = useReportDialogControl()
   const deletePromptControl = useDialogControl()
   const hidePromptControl = useDialogControl()
   const postInteractionSettingsDialogControl = useDialogControl()
   const quotePostDetachConfirmControl = useDialogControl()
   const hideReplyConfirmControl = useDialogControl()
+  const muteTimeoutDialogControl = useDialogControl()
+  const blockTimeoutDialogControl = useDialogControl()
+  const [muteDuration, setMuteDuration] =
+    useState<ModerationTimeoutDuration>('forever')
+  const [blockDuration, setBlockDuration] =
+    useState<ModerationTimeoutDuration>('forever')
   const {mutateAsync: toggleReplyVisibility} =
     useToggleReplyVisibilityMutation()
 
@@ -420,10 +430,9 @@ let PostMenuItems = ({
     })
   }
 
-  const onBlockAuthor = async () => {
+  const onBlockAuthor = () => {
     try {
-      await queueBlock()
-      Toast.show(l({message: 'Account blocked', context: 'toast'}))
+      blockTimeoutDialogControl.open()
     } catch (err) {
       const e = err as Error
       if (e?.name !== 'AbortError') {
@@ -432,13 +441,27 @@ let PostMenuItems = ({
           type: 'error',
         })
       }
-    } finally {
+    }
+  }
+
+  const onConfirmBlockTimeout = async (duration: ModerationTimeoutDuration) => {
+    try {
+      await queueBlock({expiresAt: calculateExpiresAt(duration)})
+      Toast.show(l({message: 'Account blocked', context: 'toast'}))
       ax.metric('postMenu:blockAccount', {
         uri: postUri,
         authorDid: postAuthor.did,
         logContext,
         feedDescriptor: feedFeedback.feedDescriptor,
       })
+    } catch (err) {
+      const e = err as Error
+      if (e?.name !== 'AbortError') {
+        logger.error('Failed to block account', {message: e})
+        Toast.show(l`There was an issue! ${e.toString()}`, {
+          type: 'error',
+        })
+      }
     }
   }
 
@@ -464,23 +487,26 @@ let PostMenuItems = ({
         })
       }
     } else {
-      try {
-        await queueMute()
-        Toast.show(l({message: 'Account muted', context: 'toast'}))
-      } catch (err) {
-        const e = err as Error
-        if (e?.name !== 'AbortError') {
-          logger.error('Failed to mute account', {message: e})
-          Toast.show(l`There was an issue! ${e.toString()}`, {
-            type: 'error',
-          })
-        }
-      } finally {
-        ax.metric('postMenu:muteAccount', {
-          uri: postUri,
-          authorDid: postAuthor.did,
-          logContext,
-          feedDescriptor: feedFeedback.feedDescriptor,
+      muteTimeoutDialogControl.open()
+    }
+  }
+
+  const onConfirmMuteTimeout = async (duration: ModerationTimeoutDuration) => {
+    try {
+      await queueMute({expiresAt: calculateExpiresAt(duration)})
+      Toast.show(l({message: 'Account muted', context: 'toast'}))
+      ax.metric('postMenu:muteAccount', {
+        uri: postUri,
+        authorDid: postAuthor.did,
+        logContext,
+        feedDescriptor: feedFeedback.feedDescriptor,
+      })
+    } catch (err) {
+      const e = err as Error
+      if (e?.name !== 'AbortError') {
+        logger.error('Failed to mute account', {message: e})
+        Toast.show(l`There was an issue! ${e.toString()}`, {
+          type: 'error',
         })
       }
     }
@@ -745,7 +771,7 @@ let PostMenuItems = ({
                     <Menu.Item
                       testID="postDropdownBlockBtn"
                       label={l`Block account`}
-                      onPress={() => blockPromptControl.open()}>
+                      onPress={() => void onBlockAuthor()}>
                       <Menu.ItemText>{l`Block account`}</Menu.ItemText>
                       <Menu.ItemIcon icon={PersonX} position="right" />
                     </Menu.Item>
@@ -845,13 +871,25 @@ let PostMenuItems = ({
         onConfirm={() => void onToggleReplyVisibility()}
         confirmButtonCta={l`Yes, hide`}
       />
-      <Prompt.Basic
-        control={blockPromptControl}
-        title={l`Block Account?`}
-        description={l`Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you.`}
-        onConfirm={() => void onBlockAuthor()}
-        confirmButtonCta={l`Block`}
-        confirmButtonColor="negative"
+      <TimeoutSelectDialog
+        control={muteTimeoutDialogControl}
+        label={l`Choose how long to mute this account`}
+        title={l`Mute account`}
+        description={l`Choose whether this mute should be temporary or stay in place until you remove it.`}
+        confirmLabel={l`Mute account`}
+        value={muteDuration}
+        onChange={setMuteDuration}
+        onConfirm={onConfirmMuteTimeout}
+      />
+      <TimeoutSelectDialog
+        control={blockTimeoutDialogControl}
+        label={l`Choose how long to block this account`}
+        title={l`Block account`}
+        description={l`Choose whether this block should be temporary or stay in place until you remove it.`}
+        confirmLabel={l`Block account`}
+        value={blockDuration}
+        onChange={setBlockDuration}
+        onConfirm={onConfirmBlockTimeout}
       />
     </>
   )

--- a/src/components/dms/AfterReportDialog.tsx
+++ b/src/components/dms/AfterReportDialog.tsx
@@ -1,11 +1,16 @@
 import {memo, useState} from 'react'
 import {View} from 'react-native'
 import {type AppBskyActorDefs} from '@atproto/api'
+import {msg} from '@lingui/core/macro'
 import {Trans, useLingui} from '@lingui/react/macro'
 import {StackActions, useNavigation} from '@react-navigation/native'
 
 import {type NavigationProp} from '#/lib/routes/types'
 import {useProfileShadow} from '#/state/cache/profile-shadow'
+import {
+  calculateExpiresAt,
+  type ModerationTimeoutDuration,
+} from '#/state/moderation-timeouts'
 import {useLeaveConvo} from '#/state/queries/messages/leave-conversation'
 import {
   useProfileBlockMutationQueue,
@@ -16,6 +21,7 @@ import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import * as Toggle from '#/components/forms/Toggle'
 import {Loader} from '#/components/Loader'
+import {TimeoutSelectDialog} from '#/components/moderation/TimeoutSelectDialog'
 import * as Toast from '#/components/Toast'
 import {Text} from '#/components/Typography'
 import {IS_NATIVE} from '#/env'
@@ -121,9 +127,12 @@ function DoneStep({
   const {t: l} = useLingui()
   const navigation = useNavigation<NavigationProp>()
   const control = Dialog.useDialogContext()
+  const blockTimeoutControl = Dialog.useDialogControl()
   const {gtMobile} = useBreakpoints()
   const t = useTheme()
   const [actions, setActions] = useState<string[]>(['block', 'leave'])
+  const [blockDuration, setBlockDuration] =
+    useState<ModerationTimeoutDuration>('forever')
   const shadow = useProfileShadow(profile)
   const [queueBlock] = useProfileBlockMutationQueue(shadow)
 
@@ -156,19 +165,20 @@ function DoneStep({
   }
 
   const onPressPrimaryAction = () => {
-    control.close(() => {
-      if (actions.includes('block')) {
-        void queueBlock()
-      }
-      if (actions.includes('leave')) {
+    // If block is selected, open the timeout dialog instead of closing
+    if (actions.includes('block')) {
+      blockTimeoutControl.open()
+    } else {
+      // If only leaving, close and leave
+      control.close(() => {
         leaveConvo()
-      }
-      if (toastMsg) {
-        Toast.show(toastMsg, {
-          type: 'success',
-        })
-      }
-    })
+        if (toastMsg) {
+          Toast.show(toastMsg, {
+            type: 'success',
+          })
+        }
+      })
+    }
   }
 
   return (
@@ -218,6 +228,38 @@ function DoneStep({
           </ButtonText>
         </Button>
       </View>
+
+      <TimeoutSelectDialog
+        control={blockTimeoutControl}
+        label={l(msg`Choose how long to block this user`)}
+        title={l(msg`Block user`)}
+        description={l(
+          msg`Choose whether this block should be temporary or stay in place until you remove it.`,
+        )}
+        confirmLabel={l(msg`Block user`)}
+        value={blockDuration}
+        onChange={setBlockDuration}
+        onConfirm={async duration => {
+          try {
+            await queueBlock({expiresAt: calculateExpiresAt(duration)})
+            control.close(() => {
+              if (actions.includes('leave')) {
+                leaveConvo()
+              }
+              Toast.show(l({message: 'User blocked', context: 'toast'}), {
+                type: 'success',
+              })
+            })
+          } catch (e: unknown) {
+            const error = e instanceof Error ? e : new Error(String(e))
+            if (error.name !== 'AbortError') {
+              Toast.show(l(msg`There was an issue! ${error.toString()}`), {
+                type: 'error',
+              })
+            }
+          }
+        }}
+      />
     </View>
   )
 }

--- a/src/components/moderation/TimeoutSelectDialog.tsx
+++ b/src/components/moderation/TimeoutSelectDialog.tsx
@@ -1,0 +1,166 @@
+import {View} from 'react-native'
+import {Trans, useLingui} from '@lingui/react/macro'
+
+import {type ModerationTimeoutDuration} from '#/state/moderation-timeouts'
+import {atoms as a, useTheme} from '#/alf'
+import {Button, ButtonText} from '#/components/Button'
+import * as Dialog from '#/components/Dialog'
+import * as Toggle from '#/components/forms/Toggle'
+import {Text} from '#/components/Typography'
+
+export function TimeoutSelectDialog({
+  control,
+  label,
+  title,
+  description,
+  confirmLabel,
+  value,
+  onChange,
+  onConfirm,
+  confirmColor,
+}: {
+  control: Dialog.DialogControlProps
+  label: string
+  title: string
+  description: string
+  confirmLabel: string
+  value: ModerationTimeoutDuration
+  onChange: (duration: ModerationTimeoutDuration) => void
+  onConfirm: (duration: ModerationTimeoutDuration) => void | Promise<void>
+  confirmColor?: 'primary' | 'negative'
+}) {
+  const {t: l} = useLingui()
+  const t = useTheme()
+
+  return (
+    <Dialog.Outer control={control} nativeOptions={{preventExpansion: true}}>
+      <Dialog.Handle />
+      <Dialog.ScrollableInner label={label} style={[a.gap_2xl]}>
+        <View style={[a.gap_sm, a.pb_sm]}>
+          <Text style={[a.text_2xl, a.font_bold]}>{title}</Text>
+          <Text
+            style={[a.text_md, a.leading_snug, t.atoms.text_contrast_medium]}>
+            {description}
+          </Text>
+        </View>
+
+        <Toggle.Group
+          label={l`Choose a timeout duration`}
+          type="radio"
+          values={[value]}
+          onChange={values =>
+            onChange((values.at(0) || 'forever') as ModerationTimeoutDuration)
+          }>
+          <View style={[a.gap_2xs]}>
+            <Option
+              label={l`Forever`}
+              name="forever"
+              title={
+                <Text>
+                  <Trans>Forever</Trans>
+                </Text>
+              }
+              subtitle={
+                <Text>
+                  <Trans>Keep this action until you undo it.</Trans>
+                </Text>
+              }
+            />
+            <Option
+              label={l`24 hours`}
+              name="24_hours"
+              title={
+                <Text>
+                  <Trans>24 hours</Trans>
+                </Text>
+              }
+              subtitle={
+                <Text>
+                  <Trans>Lift it after one day.</Trans>
+                </Text>
+              }
+            />
+            <Option
+              label={l`7 days`}
+              name="7_days"
+              title={
+                <Text>
+                  <Trans>7 days</Trans>
+                </Text>
+              }
+              subtitle={
+                <Text>
+                  <Trans>Lift it after one week.</Trans>
+                </Text>
+              }
+            />
+            <Option
+              label={l`30 days`}
+              name="30_days"
+              title={
+                <Text>
+                  <Trans>30 days</Trans>
+                </Text>
+              }
+              subtitle={
+                <Text>
+                  <Trans>Lift it after one month.</Trans>
+                </Text>
+              }
+            />
+          </View>
+        </Toggle.Group>
+
+        <View style={[a.gap_sm, a.mt_md]}>
+          <Button
+            label={confirmLabel}
+            onPress={() => control.close(() => void onConfirm(value))}
+            size="large"
+            color={confirmColor ?? 'primary'}>
+            <ButtonText>{confirmLabel}</ButtonText>
+          </Button>
+          <Button
+            label={l`Cancel`}
+            onPress={() => control.close()}
+            size="large"
+            color="secondary">
+            <ButtonText>
+              <Trans>Cancel</Trans>
+            </ButtonText>
+          </Button>
+        </View>
+      </Dialog.ScrollableInner>
+    </Dialog.Outer>
+  )
+}
+
+function Option({
+  label,
+  name,
+  title,
+  subtitle,
+}: {
+  label: string
+  name: ModerationTimeoutDuration
+  title: React.ReactNode
+  subtitle: React.ReactNode
+}) {
+  const t = useTheme()
+  return (
+    <Toggle.Item label={label} name={name}>
+      {({selected}) => (
+        <Toggle.Panel active={selected}>
+          <Toggle.Radio />
+          <View style={[a.flex_1, a.gap_2xs]}>
+            <Toggle.LabelText style={[a.text_md, a.font_semi_bold]}>
+              {title}
+            </Toggle.LabelText>
+            <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+              {subtitle}
+            </Text>
+          </View>
+        </Toggle.Panel>
+      )}
+    </Toggle.Item>
+  )
+}

--- a/src/state/__tests__/moderation-timeouts.test.ts
+++ b/src/state/__tests__/moderation-timeouts.test.ts
@@ -1,0 +1,505 @@
+import {beforeEach, describe, expect, it, jest} from '@jest/globals'
+
+// Local test-only types. We avoid importing these from #/storage because this
+// test intentionally mocks that module.
+type TestModerationTimeoutRecord = {
+  expiresAt: string
+  uri?: string
+}
+
+type TestModerationTimeouts = {
+  blocks: Record<string, TestModerationTimeoutRecord>
+  mutes: Record<string, Omit<TestModerationTimeoutRecord, 'uri'>>
+}
+
+// Mock the account-scoped storage used by moderation-timeouts.ts.
+// The feature stores only local expiration metadata here; the actual
+// mute/block records remain managed by the Bluesky API.
+const mockStore: Record<string, unknown> = {}
+
+jest.mock('#/storage', () => ({
+  account: {
+    get: jest.fn((key: string[]) => mockStore[key.join('::')]),
+    set: jest.fn((key: string[], value: unknown) => {
+      mockStore[key.join('::')] = value
+    }),
+  },
+
+  // Some transitive imports from the app read device storage at module load
+  // time. Keep this mock narrow but compatible with the app test setup.
+  device: {
+    get: jest.fn(),
+    set: jest.fn(),
+    remove: jest.fn(),
+  },
+}))
+
+jest.mock('#/state/queries/my-blocked-accounts', () => ({
+  RQKEY: () => ['my-blocked-accounts'],
+}))
+
+jest.mock('#/state/queries/my-muted-accounts', () => ({
+  RQKEY: () => ['my-muted-accounts'],
+}))
+
+jest.mock('#/state/queries/profile', () => ({
+  RQKEY: (did: string) => ['profile', did],
+}))
+
+jest.mock('#/state/session', () => ({
+  useAgent: jest.fn(),
+  useSession: jest.fn(),
+}))
+
+jest.mock('#/state/shell', () => ({
+  useTickEveryMinute: jest.fn(() => 0),
+}))
+
+jest.mock('#/logger', () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}))
+
+import {
+  calculateExpiresAt,
+  clearModerationTimeout,
+  getModerationTimeoutRecord,
+  getModerationTimeouts,
+  isExpired,
+  type ModerationTimeoutDuration,
+  setModerationTimeout,
+  shouldKeepModerationEntry,
+} from '#/state/moderation-timeouts'
+
+const ACCOUNT_DID = 'did:plc:account'
+const OTHER_ACCOUNT_DID = 'did:plc:other-account'
+const TARGET_DID = 'did:plc:target'
+const OTHER_TARGET_DID = 'did:plc:other-target'
+
+const HOUR_MS = 60 * 60 * 1000
+const DAY_MS = 24 * HOUR_MS
+
+// Fixed timestamp used to make expiration calculation tests deterministic.
+const NOW = Date.parse('2026-05-28T12:00:00.000Z')
+
+function storageKey(accountDid: string) {
+  return `${accountDid}::moderationTimeouts`
+}
+
+function getStoredTimeouts(accountDid: string) {
+  return mockStore[storageKey(accountDid)] as TestModerationTimeouts | undefined
+}
+
+function setStoredTimeouts(accountDid: string, value: TestModerationTimeouts) {
+  mockStore[storageKey(accountDid)] = value
+}
+
+function futureDate(ms: number) {
+  return new Date(Date.now() + ms).toISOString()
+}
+
+function pastDate(ms: number) {
+  return new Date(Date.now() - ms).toISOString()
+}
+
+beforeEach(() => {
+  for (const key of Object.keys(mockStore)) {
+    delete mockStore[key]
+  }
+
+  jest.clearAllMocks()
+})
+
+describe('calculateExpiresAt', () => {
+  it('returns undefined for permanent moderation actions', () => {
+    expect(calculateExpiresAt('forever', NOW)).toBeUndefined()
+  })
+
+  it('calculates the expiration time for 24 hours', () => {
+    expect(calculateExpiresAt('24_hours', NOW)).toBe('2026-05-29T12:00:00.000Z')
+  })
+
+  it('calculates the expiration time for 7 days', () => {
+    expect(calculateExpiresAt('7_days', NOW)).toBe('2026-06-04T12:00:00.000Z')
+  })
+
+  it('calculates the expiration time for 30 days', () => {
+    expect(calculateExpiresAt('30_days', NOW)).toBe('2026-06-27T12:00:00.000Z')
+  })
+
+  it('returns future timestamps for every temporary duration', () => {
+    const durations: ModerationTimeoutDuration[] = [
+      '24_hours',
+      '7_days',
+      '30_days',
+    ]
+
+    for (const duration of durations) {
+      const expiresAt = calculateExpiresAt(duration)
+      expect(expiresAt).toBeDefined()
+      expect(Date.parse(expiresAt!)).toBeGreaterThan(Date.now())
+    }
+  })
+})
+
+describe('isExpired', () => {
+  it('returns false when no expiration date exists', () => {
+    expect(isExpired(undefined)).toBe(false)
+  })
+
+  it('returns false for a future expiration date', () => {
+    expect(isExpired(futureDate(DAY_MS))).toBe(false)
+  })
+
+  it('returns true for a past expiration date', () => {
+    expect(isExpired(pastDate(DAY_MS))).toBe(true)
+  })
+
+  it('returns true when the expiration date is exactly now or earlier', () => {
+    expect(isExpired(new Date(Date.now()).toISOString())).toBe(true)
+  })
+
+  it('returns false for an invalid expiration date', () => {
+    expect(isExpired('not-a-date')).toBe(false)
+  })
+})
+
+describe('getModerationTimeouts', () => {
+  it('returns an empty timeout structure when the account has no stored data', () => {
+    expect(getModerationTimeouts(ACCOUNT_DID)).toEqual({
+      blocks: {},
+      mutes: {},
+    })
+  })
+
+  it('returns the stored timeout data for an account', () => {
+    const stored: TestModerationTimeouts = {
+      blocks: {
+        [TARGET_DID]: {
+          expiresAt: futureDate(DAY_MS),
+          uri: 'at://did:plc:account/app.bsky.graph.block/abc',
+        },
+      },
+      mutes: {},
+    }
+
+    setStoredTimeouts(ACCOUNT_DID, stored)
+
+    expect(getModerationTimeouts(ACCOUNT_DID)).toEqual(stored)
+  })
+
+  it('does not read timeout data from another account', () => {
+    setStoredTimeouts(OTHER_ACCOUNT_DID, {
+      blocks: {
+        [TARGET_DID]: {
+          expiresAt: futureDate(DAY_MS),
+          uri: 'at://did:plc:other-account/app.bsky.graph.block/abc',
+        },
+      },
+      mutes: {},
+    })
+
+    expect(getModerationTimeouts(ACCOUNT_DID)).toEqual({
+      blocks: {},
+      mutes: {},
+    })
+  })
+})
+
+describe('getModerationTimeoutRecord', () => {
+  it('returns undefined when no record exists', () => {
+    expect(
+      getModerationTimeoutRecord(ACCOUNT_DID, 'block', TARGET_DID),
+    ).toBeUndefined()
+  })
+
+  it('returns a stored block timeout record', () => {
+    const record = {
+      expiresAt: futureDate(DAY_MS),
+      uri: 'at://did:plc:account/app.bsky.graph.block/abc',
+    }
+
+    setStoredTimeouts(ACCOUNT_DID, {
+      blocks: {
+        [TARGET_DID]: record,
+      },
+      mutes: {},
+    })
+
+    expect(
+      getModerationTimeoutRecord(ACCOUNT_DID, 'block', TARGET_DID),
+    ).toEqual(record)
+  })
+
+  it('returns a stored mute timeout record', () => {
+    const record = {
+      expiresAt: futureDate(7 * DAY_MS),
+    }
+
+    setStoredTimeouts(ACCOUNT_DID, {
+      blocks: {},
+      mutes: {
+        [TARGET_DID]: record,
+      },
+    })
+
+    expect(getModerationTimeoutRecord(ACCOUNT_DID, 'mute', TARGET_DID)).toEqual(
+      record,
+    )
+  })
+
+  it('does not return records from another account', () => {
+    setStoredTimeouts(OTHER_ACCOUNT_DID, {
+      blocks: {
+        [TARGET_DID]: {
+          expiresAt: futureDate(DAY_MS),
+          uri: 'at://did:plc:other-account/app.bsky.graph.block/abc',
+        },
+      },
+      mutes: {},
+    })
+
+    expect(
+      getModerationTimeoutRecord(ACCOUNT_DID, 'block', TARGET_DID),
+    ).toBeUndefined()
+  })
+})
+
+describe('shouldKeepModerationEntry', () => {
+  it('keeps entries with no local timeout metadata', () => {
+    expect(shouldKeepModerationEntry(ACCOUNT_DID, 'block', TARGET_DID)).toBe(
+      true,
+    )
+  })
+
+  it('keeps entries with a future expiration date', () => {
+    setStoredTimeouts(ACCOUNT_DID, {
+      blocks: {
+        [TARGET_DID]: {
+          expiresAt: futureDate(DAY_MS),
+          uri: 'at://did:plc:account/app.bsky.graph.block/abc',
+        },
+      },
+      mutes: {},
+    })
+
+    expect(shouldKeepModerationEntry(ACCOUNT_DID, 'block', TARGET_DID)).toBe(
+      true,
+    )
+  })
+
+  it('does not keep entries with a past expiration date', () => {
+    setStoredTimeouts(ACCOUNT_DID, {
+      blocks: {
+        [TARGET_DID]: {
+          expiresAt: pastDate(DAY_MS),
+          uri: 'at://did:plc:account/app.bsky.graph.block/abc',
+        },
+      },
+      mutes: {},
+    })
+
+    expect(shouldKeepModerationEntry(ACCOUNT_DID, 'block', TARGET_DID)).toBe(
+      false,
+    )
+  })
+
+  it('works for mute timeout records', () => {
+    setStoredTimeouts(ACCOUNT_DID, {
+      blocks: {},
+      mutes: {
+        [TARGET_DID]: {
+          expiresAt: pastDate(DAY_MS),
+        },
+      },
+    })
+
+    expect(shouldKeepModerationEntry(ACCOUNT_DID, 'mute', TARGET_DID)).toBe(
+      false,
+    )
+  })
+
+  it('checks timeout metadata only for the requested account', () => {
+    setStoredTimeouts(OTHER_ACCOUNT_DID, {
+      blocks: {
+        [TARGET_DID]: {
+          expiresAt: pastDate(DAY_MS),
+          uri: 'at://did:plc:other-account/app.bsky.graph.block/abc',
+        },
+      },
+      mutes: {},
+    })
+
+    expect(shouldKeepModerationEntry(ACCOUNT_DID, 'block', TARGET_DID)).toBe(
+      true,
+    )
+  })
+})
+
+describe('setModerationTimeout', () => {
+  it('stores a block timeout record', () => {
+    const record = {
+      expiresAt: futureDate(DAY_MS),
+      uri: 'at://did:plc:account/app.bsky.graph.block/abc',
+    }
+
+    setModerationTimeout(ACCOUNT_DID, 'block', TARGET_DID, record)
+
+    expect(getStoredTimeouts(ACCOUNT_DID)?.blocks[TARGET_DID]).toEqual(record)
+  })
+
+  it('stores a mute timeout record', () => {
+    const record = {
+      expiresAt: futureDate(7 * DAY_MS),
+    }
+
+    setModerationTimeout(ACCOUNT_DID, 'mute', TARGET_DID, record)
+
+    expect(getStoredTimeouts(ACCOUNT_DID)?.mutes[TARGET_DID]).toEqual(record)
+  })
+
+  it('overwrites an existing timeout for the same target', () => {
+    const first = {
+      expiresAt: futureDate(DAY_MS),
+    }
+    const second = {
+      expiresAt: futureDate(7 * DAY_MS),
+    }
+
+    setModerationTimeout(ACCOUNT_DID, 'mute', TARGET_DID, first)
+    setModerationTimeout(ACCOUNT_DID, 'mute', TARGET_DID, second)
+
+    expect(getStoredTimeouts(ACCOUNT_DID)?.mutes[TARGET_DID]).toEqual(second)
+  })
+
+  it('does not remove timeout records for other targets', () => {
+    setModerationTimeout(ACCOUNT_DID, 'mute', TARGET_DID, {
+      expiresAt: futureDate(DAY_MS),
+    })
+    setModerationTimeout(ACCOUNT_DID, 'mute', OTHER_TARGET_DID, {
+      expiresAt: futureDate(7 * DAY_MS),
+    })
+
+    setModerationTimeout(ACCOUNT_DID, 'mute', TARGET_DID, undefined)
+
+    expect(getStoredTimeouts(ACCOUNT_DID)?.mutes[TARGET_DID]).toBeUndefined()
+    expect(
+      getStoredTimeouts(ACCOUNT_DID)?.mutes[OTHER_TARGET_DID],
+    ).toBeDefined()
+  })
+
+  it('keeps timeout records isolated between accounts', () => {
+    const accountRecord = {
+      expiresAt: futureDate(DAY_MS),
+      uri: 'at://did:plc:account/app.bsky.graph.block/abc',
+    }
+    const otherAccountRecord = {
+      expiresAt: futureDate(7 * DAY_MS),
+      uri: 'at://did:plc:other-account/app.bsky.graph.block/def',
+    }
+
+    setModerationTimeout(ACCOUNT_DID, 'block', TARGET_DID, accountRecord)
+    setModerationTimeout(
+      OTHER_ACCOUNT_DID,
+      'block',
+      TARGET_DID,
+      otherAccountRecord,
+    )
+
+    expect(getStoredTimeouts(ACCOUNT_DID)?.blocks[TARGET_DID]).toEqual(
+      accountRecord,
+    )
+    expect(getStoredTimeouts(OTHER_ACCOUNT_DID)?.blocks[TARGET_DID]).toEqual(
+      otherAccountRecord,
+    )
+  })
+})
+
+describe('clearModerationTimeout', () => {
+  it('clears a block timeout record', () => {
+    setModerationTimeout(ACCOUNT_DID, 'block', TARGET_DID, {
+      expiresAt: futureDate(DAY_MS),
+      uri: 'at://did:plc:account/app.bsky.graph.block/abc',
+    })
+
+    clearModerationTimeout(ACCOUNT_DID, 'block', TARGET_DID)
+
+    expect(getStoredTimeouts(ACCOUNT_DID)?.blocks[TARGET_DID]).toBeUndefined()
+  })
+
+  it('clears a mute timeout record', () => {
+    setModerationTimeout(ACCOUNT_DID, 'mute', TARGET_DID, {
+      expiresAt: futureDate(DAY_MS),
+    })
+
+    clearModerationTimeout(ACCOUNT_DID, 'mute', TARGET_DID)
+
+    expect(getStoredTimeouts(ACCOUNT_DID)?.mutes[TARGET_DID]).toBeUndefined()
+  })
+
+  it('does not throw when clearing a missing timeout record', () => {
+    expect(() => {
+      clearModerationTimeout(ACCOUNT_DID, 'block', TARGET_DID)
+    }).not.toThrow()
+  })
+
+  it('does not clear timeout records from another account', () => {
+    setModerationTimeout(ACCOUNT_DID, 'block', TARGET_DID, {
+      expiresAt: futureDate(DAY_MS),
+      uri: 'at://did:plc:account/app.bsky.graph.block/abc',
+    })
+    setModerationTimeout(OTHER_ACCOUNT_DID, 'block', TARGET_DID, {
+      expiresAt: futureDate(DAY_MS),
+      uri: 'at://did:plc:other-account/app.bsky.graph.block/def',
+    })
+
+    clearModerationTimeout(ACCOUNT_DID, 'block', TARGET_DID)
+
+    expect(getStoredTimeouts(ACCOUNT_DID)?.blocks[TARGET_DID]).toBeUndefined()
+    expect(
+      getStoredTimeouts(OTHER_ACCOUNT_DID)?.blocks[TARGET_DID],
+    ).toBeDefined()
+  })
+})
+
+describe('temporary moderation flow', () => {
+  it('stores a temporary block and hides it after expiration', () => {
+    setModerationTimeout(ACCOUNT_DID, 'block', TARGET_DID, {
+      expiresAt: pastDate(1),
+      uri: 'at://did:plc:account/app.bsky.graph.block/abc',
+    })
+
+    expect(shouldKeepModerationEntry(ACCOUNT_DID, 'block', TARGET_DID)).toBe(
+      false,
+    )
+  })
+
+  it('stores a temporary mute and keeps it before expiration', () => {
+    setModerationTimeout(ACCOUNT_DID, 'mute', TARGET_DID, {
+      expiresAt: futureDate(DAY_MS),
+    })
+
+    expect(shouldKeepModerationEntry(ACCOUNT_DID, 'mute', TARGET_DID)).toBe(
+      true,
+    )
+  })
+
+  it('keeps each account independent during the same target moderation flow', () => {
+    setModerationTimeout(ACCOUNT_DID, 'block', TARGET_DID, {
+      expiresAt: pastDate(DAY_MS),
+      uri: 'at://did:plc:account/app.bsky.graph.block/abc',
+    })
+    setModerationTimeout(OTHER_ACCOUNT_DID, 'block', TARGET_DID, {
+      expiresAt: futureDate(DAY_MS),
+      uri: 'at://did:plc:other-account/app.bsky.graph.block/def',
+    })
+
+    expect(shouldKeepModerationEntry(ACCOUNT_DID, 'block', TARGET_DID)).toBe(
+      false,
+    )
+    expect(
+      shouldKeepModerationEntry(OTHER_ACCOUNT_DID, 'block', TARGET_DID),
+    ).toBe(true)
+  })
+})

--- a/src/state/moderation-timeouts.ts
+++ b/src/state/moderation-timeouts.ts
@@ -1,0 +1,185 @@
+import {useEffect, useRef} from 'react'
+import {AtUri} from '@atproto/api'
+import {useQueryClient} from '@tanstack/react-query'
+
+import {logger} from '#/logger'
+import {RQKEY as MY_BLOCKED_RQKEY} from '#/state/queries/my-blocked-accounts'
+import {RQKEY as MY_MUTED_RQKEY} from '#/state/queries/my-muted-accounts'
+import {RQKEY as PROFILE_RQKEY} from '#/state/queries/profile'
+import {useAgent, useSession} from '#/state/session'
+import {useTickEveryMinute} from '#/state/shell'
+import {
+  account,
+  type ModerationTimeoutRecord,
+  type ModerationTimeouts,
+} from '#/storage'
+
+export type ModerationTimeoutKind = 'block' | 'mute'
+export type ModerationTimeoutDuration =
+  | 'forever'
+  | '24_hours'
+  | '7_days'
+  | '30_days'
+
+const ONE_DAY = 24 * 60 * 60 * 1000
+
+const defaultModerationTimeouts: ModerationTimeouts = {
+  blocks: {},
+  mutes: {},
+}
+
+function getKindKey(kind: ModerationTimeoutKind) {
+  return kind === 'block' ? 'blocks' : 'mutes'
+}
+
+export function getModerationTimeouts(accountDid: string): ModerationTimeouts {
+  return (
+    account.get([accountDid, 'moderationTimeouts']) ?? defaultModerationTimeouts
+  )
+}
+
+function cloneModerationTimeouts(accountDid: string): ModerationTimeouts {
+  const timeouts = getModerationTimeouts(accountDid)
+  return {
+    blocks: {...timeouts.blocks},
+    mutes: {...timeouts.mutes},
+  }
+}
+
+export function calculateExpiresAt(
+  duration: ModerationTimeoutDuration,
+  now = Date.now(),
+): string | undefined {
+  switch (duration) {
+    case '24_hours':
+      return new Date(now + ONE_DAY).toISOString()
+    case '7_days':
+      return new Date(now + 7 * ONE_DAY).toISOString()
+    case '30_days':
+      return new Date(now + 30 * ONE_DAY).toISOString()
+    case 'forever':
+      return undefined
+  }
+}
+
+export function isExpired(expiresAt?: string) {
+  return Boolean(expiresAt && Date.parse(expiresAt) <= Date.now())
+}
+
+export function getModerationTimeoutRecord(
+  accountDid: string,
+  kind: ModerationTimeoutKind,
+  did: string,
+) {
+  return getModerationTimeouts(accountDid)[getKindKey(kind)][did]
+}
+
+export function shouldKeepModerationEntry(
+  accountDid: string,
+  kind: ModerationTimeoutKind,
+  did: string,
+) {
+  const record = getModerationTimeoutRecord(accountDid, kind, did)
+  return !record || !isExpired(record.expiresAt)
+}
+
+export function setModerationTimeout(
+  accountDid: string,
+  kind: ModerationTimeoutKind,
+  did: string,
+  record?: ModerationTimeoutRecord,
+) {
+  const next = cloneModerationTimeouts(accountDid)
+  const kindKey = getKindKey(kind)
+
+  if (record) {
+    next[kindKey][did] = record
+  } else {
+    delete next[kindKey][did]
+  }
+
+  account.set([accountDid, 'moderationTimeouts'], next)
+}
+
+export function clearModerationTimeout(
+  accountDid: string,
+  kind: ModerationTimeoutKind,
+  did: string,
+) {
+  setModerationTimeout(accountDid, kind, did, undefined)
+}
+
+export function useModerationTimeoutCleanup() {
+  const tick = useTickEveryMinute()
+  const {currentAccount} = useSession()
+  const agent = useAgent()
+  const queryClient = useQueryClient()
+  const isRunning = useRef(false)
+
+  useEffect(() => {
+    if (!currentAccount) return
+    if (isRunning.current) return
+
+    const timeouts = getModerationTimeouts(currentAccount.did)
+    const expiredBlockEntries = Object.entries(timeouts.blocks).filter(
+      ([, record]) => isExpired(record.expiresAt),
+    )
+    const expiredMuteEntries = Object.entries(timeouts.mutes).filter(
+      ([, record]) => isExpired(record.expiresAt),
+    )
+
+    if (!expiredBlockEntries.length && !expiredMuteEntries.length) {
+      return
+    }
+
+    isRunning.current = true
+
+    void (async () => {
+      const nextTimeouts = cloneModerationTimeouts(currentAccount.did)
+
+      try {
+        for (const [did, record] of expiredBlockEntries) {
+          if (!record.uri) {
+            delete nextTimeouts.blocks[did]
+            continue
+          }
+
+          try {
+            const {rkey} = new AtUri(record.uri)
+            await agent.app.bsky.graph.block.delete({
+              repo: currentAccount.did,
+              rkey,
+            })
+            delete nextTimeouts.blocks[did]
+          } catch (e: unknown) {
+            logger.error('Failed to clean up expired block timeout', {
+              message: e,
+            })
+          }
+        }
+
+        for (const [did] of expiredMuteEntries) {
+          try {
+            await agent.unmute(did)
+            delete nextTimeouts.mutes[did]
+          } catch (e: unknown) {
+            logger.error('Failed to clean up expired mute timeout', {
+              message: e,
+            })
+          }
+        }
+
+        account.set([currentAccount.did, 'moderationTimeouts'], nextTimeouts)
+
+        void queryClient.invalidateQueries({queryKey: MY_BLOCKED_RQKEY()})
+        void queryClient.invalidateQueries({queryKey: MY_MUTED_RQKEY()})
+
+        for (const [did] of [...expiredBlockEntries, ...expiredMuteEntries]) {
+          void queryClient.invalidateQueries({queryKey: PROFILE_RQKEY(did)})
+        }
+      } finally {
+        isRunning.current = false
+      }
+    })()
+  }, [agent, currentAccount, queryClient, tick])
+}

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -25,6 +25,10 @@ import {useToggleMutationQueue} from '#/lib/hooks/useToggleMutationQueue'
 import {updateProfileShadow} from '#/state/cache/profile-shadow'
 import {type Shadow} from '#/state/cache/types'
 import {type ImageMeta} from '#/state/gallery'
+import {
+  clearModerationTimeout,
+  setModerationTimeout,
+} from '#/state/moderation-timeouts'
 import {STALE} from '#/state/queries'
 import {resetProfilePostsQueries} from '#/state/queries/post-feed'
 import {RQKEY as PROFILE_FOLLOWS_RQKEY} from '#/state/queries/profile-follows'
@@ -420,6 +424,7 @@ export function useProfileMuteMutationQueue(
 ) {
   const ax = useAnalytics()
   const queryClient = useQueryClient()
+  const {currentAccount} = useSession()
   const did = profile.did
   const initialMuted = profile.viewer?.muted
   const muteMutation = useProfileMuteMutation()
@@ -448,21 +453,42 @@ export function useProfileMuteMutationQueue(
     },
   })
 
-  const queueMute = useCallback(() => {
-    // optimistically update
-    updateProfileShadow(queryClient, did, {
-      muted: true,
-    })
-    return queueToggle(true)
-  }, [queryClient, did, queueToggle])
+  const queueMute = useCallback(
+    async ({expiresAt}: {expiresAt?: string} = {}) => {
+      // optimistically update
+      updateProfileShadow(queryClient, did, {
+        muted: true,
+      })
+      const finalMuted = await queueToggle(true)
+      if (finalMuted) {
+        if (currentAccount) {
+          setModerationTimeout(
+            currentAccount.did,
+            'mute',
+            did,
+            expiresAt ? {expiresAt} : undefined,
+          )
+        }
+      }
+      return finalMuted
+    },
+    [currentAccount, queryClient, did, queueToggle],
+  )
 
   const queueUnmute = useCallback(() => {
     // optimistically update
     updateProfileShadow(queryClient, did, {
       muted: false,
     })
-    return queueToggle(false)
-  }, [queryClient, did, queueToggle])
+    return queueToggle(false).then(async finalMuted => {
+      if (!finalMuted) {
+        if (currentAccount) {
+          clearModerationTimeout(currentAccount.did, 'mute', did)
+        }
+      }
+      return finalMuted
+    })
+  }, [currentAccount, queryClient, did, queueToggle])
 
   return [queueMute, queueUnmute] as const
 }
@@ -498,6 +524,7 @@ export function useProfileBlockMutationQueue(
 ) {
   const ax = useAnalytics()
   const queryClient = useQueryClient()
+  const {currentAccount} = useSession()
   const did = profile.did
   const initialBlockingUri = profile.viewer?.blocking
   const blockMutation = useProfileBlockMutation()
@@ -532,21 +559,42 @@ export function useProfileBlockMutationQueue(
     },
   })
 
-  const queueBlock = useCallback(() => {
-    // optimistically update
-    updateProfileShadow(queryClient, did, {
-      blockingUri: 'pending',
-    })
-    return queueToggle(true)
-  }, [queryClient, did, queueToggle])
+  const queueBlock = useCallback(
+    async ({expiresAt}: {expiresAt?: string} = {}) => {
+      // optimistically update
+      updateProfileShadow(queryClient, did, {
+        blockingUri: 'pending',
+      })
+      const finalBlockingUri = await queueToggle(true)
+      if (finalBlockingUri) {
+        if (currentAccount) {
+          setModerationTimeout(
+            currentAccount.did,
+            'block',
+            did,
+            expiresAt ? {expiresAt, uri: finalBlockingUri} : undefined,
+          )
+        }
+      }
+      return finalBlockingUri
+    },
+    [currentAccount, queryClient, did, queueToggle],
+  )
 
   const queueUnblock = useCallback(() => {
     // optimistically update
     updateProfileShadow(queryClient, did, {
       blockingUri: undefined,
     })
-    return queueToggle(false)
-  }, [queryClient, did, queueToggle])
+    return queueToggle(false).then(async finalBlockingUri => {
+      if (!finalBlockingUri) {
+        if (currentAccount) {
+          clearModerationTimeout(currentAccount.did, 'block', did)
+        }
+      }
+      return finalBlockingUri
+    })
+  }, [currentAccount, queryClient, did, queueToggle])
 
   return [queueBlock, queueUnblock] as const
 }

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -69,6 +69,16 @@ export type Device = {
   [PolicyUpdate202508]?: boolean
 }
 
+export type ModerationTimeoutRecord = {
+  expiresAt: string
+  uri?: string
+}
+
+export type ModerationTimeouts = {
+  blocks: Record<string, ModerationTimeoutRecord>
+  mutes: Record<string, Omit<ModerationTimeoutRecord, 'uri'>>
+}
+
 export type Account = {
   searchTermHistory?: string[]
   searchAccountHistory?: string[]
@@ -85,4 +95,10 @@ export type Account = {
    * Recently selected GIFs in the GIF picker. Most recent first, capped at 20.
    */
   recentGifs?: Gif[]
+
+  /**
+   * Local expiration metadata for temporary mutes and blocks.
+   * The actual moderation records are still stored by the Bluesky API.
+   */
+  moderationTimeouts?: ModerationTimeouts
 }

--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -1,4 +1,4 @@
-import {memo, useCallback, useMemo} from 'react'
+import {memo, useCallback, useMemo, useState} from 'react'
 import {type AppBskyActorDefs} from '@atproto/api'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
@@ -13,6 +13,10 @@ import {shareText, shareUrl} from '#/lib/sharing'
 import {toShareUrl} from '#/lib/strings/url-helpers'
 import {type Shadow} from '#/state/cache/types'
 import {useModalControls} from '#/state/modals'
+import {
+  calculateExpiresAt,
+  type ModerationTimeoutDuration,
+} from '#/state/moderation-timeouts'
 import {Nux, useNux, useSaveNux} from '#/state/queries/nuxs'
 import {
   RQKEY as profileQueryKey,
@@ -50,6 +54,7 @@ import {
   ReportDialog,
   useReportDialogControl,
 } from '#/components/moderation/ReportDialog'
+import {TimeoutSelectDialog} from '#/components/moderation/TimeoutSelectDialog'
 import * as Prompt from '#/components/Prompt'
 import * as Toast from '#/components/Toast'
 import {useFullVerificationState} from '#/components/verification'
@@ -102,11 +107,16 @@ let ProfileMenu = ({
     'ProfileMenu',
   )
 
-  const blockPromptControl = Prompt.usePromptControl()
   const loggedOutWarningPromptControl = Prompt.usePromptControl()
   const goLiveDialogControl = useDialogControl()
   const goLiveDisabledDialogControl = useDialogControl()
   const addToStarterPacksDialogControl = useDialogControl()
+  const muteTimeoutDialogControl = useDialogControl()
+  const blockTimeoutDialogControl = useDialogControl()
+  const [muteDuration, setMuteDuration] =
+    useState<ModerationTimeoutDuration>('forever')
+  const [blockDuration, setBlockDuration] =
+    useState<ModerationTimeoutDuration>('forever')
 
   const showLoggedOutWarning = useMemo(() => {
     return (
@@ -155,21 +165,12 @@ let ProfileMenu = ({
         }
       }
     } else {
-      try {
-        await queueMute()
-        Toast.show(_(msg({message: 'Account muted', context: 'toast'})))
-      } catch (e: any) {
-        if (e?.name !== 'AbortError') {
-          ax.logger.error('Failed to mute account', {message: e})
-          Toast.show(_(msg`There was an issue! ${e.toString()}`), {
-            type: 'error',
-          })
-        }
-      }
+      setMuteDuration('forever')
+      muteTimeoutDialogControl.open()
     }
-  }, [ax, profile.viewer?.muted, queueUnmute, _, queueMute])
+  }, [ax, profile.viewer?.muted, queueUnmute, _, muteTimeoutDialogControl])
 
-  const blockAccount = useCallback(async () => {
+  const onPressBlockAccount = useCallback(async () => {
     if (profile.viewer?.blocking) {
       try {
         await queueUnblock()
@@ -183,8 +184,32 @@ let ProfileMenu = ({
         }
       }
     } else {
+      setBlockDuration('forever')
+      blockTimeoutDialogControl.open()
+    }
+  }, [ax, profile.viewer?.blocking, _, queueUnblock, blockTimeoutDialogControl])
+
+  const onConfirmMuteTimeout = useCallback(
+    async (duration: ModerationTimeoutDuration) => {
       try {
-        await queueBlock()
+        await queueMute({expiresAt: calculateExpiresAt(duration)})
+        Toast.show(_(msg({message: 'Account muted', context: 'toast'})))
+      } catch (e: any) {
+        if (e?.name !== 'AbortError') {
+          ax.logger.error('Failed to mute account', {message: e})
+          Toast.show(_(msg`There was an issue! ${e.toString()}`), {
+            type: 'error',
+          })
+        }
+      }
+    },
+    [ax, _, queueMute],
+  )
+
+  const onConfirmBlockTimeout = useCallback(
+    async (duration: ModerationTimeoutDuration) => {
+      try {
+        await queueBlock({expiresAt: calculateExpiresAt(duration)})
         Toast.show(_(msg({message: 'Account blocked', context: 'toast'})))
       } catch (e: any) {
         if (e?.name !== 'AbortError') {
@@ -194,8 +219,9 @@ let ProfileMenu = ({
           })
         }
       }
-    }
-  }, [ax, profile.viewer?.blocking, _, queueUnblock, queueBlock])
+    },
+    [ax, _, queueBlock],
+  )
 
   const onPressFollowAccount = useCallback(async () => {
     try {
@@ -464,11 +490,11 @@ let ProfileMenu = ({
                       <Menu.Item
                         testID="profileHeaderDropdownBlockBtn"
                         label={
-                          profile.viewer
+                          profile.viewer?.blocking
                             ? _(msg`Unblock account`)
                             : _(msg`Block account`)
                         }
-                        onPress={() => blockPromptControl.open()}>
+                        onPress={onPressBlockAccount}>
                         <Menu.ItemText>
                           {profile.viewer?.blocking ? (
                             <Trans>Unblock account</Trans>
@@ -538,31 +564,31 @@ let ProfileMenu = ({
         }}
       />
 
-      <Prompt.Basic
-        control={blockPromptControl}
-        title={
-          profile.viewer?.blocking
-            ? _(msg`Unblock Account?`)
-            : _(msg`Block Account?`)
-        }
-        description={
-          profile.viewer?.blocking
-            ? _(
-                msg`The account will be able to interact with you after unblocking.`,
-              )
-            : profile.associated?.labeler
-              ? _(
-                  msg`Blocking will not prevent labels from being applied on your account, but it will stop this account from replying in your threads or interacting with you.`,
-                )
-              : _(
-                  msg`Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you.`,
-                )
-        }
-        onConfirm={blockAccount}
-        confirmButtonCta={
-          profile.viewer?.blocking ? _(msg`Unblock`) : _(msg`Block`)
-        }
-        confirmButtonColor={profile.viewer?.blocking ? undefined : 'negative'}
+      <TimeoutSelectDialog
+        control={muteTimeoutDialogControl}
+        label={_(msg`Choose how long to mute this account`)}
+        title={_(msg`Mute account`)}
+        description={_(
+          msg`Choose whether this mute should be temporary or stay in place until you remove it.`,
+        )}
+        confirmLabel={_(msg`Mute`)}
+        value={muteDuration}
+        onChange={setMuteDuration}
+        onConfirm={onConfirmMuteTimeout}
+      />
+
+      <TimeoutSelectDialog
+        control={blockTimeoutDialogControl}
+        label={_(msg`Choose how long to block this account`)}
+        title={_(msg`Block account`)}
+        description={_(
+          msg`Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you. Choose whether this block should be temporary or permanent.`,
+        )}
+        confirmLabel={_(msg`Block`)}
+        confirmColor="negative"
+        value={blockDuration}
+        onChange={setBlockDuration}
+        onConfirm={onConfirmBlockTimeout}
       />
 
       <Prompt.Basic

--- a/src/view/screens/ModerationBlockedAccounts.tsx
+++ b/src/view/screens/ModerationBlockedAccounts.tsx
@@ -1,14 +1,21 @@
 import {useCallback, useMemo, useState} from 'react'
 import {type StyleProp, View, type ViewStyle} from 'react-native'
 import {type AppBskyActorDefs as ActorDefs} from '@atproto/api'
+import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
 import {type NativeStackScreenProps} from '@react-navigation/native-stack'
 
 import {type CommonNavigatorParams} from '#/lib/routes/types'
 import {cleanError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
+import {
+  getModerationTimeoutRecord,
+  isExpired,
+} from '#/state/moderation-timeouts'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useMyBlockedAccountsQuery} from '#/state/queries/my-blocked-accounts'
+import {useSession} from '#/state/session'
+import {useTickEveryMinute} from '#/state/shell'
 import {ErrorScreen} from '#/view/com/util/error/ErrorScreen'
 import {List} from '#/view/com/util/List'
 import {atoms as a, useTheme} from '#/alf'
@@ -23,7 +30,10 @@ type Props = NativeStackScreenProps<
 >
 export function ModerationBlockedAccounts({}: Props) {
   const t = useTheme()
+  const {i18n} = useLingui()
   const moderationOpts = useModerationOpts()
+  const {currentAccount} = useSession()
+  const tick = useTickEveryMinute()
 
   const [isPTRing, setIsPTRing] = useState(false)
   const {
@@ -36,13 +46,24 @@ export function ModerationBlockedAccounts({}: Props) {
     fetchNextPage,
     isFetchingNextPage,
   } = useMyBlockedAccountsQuery()
-  const isEmpty = !isFetching && !data?.pages[0]?.blocks.length
   const profiles = useMemo(() => {
-    if (data?.pages) {
-      return data.pages.flatMap(page => page.blocks)
+    if (!currentAccount || !data?.pages) {
+      return []
     }
-    return []
-  }, [data])
+
+    return data.pages
+      .flatMap(page => page.blocks)
+      .filter(block => {
+        const timeout = getModerationTimeoutRecord(
+          currentAccount.did,
+          'block',
+          block.did,
+        )
+        return !timeout || !isExpired(timeout.expiresAt)
+      })
+  }, [currentAccount, data, tick])
+
+  const isEmpty = !isFetching && profiles.length === 0
 
   const onRefresh = useCallback(async () => {
     setIsPTRing(true)
@@ -72,15 +93,29 @@ export function ModerationBlockedAccounts({}: Props) {
     index: number
   }) => {
     if (!moderationOpts) return null
+    const timeout = currentAccount
+      ? getModerationTimeoutRecord(currentAccount.did, 'block', item.did)
+      : undefined
     return (
       <View
         style={[a.py_md, a.px_xl, a.border_t, t.atoms.border_contrast_low]}
         key={item.did}>
-        <ProfileCard.Default
-          testID={`blockedAccount-${index}`}
-          profile={item}
-          moderationOpts={moderationOpts}
-        />
+        <View style={[a.gap_xs]}>
+          <ProfileCard.Default
+            testID={`blockedAccount-${index}`}
+            profile={item}
+            moderationOpts={moderationOpts}
+          />
+          {timeout?.expiresAt && !isExpired(timeout.expiresAt) ? (
+            <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+              <Trans>Expires on</Trans>{' '}
+              {i18n.date(new Date(timeout.expiresAt), {
+                dateStyle: 'medium',
+                timeStyle: 'short',
+              })}
+            </Text>
+          ) : null}
+        </View>
       </View>
     )
   }

--- a/src/view/screens/ModerationMutedAccounts.tsx
+++ b/src/view/screens/ModerationMutedAccounts.tsx
@@ -1,14 +1,21 @@
 import {useCallback, useMemo, useState} from 'react'
 import {type StyleProp, View, type ViewStyle} from 'react-native'
 import {type AppBskyActorDefs as ActorDefs} from '@atproto/api'
+import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
 import {type NativeStackScreenProps} from '@react-navigation/native-stack'
 
 import {type CommonNavigatorParams} from '#/lib/routes/types'
 import {cleanError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
+import {
+  getModerationTimeoutRecord,
+  isExpired,
+} from '#/state/moderation-timeouts'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useMyMutedAccountsQuery} from '#/state/queries/my-muted-accounts'
+import {useSession} from '#/state/session'
+import {useTickEveryMinute} from '#/state/shell'
 import {ErrorScreen} from '#/view/com/util/error/ErrorScreen'
 import {List} from '#/view/com/util/List'
 import {atoms as a, useTheme} from '#/alf'
@@ -23,7 +30,10 @@ type Props = NativeStackScreenProps<
 >
 export function ModerationMutedAccounts({}: Props) {
   const t = useTheme()
+  const {i18n} = useLingui()
   const moderationOpts = useModerationOpts()
+  const {currentAccount} = useSession()
+  const tick = useTickEveryMinute()
 
   const [isPTRing, setIsPTRing] = useState(false)
   const {
@@ -36,13 +46,24 @@ export function ModerationMutedAccounts({}: Props) {
     fetchNextPage,
     isFetchingNextPage,
   } = useMyMutedAccountsQuery()
-  const isEmpty = !isFetching && !data?.pages[0]?.mutes.length
   const profiles = useMemo(() => {
-    if (data?.pages) {
-      return data.pages.flatMap(page => page.mutes)
+    if (!currentAccount || !data?.pages) {
+      return []
     }
-    return []
-  }, [data])
+
+    return data.pages
+      .flatMap(page => page.mutes)
+      .filter(mute => {
+        const timeout = getModerationTimeoutRecord(
+          currentAccount.did,
+          'mute',
+          mute.did,
+        )
+        return !timeout || !isExpired(timeout.expiresAt)
+      })
+  }, [currentAccount, data, tick])
+
+  const isEmpty = !isFetching && profiles.length === 0
 
   const onRefresh = useCallback(async () => {
     setIsPTRing(true)
@@ -72,29 +93,43 @@ export function ModerationMutedAccounts({}: Props) {
     index: number
   }) => {
     if (!moderationOpts) return null
+    const timeout = currentAccount
+      ? getModerationTimeoutRecord(currentAccount.did, 'mute', item.did)
+      : undefined
     return (
       <View
         style={[a.py_md, a.px_xl, a.border_t, t.atoms.border_contrast_low]}
         key={item.did}>
-        <ProfileCard.Link profile={item} testID={`mutedAccount-${index}`}>
-          <ProfileCard.Outer>
-            <ProfileCard.Header>
-              <ProfileCard.Avatar
+        <View style={[a.gap_xs]}>
+          <ProfileCard.Link profile={item} testID={`mutedAccount-${index}`}>
+            <ProfileCard.Outer>
+              <ProfileCard.Header>
+                <ProfileCard.Avatar
+                  profile={item}
+                  moderationOpts={moderationOpts}
+                />
+                <ProfileCard.NameAndHandle
+                  profile={item}
+                  moderationOpts={moderationOpts}
+                />
+              </ProfileCard.Header>
+              <ProfileCard.Labels
                 profile={item}
                 moderationOpts={moderationOpts}
               />
-              <ProfileCard.NameAndHandle
-                profile={item}
-                moderationOpts={moderationOpts}
-              />
-            </ProfileCard.Header>
-            <ProfileCard.Labels
-              profile={item}
-              moderationOpts={moderationOpts}
-            />
-            <ProfileCard.Description profile={item} />
-          </ProfileCard.Outer>
-        </ProfileCard.Link>
+              <ProfileCard.Description profile={item} />
+            </ProfileCard.Outer>
+          </ProfileCard.Link>
+          {timeout?.expiresAt && !isExpired(timeout.expiresAt) ? (
+            <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+              <Trans>Expires on</Trans>{' '}
+              {i18n.date(new Date(timeout.expiresAt), {
+                dateStyle: 'medium',
+                timeStyle: 'short',
+              })}
+            </Text>
+          ) : null}
+        </View>
       </View>
     )
   }

--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -12,6 +12,7 @@ import {useNotificationsHandler} from '#/lib/hooks/useNotificationHandler'
 import {useNotificationsRegistration} from '#/lib/notifications/notifications'
 import {isStateAtTabRoot} from '#/lib/routes/helpers'
 import {useDialogFullyExpandedCountContext} from '#/state/dialogs'
+import {useModerationTimeoutCleanup} from '#/state/moderation-timeouts'
 import {useSession} from '#/state/session'
 import {
   useIsDrawerOpen,
@@ -53,6 +54,8 @@ import {DrawerContent} from './Drawer'
 function ShellInner() {
   const insets = useSafeAreaInsets()
   const {state: policyUpdateState} = usePolicyUpdateContext()
+
+  useModerationTimeoutCleanup()
 
   const closeAnyActiveElement = useCloseAnyActiveElement()
 


### PR DESCRIPTION
### Feature: 

Allows users to choose whether a mute or block should be permanent or temporary (24 hours, 7 days, or 30 days). 

### Implementation details:
-  Architecture: App-level implementation requiring no changes to the AT Protocol. Continues to use existing APIs while storing local expiration metadata (target DID, expiration time, and block record URI).

-  Storage: Metadata is stored in account-scoped storage to ensure temporary moderation actions from one account do not affect another account on the same device.

-  Logic & Hooks: Introduced src/state/moderation-timeouts.ts and the useModerationTimeoutCleanup() hook, which runs periodically in the app shell to remove expired actions and invalidate UI queries. Profile mutation queues were extended to accept an optional expiresAt value.

-  UI: Added TimeoutSelectDialog to profile menus, post menus, and the after-report flow. Moderation settings screens now read local timeout metadata, hide expired entries, and display expiration info.

-  Testing: Added comprehensive unit tests in src/state/__tests__/moderation-timeouts.test.ts covering expiration logic, storage, and account separation.

### Linked Issue:

-  #8003 

### Co-Author:

-  @Miguel-Alfaiao