### PR TITLE
[Chat] Show invite link label in chat list preview

### DIFF
--- a/src/components/dms/getMessageInfo.ts
+++ b/src/components/dms/getMessageInfo.ts
@@ -1,4 +1,8 @@
-import {AppBskyEmbedRecord, ChatBskyConvoDefs} from '@atproto/api'
+import {
+  AppBskyEmbedRecord,
+  ChatBskyConvoDefs,
+  ChatBskyEmbedJoinLink,
+} from '@atproto/api'
 import {type I18n} from '@lingui/core'
 import {msg} from '@lingui/core/macro'
 
@@ -83,6 +87,8 @@ export function getMessageInfo({
       } else {
         message = prefix(defaultEmbeddedContentMessage)
       }
+    } else if (ChatBskyEmbedJoinLink.isView(lastMessage.embed)) {
+      message = prefix(i18n._(msg`(chat invite link)`))
     } else {
       message = prefix(defaultEmbeddedContentMessage)
     }


### PR DESCRIPTION
## Description

When the last message in a chat is a join/invite link embed, the chat list preview now shows "(chat invite link)" instead of the generic "(contains embedded content)" fallback.

Handles `ChatBskyEmbedJoinLink` views in `getMessageInfo`.

## Test plan

- Send a chat invite link as the last message in a conversation
- Confirm the chat list preview reads "(chat invite link)" (prefixed with sender name in group chats / "You:" when sent by you)

🤖 Generated with [Claude Code](https://claude.com/claude-code)