### PR TITLE
Fix text truncating in image menu on iOS

### DIFF
--- a/src/components/Lightbox/chrome/ImageMenu.tsx
+++ b/src/components/Lightbox/chrome/ImageMenu.tsx
@@ -10,7 +10,7 @@ import Animated, {
 } from 'react-native-reanimated'
 import {useLingui} from '@lingui/react/macro'
 
-import {android, atoms as a, ios} from '#/alf'
+import {atoms as a} from '#/alf'
 import {ArrowShareRight_Stroke2_Corner2_Rounded as ShareIcon} from '#/components/icons/ArrowShareRight'
 import {type Props as IconProps} from '#/components/icons/common'
 import {DotGrid3x1_Stroke2_Corner0_Rounded as DotsIcon} from '#/components/icons/DotGrid'
@@ -25,7 +25,6 @@ type Props = {
 
 type Anchor = {x: number; y: number; width: number; height: number}
 
-const MENU_WIDTH = 160
 const GAP = 6
 const CARD_BG = '#000000'
 const CARD_BORDER = '#232e3e'
@@ -124,9 +123,8 @@ function MenuCard({
     <Animated.View
       style={[
         a.absolute,
+        a.self_start,
         styles.card,
-        android({alignSelf: 'flex-start'}),
-        ios({width: MENU_WIDTH}),
         {
           top: anchor.y + anchor.height + GAP,
           left: anchor.x,
@@ -186,7 +184,6 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(255, 255, 255, 0.08)',
   },
   itemText: {
-    flex: 1,
     fontSize: 15,
     fontWeight: '500',
     lineHeight: 19.5,


### PR DESCRIPTION
With an explicit width, the text would overflow at larger than default sizes.

This PR just aligns the iOS behavior with Android and web.

Before:

https://github.com/user-attachments/assets/9b6e991b-5ee0-4d0a-8204-9e783977e0a7

After:

https://github.com/user-attachments/assets/0e14b132-bacf-4fa3-bea4-ca764a98c294