### PR TITLE
[Chat] Fix duplicate messages when history fetch races firehose

### DIFF
--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -881,17 +881,27 @@ export class Convo {
             ChatBskyConvoDefs.isLogCreateMessage(ev) &&
             ChatBskyConvoDefs.isMessageView(ev.message)
           ) {
-            /**
-             * If this message is already in new messages, it was added by our
-             * sending logic, and is based on client-ordering. When we receive
-             * the "committed" event from the log, we should replace this
-             * reference and re-insert in order to respect the order we received
-             * from the log.
+            /*
+             * If this message is already in past messages, the initial
+             * history fetch raced this log event and already returned it.
+             * Update in place rather than inserting a duplicate into new
+             * messages.
              */
-            if (this.newMessages.has(ev.message.id)) {
-              this.newMessages.delete(ev.message.id)
+            if (this.pastMessages.has(ev.message.id)) {
+              this.pastMessages.set(ev.message.id, ev.message)
+            } else {
+              /**
+               * If this message is already in new messages, it was added by our
+               * sending logic, and is based on client-ordering. When we receive
+               * the "committed" event from the log, we should replace this
+               * reference and re-insert in order to respect the order we received
+               * from the log.
+               */
+              if (this.newMessages.has(ev.message.id)) {
+                this.newMessages.delete(ev.message.id)
+              }
+              this.newMessages.set(ev.message.id, ev.message)
             }
-            this.newMessages.set(ev.message.id, ev.message)
             needsCommit = true
           } else if (
             ChatBskyConvoDefs.isLogDeleteMessage(ev) &&
@@ -928,7 +938,12 @@ export class Convo {
           } else {
             const systemView = toSystemMessageView(ev)
             if (systemView) {
-              this.newMessages.set(systemView.id, systemView)
+              // same as above: avoid duplicating if history fetch won the race
+              if (this.pastMessages.has(systemView.id)) {
+                this.pastMessages.set(systemView.id, systemView)
+              } else {
+                this.newMessages.set(systemView.id, systemView)
+              }
               needsCommit = true
             }
           }


### PR DESCRIPTION
## Problem

Opening a chat right as someone sends a message could show that message twice in the list.

`Convo.init()` kicks off two independent async chains: the history fetch (`getMessages` → `pastMessages`) and the firehose/event bus (`getLog` → `ingestFirehose` → `newMessages`). `getItems()` renders both maps, so the same message id landing in both renders twice.

The dedup between the two chains only worked in one direction:

- `fetchMessageHistory` checks `newMessages` before writing to `pastMessages` ✅ (firehose lands first → fine)
- `ingestFirehose`'s create branch only checked `newMessages`, never `pastMessages` ❌ (history lands first → duplicate)

The history-first ordering is the common one in practice: the event bus polls on a 60s default interval (and the immediate poll triggered by `requestPollInterval` is skipped if a poll is already in flight), so a `logCreateMessage` for a message already returned by the initial history page can arrive seconds later and get inserted into `newMessages` as a "new" message.

The delete and reaction branches of `ingestFirehose` already handle both maps — only the create branch and the system-message fallback had this gap (so member-join/leave system messages could duplicate the same way).

## Fix

In `ingestFirehose`, if the incoming message already exists in `pastMessages`, update it in place (trusting server ordering) instead of inserting into `newMessages`. Applied to both the `logCreateMessage` branch and the system-message fallback, mirroring what the reaction branch already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)