### PR TITLE
Guard popper against null reference rect in composer autocomplete

### DIFF
--- a/src/view/com/composer/text-input/web/Autocomplete.tsx
+++ b/src/view/com/composer/text-input/web/Autocomplete.tsx
@@ -40,6 +40,24 @@ export function createSuggestion({
     render: () => {
       let component: ReactRenderer<MentionListRef> | undefined
       let popup: TippyInstance[] | undefined
+      // Popper holds onto getReferenceClientRect and calls it on a debounced
+      // update. By the time it fires the suggestion may have torn down, in
+      // which case props.clientRect() returns null and popper crashes on
+      // `clientRect.left`. Remember the last valid rect and fall back to it so
+      // popper always receives a real DOMRect. See APP-P7.
+      let lastClientRect: DOMRect | undefined
+
+      const getReferenceClientRect = (
+        clientRect: SuggestionProps['clientRect'],
+      ) => {
+        return () => {
+          const rect = clientRect?.()
+          if (rect) {
+            lastClientRect = rect
+          }
+          return lastClientRect ?? new DOMRect()
+        }
+      }
 
       const hide = () => {
         popup?.[0]?.destroy()
@@ -57,9 +75,8 @@ export function createSuggestion({
             return
           }
 
-          // @ts-ignore getReferenceClientRect doesnt like that clientRect can return null -prf
           popup = tippy('body', {
-            getReferenceClientRect: props.clientRect,
+            getReferenceClientRect: getReferenceClientRect(props.clientRect),
             appendTo: () => document.body,
             content: component.element,
             showOnCreate: true,
@@ -77,8 +94,7 @@ export function createSuggestion({
           }
 
           popup?.[0]?.setProps({
-            // @ts-ignore getReferenceClientRect doesnt like that clientRect can return null -prf
-            getReferenceClientRect: props.clientRect,
+            getReferenceClientRect: getReferenceClientRect(props.clientRect),
           })
         },
 


### PR DESCRIPTION
Fixes [APP-P7](https://blueskyweb.sentry.io/issues/APP-P7) (~188k events, 256 users - a tight per-session loop, so impact is larger than the user count suggests). Seer rated this super_high actionability.

## Root cause

The only `@popperjs/core` consumer in the app is `tippy.js`, used in exactly one place: the composer's mention autocomplete (`src/view/com/composer/text-input/web/Autocomplete.tsx`). It hands tippy `@tiptap/suggestion`'s `clientRect` directly as `getReferenceClientRect`. That function can return `null` once the editor/suggestion tears down. Popper retains it and re-invokes it on its debounced `instance.update`; when that fires after the reference is gone, `getReferenceClientRect()` returns null and popper crashes dereferencing `clientRect.left`. Two pre-existing `@ts-ignore` comments already acknowledged the null return but didn't guard it.

## Fix

Wrap `getReferenceClientRect` to cache the last valid rect and never hand popper a null (falls back to a zeroed `DOMRect`), used in both `onStart` and `onUpdate`. The two now-moot `@ts-ignore` comments are removed.

Worst case, a late popper update positions the popover at a stale/origin location for a frame instead of crashing - effectively invisible given tippy is `trigger: 'manual'` and `onExit` destroys the popup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)