### PR TITLE
Only show Message option if chat member can be messaged

### DIFF
--- a/src/screens/Messages/ConversationSettings/MemberMenu.tsx
+++ b/src/screens/Messages/ConversationSettings/MemberMenu.tsx
@@ -12,7 +12,7 @@ import {useGetConvoForMembers} from '#/state/queries/messages/get-convo-for-memb
 import {useRemoveFromGroupChat} from '#/state/queries/messages/remove-from-group'
 import {useProfileBlockMutationQueue} from '#/state/queries/profile'
 import {atoms as a, useTheme} from '#/alf'
-import {type ConvoWithDetails} from '#/components/dms/util'
+import {canBeMessaged, type ConvoWithDetails} from '#/components/dms/util'
 import {ArrowBoxLeft_Stroke2_Corner0_Rounded as ArrowBoxLeftIcon} from '#/components/icons/ArrowBoxLeft'
 import {DotGrid3x1_Stroke2_Corner0_Rounded as EllipsisIcon} from '#/components/icons/DotGrid'
 import {Message_Stroke2_Corner0_Rounded as MessageIcon} from '#/components/icons/Message'
@@ -127,6 +127,7 @@ export function MemberMenu({
     }
   }
 
+  const canMessageMember = canBeMessaged(profile)
   const canBlockMember = type === 'owner' || type === 'standard'
   const canRemoveMember = isOwner && type !== 'invited'
   // TODO Need to integrate this. -dsb
@@ -191,14 +192,16 @@ export function MemberMenu({
                 <Trans>Go to profile</Trans>
               </Menu.ItemText>
             </Menu.Item>
-            <Menu.Item
-              label={l`Message ${displayName}`}
-              onPress={handleMessageMember}>
-              <Menu.ItemIcon icon={MessageIcon} />
-              <Menu.ItemText>
-                <Trans context="action">Message</Trans>
-              </Menu.ItemText>
-            </Menu.Item>
+            {canMessageMember ? (
+              <Menu.Item
+                label={l`Message ${displayName}`}
+                onPress={handleMessageMember}>
+                <Menu.ItemIcon icon={MessageIcon} />
+                <Menu.ItemText>
+                  <Trans context="action">Message</Trans>
+                </Menu.ItemText>
+              </Menu.Item>
+            ) : null}
           </Menu.Group>
           <Menu.Divider />
           <Menu.Group>


### PR DESCRIPTION
No need to show this when it can’t be used.