### PR TITLE
[Chat] Rename invite route to /chat/

### DIFF
--- a/__tests__/lib/strings/url-helpers.test.ts
+++ b/__tests__/lib/strings/url-helpers.test.ts
@@ -184,39 +184,39 @@ describe('getChatInviteCodeFromUrl', () => {
   type Case = [string, string | undefined]
 
   const cases: Case[] = [
-    ['https://bsky.app/c/abcdefg', 'abcdefg'],
-    ['https://bsky.app/c/abcdefghij', 'abcdefghij'],
+    ['https://bsky.app/chat/abcdefg', 'abcdefg'],
+    ['https://bsky.app/chat/abcdefghij', 'abcdefghij'],
     // http is not recognized as a bsky.app url
-    ['http://bsky.app/c/abcdefg', undefined],
-    ['https://bsky.app/c/abcdefg?utm=foo', 'abcdefg'],
-    ['https://bsky.app/c/abcdefg#section', 'abcdefg'],
-    ['/c/abcdefg', 'abcdefg'],
-    ['/c/abcdefg?utm=foo', 'abcdefg'],
-    ['/c/abcdefg#section', 'abcdefg'],
+    ['http://bsky.app/chat/abcdefg', undefined],
+    ['https://bsky.app/chat/abcdefg?utm=foo', 'abcdefg'],
+    ['https://bsky.app/chat/abcdefg#section', 'abcdefg'],
+    ['/chat/abcdefg', 'abcdefg'],
+    ['/chat/abcdefg?utm=foo', 'abcdefg'],
+    ['/chat/abcdefg#section', 'abcdefg'],
 
     // too short
-    ['https://bsky.app/c/abcdef', undefined],
-    ['/c/abcdef', undefined],
+    ['https://bsky.app/chat/abcdef', undefined],
+    ['/chat/abcdef', undefined],
     // too long
-    ['https://bsky.app/c/abcdefghijk', undefined],
-    ['/c/abcdefghijk', undefined],
+    ['https://bsky.app/chat/abcdefghijk', undefined],
+    ['/chat/abcdefghijk', undefined],
     // invalid characters
-    ['https://bsky.app/c/abc-def', undefined],
-    ['/c/abc def', undefined],
+    ['https://bsky.app/chat/abc-def', undefined],
+    ['/chat/abc def', undefined],
     // trailing path
-    ['https://bsky.app/c/abcdefg/extra', undefined],
-    ['/c/abcdefg/extra', undefined],
+    ['https://bsky.app/chat/abcdefg/extra', undefined],
+    ['/chat/abcdefg/extra', undefined],
     // wrong path
     ['https://bsky.app/profile/abcdefg', undefined],
-    ['https://bsky.app/c', undefined],
+    ['https://bsky.app/chat', undefined],
     // wrong host
-    ['https://example.com/c/abcdefg', undefined],
+    ['https://example.com/chat/abcdefg', undefined],
     // not a url, not a path
-    ['c/abcdefg', undefined],
+    ['chat/abcdefg', undefined],
     ['abcdefg', undefined],
     ['', undefined],
     // malformed url
-    ['https://[invalid/c/abcdefg', undefined],
+    ['https://[invalid/chat/abcdefg', undefined],
   ]
 
   it.each(cases)('given input %p, returns %p', (input, expected) => {

--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -88,7 +88,7 @@ func serve(cctx *cli.Context) error {
 		Host:   appviewHost,
 	}
 
-	// optional client for the chat appview, used by /c/<code> for OG previews.
+	// optional client for the chat appview, used by /chat/<code> for OG previews.
 	var chatXrpcc *xrpc.Client
 	if chatHost != "" {
 		chatXrpcc = &xrpc.Client{
@@ -367,7 +367,7 @@ func serve(cctx *cli.Context) error {
 	e.GET("/start/:handleOrDID/:rkey", server.WebStarterPack)
 
 	// chat invites
-	e.GET("/c/:code", server.WebChatInvite)
+	e.GET("/chat/:code", server.WebChatInvite)
 
 	// bookmarks
 	e.GET("/saved", server.WebGeneric)
@@ -695,7 +695,7 @@ func (srv *Server) WebChatInvite(c echo.Context) error {
 
 	data["title"] = preview.Name
 	if srv.cfg.ogcardHost != "" {
-		// bskyogcard registers this route as /chat-invite/:code, not /c/:code.
+		// bskyogcard registers this route as /chat-invite/:code, not /chat/:code.
 		data["imgThumbUrl"] = fmt.Sprintf("%s/chat-invite/%s", srv.cfg.ogcardHost, code)
 	}
 	return c.Render(http.StatusOK, "chatinvite.html", data)

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -804,7 +804,7 @@ const LINKING = {
       return buildStateObject('Flat', 'Home', params)
     }
 
-    // Chat invite URLs (`/c/:code`) are handled by `useIntentHandler`, which
+    // Chat invite URLs (`/chat/:code`) are handled by `useIntentHandler`, which
     // opens the GroupChatJoinDialog (or the logged-out join flow). Route the
     // path to Home so the dialog overlays Home instead of NotFound. On native,
     // react-navigation strips the `bluesky://` prefix and passes the path

--- a/src/components/Post/Embed/ChatInviteEmbed.tsx
+++ b/src/components/Post/Embed/ChatInviteEmbed.tsx
@@ -8,7 +8,7 @@ import {JoinRequestEmbedBody} from '#/components/Post/Embed/JoinRequestEmbed'
 
 /**
  * Renders a chat invite link found in an `app.bsky.embed.external` embed (e.g.
- * a `bsky.app/c/<code>` link posted to the feed) as a join request card,
+ * a `bsky.app/chat/<code>` link posted to the feed) as a join request card,
  * falling back to a plain external embed if the invite can't be resolved.
  */
 export function ChatInviteEmbed({

--- a/src/components/dms/ChatInvite/Root.tsx
+++ b/src/components/dms/ChatInvite/Root.tsx
@@ -78,7 +78,7 @@ export function Root({
         color: 'primary',
         disabled: false,
         onPress: () => {
-          void setStringAsync(`https://bsky.app/c/${preview.code}`)
+          void setStringAsync(`https://bsky.app/chat/${preview.code}`)
           Toast.show(l`Copied to clipboard`, {type: 'success'})
         },
       }

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -179,7 +179,7 @@ export function isBskyStarterPackUrl(url: string): boolean {
 }
 
 // Invite codes are 7 alphanumeric characters long, supporting up to 10 here to future-proof.
-export const CHAT_INVITE_CODE_REGEX = /^\/c\/([a-zA-Z0-9]{7,10})$/
+export const CHAT_INVITE_CODE_REGEX = /^\/chat\/([a-zA-Z0-9]{7,10})$/
 
 export function getChatInviteCodeFromUrl(url: string): string | undefined {
   let pathname: string

--- a/src/screens/Messages/components/InviteLinkDialog.tsx
+++ b/src/screens/Messages/components/InviteLinkDialog.tsx
@@ -292,7 +292,7 @@ export function InviteLinkDialog({
       const linkEnabled = joinLink?.enabledStatus === 'enabled'
       const linkDisabled = joinLink?.enabledStatus === 'disabled'
       const joinLinkURI = joinLink?.code
-        ? `https://bsky.app/c/${joinLink.code}`
+        ? `https://bsky.app/chat/${joinLink.code}`
         : 'https://bsky.app/'
       const createdAt = joinLink ? new Date(joinLink.createdAt) : null
       const currentOption =


### PR DESCRIPTION
Decided `/c/:code` is pretty ugly compared to `/chat/:code`