### PR TITLE
Show accept/reject footer for empty request convos

### DIFF
--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -709,16 +709,16 @@ function getFooterState(
   convoState: ActiveConvoStates,
   hasAcceptOverride?: boolean,
 ): FooterState {
+  if (convoState.convo.view.status === 'request' && !hasAcceptOverride) {
+    return 'request'
+  }
+
   if (convoState.items.length === 0) {
     if (convoState.isFetchingHistory) {
       return 'loading'
     } else {
       return 'new-chat'
     }
-  }
-
-  if (convoState.convo.view.status === 'request' && !hasAcceptOverride) {
-    return 'request'
   }
 
   return 'standard'


### PR DESCRIPTION
## What

Fixes a bug where a pending chat request with no messages yet showed the message composer instead of the accept/reject footer.

## Cause

In `getFooterState()` (`MessagesList.tsx`), the `items.length === 0` check ran before the `request` status check, so an empty request convo returned `new-chat` (composer) and never reached the `request` branch (`ChatStatusInfo`).

## Fix

Check the `request` status first, so a pending request renders its accept/reject footer regardless of message count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)