### PR TITLE
Don't suggest users who can't be messaged/added

### DIFF
--- a/src/components/dms/AddMembersFlow.tsx
+++ b/src/components/dms/AddMembersFlow.tsx
@@ -209,6 +209,7 @@ export function AddMembersFlow({
       if (follows) {
         for (const page of follows.pages) {
           for (const profile of page.follows) {
+            if (!canBeAddedToGroup(profile)) continue
             _items.push({
               type: 'profile',
               key: profile.did,
@@ -216,12 +217,6 @@ export function AddMembersFlow({
             })
           }
         }
-
-        _items.sort(item => {
-          return item.type === 'profile' && canBeAddedToGroup(item.profile)
-            ? -1
-            : 1
-        })
       } else {
         for (let i = 0; i < 10; i++) {
           _items.push({type: 'placeholder', key: i + ''})

--- a/src/components/dms/InitiateChatFlow.tsx
+++ b/src/components/dms/InitiateChatFlow.tsx
@@ -303,6 +303,7 @@ export function InitiateChatFlow({
       if (follows) {
         for (const page of follows.pages) {
           for (const profile of page.follows) {
+            if (!checker(profile)) continue
             _items.push({
               type: 'profile',
               key: profile.did,
@@ -310,10 +311,6 @@ export function InitiateChatFlow({
             })
           }
         }
-
-        _items = _items.sort(item => {
-          return item.type === 'profile' && checker(item.profile) ? -1 : 1
-        })
       } else {
         _items.push(...placeholders)
       }


### PR DESCRIPTION
Was odd to put these under “Suggestions”. Note this only filters them underneath that heading; they still appear when you search.