### PR TITLE
Fix stale push notification replay after account switch

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -844,6 +844,8 @@ const LINKING = {
   },
 } satisfies LinkingOptions<AllNavigatorParams>
 
+let didHandlePushNotificationEntry = false
+
 function RoutesContainer({children}: React.PropsWithChildren<{}>) {
   const ax = useAnalytics()
   // eslint-disable-next-line react-compiler/react-compiler
@@ -903,6 +905,14 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
 
   function handlePushNotificationEntry() {
     if (!IS_NATIVE) return
+
+    // Only consume a launching notification once per JS runtime. Account
+    // switches remount the entire tree (see `key={currentAccount?.did}` in
+    // `App.native.tsx`), which re-fires `onNavigationReady` and would
+    // otherwise re-process whatever `getLastNotificationResponse` still has
+    // cached natively (APP-2338).
+    if (didHandlePushNotificationEntry) return
+    didHandlePushNotificationEntry = true
 
     // intent urls are handled by `useIntentHandler`
     if (linkingUrl) return

--- a/src/lib/hooks/useNotificationHandler.ts
+++ b/src/lib/hooks/useNotificationHandler.ts
@@ -380,6 +380,18 @@ export function useNotificationsHandler() {
 
           handleNotification(payload)
           Notifications.dismissAllNotificationsAsync()
+          // Also clear the native `lastResponse` cache. Otherwise a subsequent
+          // `getLastNotificationResponse()` (e.g. on an account-switch remount,
+          // which re-runs `handlePushNotificationEntry`) would replay this
+          // payload and ping-pong the user back to the previous account/chat.
+          try {
+            Notifications.clearLastNotificationResponse()
+          } catch (error) {
+            notyLogger.error(
+              `useNotificationsHandler: error clearing notification response`,
+              {error},
+            )
+          }
         } else {
           logger.error('useNotificationsHandler: received no payload', {
             identifier: e.notification.request.identifier,


### PR DESCRIPTION
## Summary

- When a push notification tap is handled by the response listener (foreground/background tap), the native `lastResponse` cache was never cleared — `dismissAllNotificationsAsync` only clears the notification tray, not the OS-cached tap response.
- The root tree remounts on every account switch (`<Fragment key={currentAccount?.did}>` in `App.native.tsx`), which re-fires `onNavigationReady` → `handlePushNotificationEntry()` → `getLastNotificationResponse()`. That returned the stale payload, saw a recipient/account mismatch, stashed it for replay, and called `onPressSwitchAccount` back to the previous account. The tree remounted again and the stored payload was replayed, navigating back to the prior chat.
- Net effect: tap a DM notification, back out, long-press avatar to switch accounts — the app flashes between screens and lands back on the previous chat as the previous account.

Two changes:

1. `useNotificationsHandler` now calls `Notifications.clearLastNotificationResponse()` after the response listener handles a tap, mirroring what `handlePushNotificationEntry` already does on cold start. This is the load-bearing fix.
2. `handlePushNotificationEntry` is now guarded by a module-level `didHandlePushNotificationEntry` flag so it only runs once per JS runtime, not on every account-switch remount. Defense-in-depth — even if a stale `lastResponse` somehow lingers, the entry path won't re-consume it.

## Test plan

- [ ] Sign in to two accounts on a device build.
- [ ] Send UserA a DM from a third account; with the app backgrounded, tap the push notification.
- [ ] App opens to the chat as UserA. Back out to the chat list.
- [ ] Long-press the avatar and switch to UserB.
- [ ] Verify: no flash, app lands cleanly on UserB's home (or wherever the default landing is) — no re-navigation back to UserA's chat.
- [ ] Repeat with a cold-start tap (kill the app first, then tap the notification) — verify the chat still opens as the recipient on launch.
- [ ] Repeat with non-chat push notifications (like, reply, mention) to confirm the cold-start path still routes correctly.