### PR TITLE
Catch NotAllowedError in web GIF player + lint modules/

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,4 +1,113 @@
 {
+  "modules/bottom-sheet/src/BottomSheetNativeComponent.tsx": {
+    "@typescript-eslint/no-explicit-any": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "modules/bottom-sheet/src/BottomSheetPortal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "modules/bottom-sheet/src/lib/Portal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "modules/expo-background-notification-handler/src/BackgroundNotificationHandlerProvider.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "modules/expo-background-notification-handler/src/ExpoBackgroundNotificationHandlerModule.web.ts": {
+    "@typescript-eslint/require-await": {
+      "count": 4
+    }
+  },
+  "modules/expo-bluesky-gif-view/src/GifView.tsx": {
+    "@typescript-eslint/no-explicit-any": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 4
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 4
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "modules/expo-bluesky-gif-view/src/GifView.web.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2
+    },
+    "@typescript-eslint/require-await": {
+      "count": 2
+    }
+  },
+  "modules/expo-bluesky-swiss-army/src/PlatformInfo/index.native.ts": {
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 3
+    }
+  },
+  "modules/expo-bluesky-swiss-army/src/Referrer/index.android.ts": {
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    }
+  },
+  "modules/expo-bluesky-swiss-army/src/SharedPrefs/index.native.ts": {
+    "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 9
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 9
+    }
+  },
+  "modules/expo-bluesky-swiss-army/src/VisibilityView/index.native.tsx": {
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "modules/expo-bluesky-swiss-army/src/VisibilityView/index.tsx": {
+    "@typescript-eslint/require-await": {
+      "count": 1
+    }
+  },
+  "modules/expo-bluesky-swiss-army/src/VisibilityView/types.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "modules/expo-emoji-picker/src/EmojiPickerView.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/Navigation.tsx": {
     "@typescript-eslint/no-floating-promises": {
       "count": 1

--- a/modules/expo-bluesky-gif-view/src/GifView.web.tsx
+++ b/modules/expo-bluesky-gif-view/src/GifView.web.tsx
@@ -67,7 +67,18 @@ export class GifView extends PureComponent<GifViewProps> {
   }
 
   async playAsync(): Promise<void> {
-    this.videoPlayerRef.current?.play()
+    try {
+      await this.videoPlayerRef.current?.play()
+    } catch (err) {
+      // `play()` rejects with a NotAllowedError when the browser blocks
+      // playback (e.g. Safari low-power mode or autoplay policy). This is
+      // expected and benign - the GIF simply stays paused - so swallow it
+      // rather than letting it surface as an unhandled rejection.
+      if (err instanceof DOMException && err.name === 'NotAllowedError') {
+        return
+      }
+      throw err
+    }
   }
 
   async pauseAsync(): Promise<void> {

--- a/modules/expo-bluesky-swiss-army/src/VisibilityView/index.native.tsx
+++ b/modules/expo-bluesky-swiss-army/src/VisibilityView/index.native.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import {StyleProp, ViewStyle} from 'react-native'
+import {type StyleProp, type ViewStyle} from 'react-native'
 import {requireNativeModule, requireNativeViewManager} from 'expo-modules-core'
 
-import {VisibilityViewProps} from './types'
+import {type VisibilityViewProps} from './types'
 const NativeView: React.ComponentType<{
   onChangeStatus: (e: {nativeEvent: {isActive: boolean}}) => void
   children: React.ReactNode
-  enabled: Boolean
+  enabled: boolean
   style: StyleProp<ViewStyle>
 }> = requireNativeViewManager('ExpoBlueskyVisibilityView')
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "test-watch": "NODE_ENV=test jest --watchAll",
     "test-ci": "NODE_ENV=test jest --ci --forceExit --reporters=default --reporters=jest-junit",
     "test-coverage": "NODE_ENV=test jest --coverage",
-    "lint": "eslint --cache --quiet src",
+    "lint": "eslint --cache --quiet src modules",
     "lint-native": "swiftlint ./modules && ktlint ./modules",
     "lint-native:fix": "swiftlint --fix ./modules && ktlint --format ./modules",
     "typecheck": "tsgo --project ./tsconfig.check.json",


### PR DESCRIPTION
## Catch `NotAllowedError` in web GIF player

Fixes [APP-S670](https://blueskyweb.sentry.io/issues/APP-S670) (~31k events, ~18.7k users).

`HTMLMediaElement.play()` returns a promise that rejects with a `NotAllowedError` when the browser blocks playback (Safari low-power mode, autoplay policy, backgrounded tab). In `GifView.web`'s `playAsync` the promise was fired-and-forgotten, so the rejection surfaced as an unhandled rejection and got reported to Sentry. It's expected and benign - the GIF just stays paused - so we now `await` it and swallow that specific error, rethrowing anything genuinely unexpected.

## Apply eslint to `modules/`

The `lint` script previously only covered `src`, so `modules/` was unlinted. This extends it to `modules` as well, baselines the pre-existing violations there into `eslint-suppressions.json`, and fixes the couple of cheap ones along the way (`consistent-type-imports` and a `Boolean`→`boolean` in `VisibilityView`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)