### PR TITLE
[Chat] Fix overflowing chat names

### DIFF
--- a/src/screens/Messages/components/MessagesListGroupInfoPanel.tsx
+++ b/src/screens/Messages/components/MessagesListGroupInfoPanel.tsx
@@ -94,7 +94,7 @@ export function MessagesListGroupInfoPanel({
         />
         {convo.details.name ? (
           <Text
-            style={[a.text_2xl, a.font_bold, a.mt_lg, a.px_lg, t.atoms.text]}>
+            style={[a.text_2xl, a.font_bold, a.mt_lg, a.px_xl, a.text_center]}>
             {convo.details.name}
           </Text>
         ) : null}

--- a/src/screens/Messages/components/MessagesListInfoPanel.tsx
+++ b/src/screens/Messages/components/MessagesListInfoPanel.tsx
@@ -55,8 +55,12 @@ export function MessagesListInfoPanel({
           a.justify_center,
           a.gap_xs,
           a.mt_lg,
+          a.px_xl,
+          a.max_w_full,
         ]}>
-        <Text style={[a.text_2xl, a.font_bold, t.atoms.text]}>
+        <Text
+          style={[a.text_2xl, a.font_bold, a.text_center, a.flex_shrink]}
+          numberOfLines={1}>
           {displayName}
         </Text>
         <ProfileBadges profile={profile} size="lg" />


### PR DESCRIPTION
Resolves [APP-2330](https://linear.app/blueskyweb/issue/APP-2330/truncate-long-display-names-in-profile-header)

- Direct: clamp to 1 line, add padding
- Group: center align

<img width="398" height="353" alt="Screenshot 2026-06-08 at 12 05 19" src="https://github.com/user-attachments/assets/2c2d57f3-96cc-4490-b218-c86dd5f61aa7" />
<img width="398" height="271" alt="Screenshot 2026-06-08 at 12 11 40" src="https://github.com/user-attachments/assets/2817f384-3a84-4640-972e-0005e9a0a9e6" />
