### PR TITLE
Refactor photo embed analytics to post:photoEmbed:* namespace

### DIFF
--- a/src/analytics/metrics/types.ts
+++ b/src/analytics/metrics/types.ts
@@ -1179,24 +1179,24 @@ export type Events = {
   'post:photoEmbed:impression': {
     layout: 'single' | 'grid' | 'carousel'
     totalImages: number
-    uri: string
-    authorDid: string
+    postUri: string
+    postAuthorDid: string
     feedDescriptor?: string
   }
   'post:photoEmbed:open': {
     layout: 'single' | 'grid' | 'carousel'
     fromImage: number
     totalImages: number
-    uri: string
-    authorDid: string
+    postUri: string
+    postAuthorDid: string
     feedDescriptor?: string
   }
   'post:photoEmbed:carouselSwipe': {
     fromImage: number
     toImage: number
     totalImages: number
-    uri: string
-    authorDid: string
+    postUri: string
+    postAuthorDid: string
     feedDescriptor?: string
   }
   'post:photoEmbed:lightboxSwipe': {
@@ -1204,8 +1204,8 @@ export type Events = {
     fromImage: number
     toImage: number
     totalImages: number
-    uri: string
-    authorDid: string
+    postUri: string
+    postAuthorDid: string
     feedDescriptor?: string
   }
 }

--- a/src/analytics/metrics/types.ts
+++ b/src/analytics/metrics/types.ts
@@ -1175,18 +1175,37 @@ export type Events = {
   'profile:associated:germ:self-disconnect': {}
   'profile:associated:germ:self-reconnect': {}
 
-  // Gallery carousel events
-  'post:gallery:swipe': {
+  // Post photo embed events
+  'post:photoEmbed:impression': {
+    layout: 'single' | 'grid' | 'carousel'
+    totalImages: number
+    uri: string
+    authorDid: string
+    feedDescriptor?: string
+  }
+  'post:photoEmbed:open': {
+    layout: 'single' | 'grid' | 'carousel'
+    fromImage: number
+    totalImages: number
+    uri: string
+    authorDid: string
+    feedDescriptor?: string
+  }
+  'post:photoEmbed:carouselSwipe': {
     fromImage: number
     toImage: number
     totalImages: number
+    uri: string
+    authorDid: string
+    feedDescriptor?: string
   }
-  'post:gallery:openLightbox': {
+  'post:photoEmbed:lightboxSwipe': {
+    layout: 'single' | 'grid' | 'carousel'
     fromImage: number
+    toImage: number
     totalImages: number
-  }
-  'post:gallery:impression': {
-    totalImages: number
-    postUri: string
+    uri: string
+    authorDid: string
+    feedDescriptor?: string
   }
 }

--- a/src/components/Lightbox/pager/ImagePager.tsx
+++ b/src/components/Lightbox/pager/ImagePager.tsx
@@ -39,6 +39,7 @@ import {type Dimensions} from '#/lib/media/types'
 import {useTheme} from '#/alf'
 import {setSystemUITheme} from '#/alf/util/systemUI'
 import {type Lightbox} from '#/components/Lightbox/state'
+import {useAnalytics} from '#/analytics'
 import {IS_IOS} from '#/env'
 import {PlatformInfo} from '../../../../modules/expo-bluesky-swiss-army'
 import {Footer} from '../chrome/Footer'
@@ -228,7 +229,8 @@ function ImageView({
   openProgress: SharedValue<number>
   thumbRects: SharedValue<Record<number, MeasuredDimensions | null>>
 }) {
-  const {images, index: initialImageIndex} = lightbox
+  const {images, index: initialImageIndex, metricsContext} = lightbox
+  const ax = useAnalytics()
   const isAnimated = useMemo(() => canAnimate(lightbox), [lightbox])
   const [isScaled, setIsScaled] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
@@ -377,7 +379,21 @@ function ImageView({
         scrollEnabled={!isScaled}
         initialPage={initialImageIndex}
         onPageSelected={e => {
-          setImageIndex(e.nativeEvent.position)
+          const next = e.nativeEvent.position
+          setImageIndex(prev => {
+            if (metricsContext && prev !== next) {
+              ax.metric('post:photoEmbed:lightboxSwipe', {
+                layout: metricsContext.layout,
+                fromImage: prev + 1,
+                toImage: next + 1,
+                totalImages: images.length,
+                uri: metricsContext.uri,
+                authorDid: metricsContext.authorDid,
+                feedDescriptor: metricsContext.feedDescriptor,
+              })
+            }
+            return next
+          })
           setIsScaled(false)
         }}
         onPageScrollStateChanged={e => {

--- a/src/components/Lightbox/pager/ImagePager.tsx
+++ b/src/components/Lightbox/pager/ImagePager.tsx
@@ -387,8 +387,8 @@ function ImageView({
                 fromImage: prev + 1,
                 toImage: next + 1,
                 totalImages: images.length,
-                uri: metricsContext.uri,
-                authorDid: metricsContext.authorDid,
+                postUri: metricsContext.postUri,
+                postAuthorDid: metricsContext.postAuthorDid,
                 feedDescriptor: metricsContext.feedDescriptor,
               })
             }

--- a/src/components/Lightbox/state.tsx
+++ b/src/components/Lightbox/state.tsx
@@ -13,8 +13,8 @@ import {type ImageSource} from '#/components/Lightbox/types'
 
 export type LightboxMetricsContext = {
   layout: 'single' | 'grid' | 'carousel'
-  uri: string
-  authorDid: string
+  postUri: string
+  postAuthorDid: string
   feedDescriptor?: string
 }
 

--- a/src/components/Lightbox/state.tsx
+++ b/src/components/Lightbox/state.tsx
@@ -11,10 +11,20 @@ import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {useHotkeysContext} from '#/lib/hotkeys'
 import {type ImageSource} from '#/components/Lightbox/types'
 
+export type LightboxMetricsContext = {
+  layout: 'single' | 'grid' | 'carousel'
+  uri: string
+  authorDid: string
+  feedDescriptor?: string
+}
+
 export type Lightbox = {
   id: string
   images: ImageSource[]
   index: number
+  // Set for post photo embeds so the lightbox can emit post:photoEmbed:lightboxSwipe.
+  // Left unset for non-post contexts (e.g. profile avatar/banner lightbox).
+  metricsContext?: LightboxMetricsContext
 }
 
 const LightboxContext = createContext<{

--- a/src/components/Post/Embed/ImageEmbed.tsx
+++ b/src/components/Post/Embed/ImageEmbed.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react'
+import {useEffect, useRef} from 'react'
 import {InteractionManager, View} from 'react-native'
 import {type AnimatedRef} from 'react-native-reanimated'
 import {Image} from 'expo-image'
@@ -8,7 +8,10 @@ import {atoms as a, tokens} from '#/alf'
 import {AutoSizedImage} from '#/components/images/AutoSizedImage'
 import {Gallery} from '#/components/images/Gallery'
 import {ImageLayoutGrid} from '#/components/images/ImageLayoutGrid'
-import {useLightboxControls} from '#/components/Lightbox/state'
+import {
+  type LightboxMetricsContext,
+  useLightboxControls,
+} from '#/components/Lightbox/state'
 import {type Dimensions} from '#/components/Lightbox/types'
 import {ImageContextMenu} from '#/components/Post/Embed/ImageContextMenu'
 import {PostEmbedViewContext} from '#/components/Post/Embed/types'
@@ -40,6 +43,35 @@ export function ImageEmbed({
       ? images.length > MAX_GRID_IMAGES
       : ax.features.enabled(ax.features.PostGalleryEmbedEnable)
 
+  const layout: 'single' | 'grid' | 'carousel' =
+    images.length === 1 ? 'single' : useExpandedLayout ? 'carousel' : 'grid'
+
+  const postContext =
+    rest.uri && rest.authorDid
+      ? {
+          uri: rest.uri,
+          authorDid: rest.authorDid,
+          feedDescriptor: rest.feedDescriptor,
+        }
+      : undefined
+  const metricsContext: LightboxMetricsContext | undefined = postContext
+    ? {layout, ...postContext}
+    : undefined
+
+  // Impression: one per mount of a post photo embed. Covers all three layouts
+  // identically so the opens/impressions CTR is unbiased by layout.
+  useEffect(() => {
+    if (images.length > 0 && postContext) {
+      ax.metric('post:photoEmbed:impression', {
+        layout,
+        totalImages: images.length,
+        ...postContext,
+      })
+    }
+    // Fire once per mount; intentionally not reactive to post context changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   // Captured from AutoSizedImage so the peek-commit handler can reuse the same
   // ref + dims that a tap would — keeps the lightbox's return animation intact.
   const singleContainerRef = useRef<AnimatedRef<any> | null>(null)
@@ -57,6 +89,14 @@ export function ImageEmbed({
       refs: AnimatedRef<any>[],
       fetchedDims: (Dimensions | null)[],
     ) => {
+      if (postContext) {
+        ax.metric('post:photoEmbed:open', {
+          layout,
+          fromImage: index + 1,
+          totalImages: images.length,
+          ...postContext,
+        })
+      }
       openLightbox({
         images: items.map((item, i) => ({
           ...item,
@@ -67,6 +107,7 @@ export function ImageEmbed({
           type: 'image',
         })),
         index,
+        metricsContext,
       })
     }
     const onPressIn = (_: number) => {
@@ -132,6 +173,7 @@ export function ImageEmbed({
             onPressIn={onPressIn}
             viewContext={rest.viewContext}
             isWithinQuote={rest.isWithinQuote}
+            metricsPostContext={postContext}
           />
         </View>
       )

--- a/src/components/Post/Embed/ImageEmbed.tsx
+++ b/src/components/Post/Embed/ImageEmbed.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef} from 'react'
+import {useRef} from 'react'
 import {InteractionManager, View} from 'react-native'
 import {type AnimatedRef} from 'react-native-reanimated'
 import {Image} from 'expo-image'
@@ -56,20 +56,6 @@ export function ImageEmbed({
   const metricsContext: LightboxMetricsContext | undefined = postContext
     ? {layout, ...postContext}
     : undefined
-
-  // Impression: one per mount of a post photo embed. Covers all three layouts
-  // identically so the opens/impressions CTR is unbiased by layout.
-  useEffect(() => {
-    if (images.length > 0 && postContext) {
-      ax.metric('post:photoEmbed:impression', {
-        layout,
-        totalImages: images.length,
-        ...postContext,
-      })
-    }
-    // Fire once per mount; intentionally not reactive to post context changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
   // Captured from AutoSizedImage so the peek-commit handler can reuse the same
   // ref + dims that a tap would — keeps the lightbox's return animation intact.

--- a/src/components/Post/Embed/ImageEmbed.tsx
+++ b/src/components/Post/Embed/ImageEmbed.tsx
@@ -46,14 +46,13 @@ export function ImageEmbed({
   const layout: 'single' | 'grid' | 'carousel' =
     images.length === 1 ? 'single' : useExpandedLayout ? 'carousel' : 'grid'
 
-  const postContext =
-    rest.uri && rest.authorDid
-      ? {
-          uri: rest.uri,
-          authorDid: rest.authorDid,
-          feedDescriptor: rest.feedDescriptor,
-        }
-      : undefined
+  const postContext = rest.post
+    ? {
+        uri: rest.post.uri,
+        authorDid: rest.post.author.did,
+        feedDescriptor: rest.feedDescriptor,
+      }
+    : undefined
   const metricsContext: LightboxMetricsContext | undefined = postContext
     ? {layout, ...postContext}
     : undefined

--- a/src/components/Post/Embed/ImageEmbed.tsx
+++ b/src/components/Post/Embed/ImageEmbed.tsx
@@ -48,8 +48,8 @@ export function ImageEmbed({
 
   const postContext = rest.post
     ? {
-        uri: rest.post.uri,
-        authorDid: rest.post.author.did,
+        postUri: rest.post.uri,
+        postAuthorDid: rest.post.author.did,
         feedDescriptor: rest.feedDescriptor,
       }
     : undefined

--- a/src/components/Post/Embed/index.tsx
+++ b/src/components/Post/Embed/index.tsx
@@ -345,6 +345,10 @@ export function QuoteEmbed({
           allowNestedQuotes={
             parentIsWithinQuote ? false : parentAllowNestedQuotes
           }
+          // The photo embed belongs to the quoted post, so attribute its
+          // analytics to the quoted post rather than the parent.
+          uri={quote.uri}
+          authorDid={quote.author.did}
         />
       )}
     </>

--- a/src/components/Post/Embed/index.tsx
+++ b/src/components/Post/Embed/index.tsx
@@ -347,8 +347,7 @@ export function QuoteEmbed({
           }
           // The photo embed belongs to the quoted post, so attribute its
           // analytics to the quoted post rather than the parent.
-          uri={quote.uri}
-          authorDid={quote.author.did}
+          post={quote}
         />
       )}
     </>

--- a/src/components/Post/Embed/types.ts
+++ b/src/components/Post/Embed/types.ts
@@ -15,6 +15,12 @@ export type CommonProps = {
   viewContext?: PostEmbedViewContext
   isWithinQuote?: boolean
   allowNestedQuotes?: boolean
+  // Post context for analytics on photo embed events (post:photoEmbed:*).
+  // When the embed has no owning post (e.g. previews), leave these undefined
+  // and no events will be emitted.
+  uri?: string
+  authorDid?: string
+  feedDescriptor?: string
 }
 
 export type EmbedProps = CommonProps & {

--- a/src/components/Post/Embed/types.ts
+++ b/src/components/Post/Embed/types.ts
@@ -15,11 +15,12 @@ export type CommonProps = {
   viewContext?: PostEmbedViewContext
   isWithinQuote?: boolean
   allowNestedQuotes?: boolean
-  // Post context for analytics on photo embed events (post:photoEmbed:*).
-  // When the embed has no owning post (e.g. previews), leave these undefined
-  // and no events will be emitted.
-  uri?: string
-  authorDid?: string
+  /**
+   * The post that contains this embed. Used for analytics on photo embed
+   * events (post:photoEmbed:*). When the embed has no owning post (e.g.
+   * composer previews), leave this undefined and no events will be emitted.
+   */
+  post?: AppBskyFeedDefs.PostView
   feedDescriptor?: string
 }
 

--- a/src/components/images/Gallery/index.tsx
+++ b/src/components/images/Gallery/index.tsx
@@ -55,6 +55,13 @@ interface GalleryProps {
   onPressIn?: (index: number) => void
   viewContext?: PostEmbedViewContext
   isWithinQuote?: boolean
+  // Post context for the in-feed carousel swipe metric. Omit for non-post
+  // contexts (no event will be emitted).
+  metricsPostContext?: {
+    uri: string
+    authorDid: string
+    feedDescriptor?: string
+  }
 }
 
 const Context = createContext<{
@@ -99,6 +106,7 @@ export function Gallery({
   onPressIn,
   viewContext,
   isWithinQuote,
+  metricsPostContext,
 }: GalleryProps) {
   const {t: l} = useLingui()
   const ax = useAnalytics()
@@ -169,13 +177,17 @@ export function Gallery({
   const emitSwipeMetric = useMemo(
     () =>
       debounce((fromIndex: number, toIndex: number) => {
-        ax.metric('post:gallery:swipe', {
+        if (!metricsPostContext) return
+        ax.metric('post:photoEmbed:carouselSwipe', {
           fromImage: fromIndex + 1, // convert to 1-based index for easier analysis
           toImage: toIndex + 1, // convert to 1-based index for easier analysis
           totalImages: images.length,
+          uri: metricsPostContext.uri,
+          authorDid: metricsPostContext.authorDid,
+          feedDescriptor: metricsPostContext.feedDescriptor,
         })
       }, 200),
-    [ax, images.length],
+    [ax, images.length, metricsPostContext],
   )
 
   const setCurrentIndex = (index: number) => {
@@ -277,10 +289,6 @@ export function Gallery({
           renderItem={({item, index}) => {
             const openLightboxAtIndex = onPress
               ? () => {
-                  ax.metric('post:gallery:openLightbox', {
-                    fromImage: index + 1, // convert to 1-based index for easier analysis
-                    totalImages: images.length,
-                  })
                   const refs: AnimatedRef<any>[] = []
                   const dims: (Dimensions | null)[] = []
                   for (let i = 0; i < images.length; i++) {

--- a/src/components/images/Gallery/index.tsx
+++ b/src/components/images/Gallery/index.tsx
@@ -58,8 +58,8 @@ interface GalleryProps {
   // Post context for the in-feed carousel swipe metric. Omit for non-post
   // contexts (no event will be emitted).
   metricsPostContext?: {
-    uri: string
-    authorDid: string
+    postUri: string
+    postAuthorDid: string
     feedDescriptor?: string
   }
 }
@@ -182,8 +182,8 @@ export function Gallery({
           fromImage: fromIndex + 1, // convert to 1-based index for easier analysis
           toImage: toIndex + 1, // convert to 1-based index for easier analysis
           totalImages: images.length,
-          uri: metricsPostContext.uri,
-          authorDid: metricsPostContext.authorDid,
+          postUri: metricsPostContext.postUri,
+          postAuthorDid: metricsPostContext.postAuthorDid,
           feedDescriptor: metricsPostContext.feedDescriptor,
         })
       }, 200),

--- a/src/screens/PostThread/components/ThreadItemAnchor.tsx
+++ b/src/screens/PostThread/components/ThreadItemAnchor.tsx
@@ -414,8 +414,7 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
                     moderation={moderation}
                     viewContext={PostEmbedViewContext.ThreadHighlighted}
                     onOpen={onOpenEmbed}
-                    uri={post.uri}
-                    authorDid={post.author.did}
+                    post={post}
                   />
                 </View>
               )}

--- a/src/screens/PostThread/components/ThreadItemAnchor.tsx
+++ b/src/screens/PostThread/components/ThreadItemAnchor.tsx
@@ -415,6 +415,7 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
                     viewContext={PostEmbedViewContext.ThreadHighlighted}
                     onOpen={onOpenEmbed}
                     post={post}
+                    feedDescriptor={feedFeedback.feedDescriptor}
                   />
                 </View>
               )}

--- a/src/screens/PostThread/components/ThreadItemAnchor.tsx
+++ b/src/screens/PostThread/components/ThreadItemAnchor.tsx
@@ -414,6 +414,8 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
                     moderation={moderation}
                     viewContext={PostEmbedViewContext.ThreadHighlighted}
                     onOpen={onOpenEmbed}
+                    uri={post.uri}
+                    authorDid={post.author.did}
                   />
                 </View>
               )}

--- a/src/screens/PostThread/components/ThreadItemPost.tsx
+++ b/src/screens/PostThread/components/ThreadItemPost.tsx
@@ -349,8 +349,7 @@ const ThreadItemPostInner = memo(function ThreadItemPostInner({
                     embed={post.embed}
                     moderation={moderation}
                     viewContext={PostEmbedViewContext.Feed}
-                    uri={post.uri}
-                    authorDid={post.author.did}
+                    post={post}
                   />
                 </View>
               )}

--- a/src/screens/PostThread/components/ThreadItemPost.tsx
+++ b/src/screens/PostThread/components/ThreadItemPost.tsx
@@ -349,6 +349,8 @@ const ThreadItemPostInner = memo(function ThreadItemPostInner({
                     embed={post.embed}
                     moderation={moderation}
                     viewContext={PostEmbedViewContext.Feed}
+                    uri={post.uri}
+                    authorDid={post.author.did}
                   />
                 </View>
               )}

--- a/src/screens/PostThread/components/ThreadItemTreePost.tsx
+++ b/src/screens/PostThread/components/ThreadItemTreePost.tsx
@@ -371,6 +371,8 @@ const ThreadItemTreePostInner = memo(function ThreadItemTreePostInner({
                         embed={post.embed}
                         moderation={moderation}
                         viewContext={PostEmbedViewContext.Feed}
+                        uri={post.uri}
+                        authorDid={post.author.did}
                       />
                     </View>
                   )}

--- a/src/screens/PostThread/components/ThreadItemTreePost.tsx
+++ b/src/screens/PostThread/components/ThreadItemTreePost.tsx
@@ -371,8 +371,7 @@ const ThreadItemTreePostInner = memo(function ThreadItemTreePostInner({
                         embed={post.embed}
                         moderation={moderation}
                         viewContext={PostEmbedViewContext.Feed}
-                        uri={post.uri}
-                        authorDid={post.author.did}
+                        post={post}
                       />
                     </View>
                   )}

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -255,6 +255,8 @@ function PostInner({
                     embed={post.embed}
                     moderation={moderation}
                     viewContext={PostEmbedViewContext.Feed}
+                    uri={post.uri}
+                    authorDid={post.author.did}
                   />
                 </View>
               ) : null}

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -255,8 +255,7 @@ function PostInner({
                     embed={post.embed}
                     moderation={moderation}
                     viewContext={PostEmbedViewContext.Feed}
-                    uri={post.uri}
-                    authorDid={post.author.did}
+                    post={post}
                   />
                 </View>
               ) : null}

--- a/src/view/com/posts/PostFeed.tsx
+++ b/src/view/com/posts/PostFeed.tsx
@@ -13,6 +13,8 @@ import {
 import {
   type AppBskyActorDefs,
   AppBskyEmbedExternal,
+  AppBskyEmbedGallery,
+  AppBskyEmbedImages,
   AppBskyEmbedVideo,
   type AppBskyFeedDefs,
 } from '@atproto/api'
@@ -907,7 +909,9 @@ let PostFeed = ({
 
   const seenActorWithStatusRef = useRef<Set<string>>(new Set())
   const seenPostUrisRef = useRef<Set<string>>(new Set())
-  const seenStandardSiteUrisRef = useRef<Set<string>>(new Set())
+  // Tracks every post we've seen so we can fire per-post events exactly once,
+  // regardless of the post's position within its slice.
+  const seenPerPostUrisRef = useRef<Set<string>>(new Set())
 
   // Helper to calculate position in feed (count only root posts, not interstitials or thread replies)
   const getPostPosition = useNonReactiveCallback(
@@ -940,12 +944,56 @@ let PostFeed = ({
     (item: FeedRow) => {
       feedFeedback.onItemSeen(item)
 
+      // Events that should fire exactly once for every new post, regardless of
+      // its position within a slice or video grid row.
+      const onPostSeen = (post: AppBskyFeedDefs.PostView) => {
+        if (seenPerPostUrisRef.current.has(post.uri)) return
+        seenPerPostUrisRef.current.add(post.uri)
+
+        // Standard site embed view tracking
+        if (
+          AppBskyEmbedExternal.isView(post.embed) &&
+          isStandardSiteEmbed(post.embed.external)
+        ) {
+          ax.metric('embed:standardSite:view', {url: post.embed.external.uri})
+        }
+
+        // Photo embed impression tracking
+        if (
+          AppBskyEmbedImages.isView(post.embed) ||
+          AppBskyEmbedGallery.isView(post.embed)
+        ) {
+          const totalImages = AppBskyEmbedGallery.isView(post.embed)
+            ? post.embed.items.filter(AppBskyEmbedGallery.isViewImage).length
+            : post.embed.images.length
+          const useExpandedLayout = AppBskyEmbedGallery.isView(post.embed)
+            ? totalImages > 4
+            : ax.features.enabled(ax.features.PostGalleryEmbedEnable)
+          const layout =
+            totalImages === 1
+              ? 'single'
+              : useExpandedLayout
+                ? 'carousel'
+                : 'grid'
+
+          ax.metric('post:photoEmbed:impression', {
+            layout,
+            totalImages,
+            uri: post.uri,
+            authorDid: post.author.did,
+            feedDescriptor: feedFeedback.feedDescriptor || feed,
+          })
+        }
+      }
+
       // Track post:view events
       if (item.type === 'sliceItem') {
         const slice = item.slice
         const indexInSlice = item.indexInSlice
         const postItem = slice.items[indexInSlice]
         const post = postItem.post
+
+        onPostSeen(post)
 
         // Only track the root post of each slice (index 0) to avoid double-counting thread items
         if (indexInSlice === 0 && !seenPostUrisRef.current.has(post.uri)) {
@@ -976,16 +1024,6 @@ let PostFeed = ({
               feed,
             })
           }
-        }
-
-        // Standard site embed view tracking
-        if (
-          AppBskyEmbedExternal.isView(post.embed) &&
-          isStandardSiteEmbed(post.embed.external) &&
-          !seenStandardSiteUrisRef.current.has(post.embed.external.uri)
-        ) {
-          seenStandardSiteUrisRef.current.add(post.embed.external.uri)
-          ax.metric('embed:standardSite:view', {url: post.embed.external.uri})
         }
       } else if (item.type === 'videoGridRow') {
         // Track each video in the grid row

--- a/src/view/com/posts/PostFeed.tsx
+++ b/src/view/com/posts/PostFeed.tsx
@@ -979,8 +979,8 @@ let PostFeed = ({
           ax.metric('post:photoEmbed:impression', {
             layout,
             totalImages,
-            uri: post.uri,
-            authorDid: post.author.did,
+            postUri: post.uri,
+            postAuthorDid: post.author.did,
             feedDescriptor: feedFeedback.feedDescriptor || feed,
           })
         }

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -531,8 +531,7 @@ let PostContent = ({
             moderation={moderation}
             onOpen={onOpenEmbed}
             viewContext={PostEmbedViewContext.Feed}
-            uri={post.uri}
-            authorDid={post.author.did}
+            post={post}
             feedDescriptor={feedDescriptor}
           />
         </View>

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -429,6 +429,7 @@ let FeedItemInner = ({
               onOpenEmbed={onOpenEmbed}
               post={post}
               additionalPostAlerts={additionalPostAlerts}
+              feedDescriptor={feedDescriptor}
             />
             <PostControls
               post={post}
@@ -460,6 +461,7 @@ let PostContent = ({
   postAuthor,
   onOpenEmbed,
   additionalPostAlerts,
+  feedDescriptor,
 }: {
   moderation: ModerationDecision
   richText: RichTextAPI
@@ -468,6 +470,7 @@ let PostContent = ({
   onOpenEmbed: () => void
   post: AppBskyFeedDefs.PostView
   additionalPostAlerts?: AppModerationCause[]
+  feedDescriptor?: string
 }): React.ReactNode => {
   const [limitLines, setLimitLines] = useState(
     () => countLines(richText.text) >= MAX_POST_LINES,
@@ -528,6 +531,9 @@ let PostContent = ({
             moderation={moderation}
             onOpen={onOpenEmbed}
             viewContext={PostEmbedViewContext.Feed}
+            uri={post.uri}
+            authorDid={post.author.did}
+            feedDescriptor={feedDescriptor}
           />
         </View>
       ) : null}


### PR DESCRIPTION
## Summary

Photo-embed analytics were built around the swipeable carousel only, and were inconsistent and incomplete across the three ways a post photo embed can render (single, 2-4 grid, carousel). Opens were biased by the `PostGalleryEmbedEnable` flag rollout, and the `post:gallery:impression` event was defined but never emitted.

This PR replaces `post:gallery:*` with a coherent, layout-agnostic `post:photoEmbed:*` family so opens and impressions are directly comparable across all three layouts.

### New events

All carry `uri`, `authorDid`, and an optional `feedDescriptor`, matching the shape of other post-interaction events.

- `post:photoEmbed:impression` — `{layout, totalImages, ...post}`. Fires once per mount of a post photo embed across all three layouts.
- `post:photoEmbed:open` — `{layout, fromImage, totalImages, ...post}`. Emitted from the single shared `onPress` in `ImageEmbed`, so all three layouts emit it without per-layout duplication.
- `post:photoEmbed:carouselSwipe` — in-feed carousel swipe (debounced 200ms).
- `post:photoEmbed:lightboxSwipe` — fires from the lightbox pager on every index change, regardless of which layout opened the lightbox.

### Removed

Hard-replace, no dual-emit:

- `post:gallery:swipe`
- `post:gallery:openLightbox`
- `post:gallery:impression` (was dead — defined but never emitted, and used `postUri` instead of `uri`)

### Scope

- **Post photo embeds only.** Profile avatar/banner lightboxes (and any other non-post lightbox openers) leave the new optional `metricsContext` unset on the `Lightbox`, so the new events skip cleanly there.
- Quoted-post photos are attributed to the **quoted** post (`quote.uri` / `quote.author.did`), not the surrounding post.

### Implementation notes

- Added optional `uri` / `authorDid` / `feedDescriptor` to `CommonProps` and wired them at the feed / post / thread callsites of `<Embed>`. When absent (e.g. `MediaPreview`), no events fire.
- `ImageEmbed` is the single choke point: it computes `layout` once, emits `impression` on mount and `open` from the shared `onPress`, and threads a `metricsContext` into `openLightbox`.
- The `Lightbox` state carries an optional `metricsContext`; `ImagePager.onPageSelected` emits `lightboxSwipe` only when it's set.
- The `Gallery` carousel takes a `metricsPostContext` prop; the now-redundant `post:gallery:openLightbox` emit there is removed (the shared `onPress` covers it).

## Test plan

- [ ] Manual: in feed, tap a single-image post — verify `impression` (layout=single) and `open` (layout=single, fromImage=1) fire.
- [ ] Manual: in feed, tap a 2-4 image post — verify `impression` (layout=grid) and `open` (layout=grid) fire with the right `fromImage`.
- [ ] Manual: in feed, tap a >4 image post (or any with the gallery flag on) — verify `impression` / `open` (layout=carousel) fire.
- [ ] Manual: in the in-feed carousel, swipe between images — verify `carouselSwipe` fires (debounced).
- [ ] Manual: open lightbox from any of the three layouts, swipe inside — verify `lightboxSwipe` fires with the originating `layout`.
- [ ] Manual: open a profile avatar / banner lightbox — verify no `post:photoEmbed:*` events fire.
- [ ] Manual: feed item with a quoted post that has images — verify events for the quoted-post images carry the quoted post's `uri` / `authorDid`.
- [ ] Automated: `pnpm typecheck`, `pnpm lint`, `pnpm test` all green.