### PR TITLE
Fix "Position out of range" crash in web composer Backspace

### DIFF
--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -231,10 +231,19 @@ export function TextInput({
                   // otherwise, delete the last grapheme using deleteRange,
                   // so that emojis are deleted as a whole
                   const deleteFrom = cursorPosition - lastGrapheme.length
-                  editor?.commands.deleteRange({
-                    from: deleteFrom,
-                    to: cursorPosition,
-                  })
+                  // Resolve positions against `view`, not the closed-over
+                  // `editor`. The `editor` ref can briefly point at a stale
+                  // instance (e.g. after the editor is recreated on a theme
+                  // change or content reset) whose document is out of sync
+                  // with the live `view`, causing deleteRange to throw
+                  // "Position X out of range". Clamp to the live doc as a
+                  // final guard. See APP-SBSP -sfn
+                  const docSize = view.state.doc.content.size
+                  const from = Math.max(0, Math.min(deleteFrom, docSize))
+                  const to = Math.max(from, Math.min(cursorPosition, docSize))
+                  if (from < to) {
+                    view.dispatch(view.state.tr.delete(from, to))
+                  }
                   return true
                 }
               }


### PR DESCRIPTION
Fixes [APP-SBSP](https://blueskyweb.sentry.io/issues/APP-SBSP) (~87k events, ~7.6k users).

## Root cause

The web composer's graphemewise Backspace handler computes positions from the `view` argument it receives (`view.state.selection.$anchor.pos`, `view.state.doc.textBetween(...)`), but then executed the delete against the closed-over React `editor` value: `editor?.commands.deleteRange(...)`.

Normally `editor.view === view` and their docs match. But the `editorProps` handler is created once when `useEditor` builds the instance, and the captured `editor` can briefly point at a stale instance - the editor is recreated when `modeClass` changes (light/dark toggle) and the doc is reset. During that reconciliation window, `editor.state.doc` is a different, smaller document than the live `view.state.doc`. A `cursorPosition` valid in `view` overflows the stale doc, so ProseMirror's `tr.delete` -> `doc.resolve(from)` throws "Position N out of range". This explains an out-of-range position *larger* than docSize and the intermittent, high-volume nature.

## Fix

Dispatch the delete on the `view` the handler received (so positions and document come from the same state) and clamp `from`/`to` to `view.state.doc.content.size` as a defensive backstop. `view.state.tr.delete(from, to)` is exactly what TipTap's `deleteRange` calls internally, so the normal emoji/grapheme case is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)