### PR TITLE
[Chat] Fix shadow overlay gaps + placeholder bubbles (stacked on #10827)

### DIFF
--- a/src/components/AvatarBubbles.tsx
+++ b/src/components/AvatarBubbles.tsx
@@ -10,7 +10,7 @@ import Animated, {
 } from 'react-native-reanimated'
 import {moderateProfile} from '@atproto/api'
 
-import {useProfileShadow} from '#/state/cache/profile-shadow'
+import {useMaybeProfileShadow} from '#/state/cache/profile-shadow'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useSession} from '#/state/session'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
@@ -90,22 +90,18 @@ export function AvatarBubbles({
           transform: [{scale}],
           transformOrigin: 'top left',
         }}>
-        {layouts.map((layout, i) => {
-          const profile = profiles[i]
-          if (!profile) return null
-          return (
-            <AvatarBubble
-              key={i}
-              profile={profile}
-              scale={scales[i]}
-              size={layout.size}
-              x={layout.x}
-              y={layout.y}
-              zIndex={layout.zIndex}
-              includeProfileBorder={layout.border}
-            />
-          )
-        })}
+        {layouts.map((layout, i) => (
+          <AvatarBubble
+            key={i}
+            profile={profiles[i]}
+            scale={scales[i]}
+            size={layout.size}
+            x={layout.x}
+            y={layout.y}
+            zIndex={layout.zIndex}
+            includeProfileBorder={layout.border}
+          />
+        ))}
       </View>
     </Animated.View>
   )
@@ -120,7 +116,7 @@ function AvatarBubble({
   zIndex,
   includeProfileBorder,
 }: {
-  profile: bsky.profile.AnyProfileView
+  profile?: bsky.profile.AnyProfileView
   scale: SharedValue<number>
   size: number
   x: number
@@ -133,42 +129,34 @@ function AvatarBubble({
     transform: [{translateX: x}, {translateY: y}, {scale: scale.get()}],
   }))
 
-  const style = [
-    a.absolute,
-    a.rounded_full,
-    a.flex_grow_0,
-    includeProfileBorder && {
-      borderColor: t.atoms.text_inverted.color,
-      borderWidth: 2,
-    },
-    zIndex != null && {zIndex},
-    animatedStyle,
-  ]
-
-  const profile = useProfileShadow(profileUnshadowed)
+  const profile = useMaybeProfileShadow(profileUnshadowed)
   const moderationOpts = useModerationOpts()
 
-  if (!moderationOpts) {
-    return (
-      <Animated.View style={style}>
-        <AvatarPlaceholder size={size} />
-      </Animated.View>
-    )
-  }
-
-  const moderation = moderateProfile(profile, moderationOpts)
-  const avatarModeration = moderation.ui('avatar')
-
   return (
-    <Animated.View style={style}>
-      <UserAvatar
-        avatar={profile.avatar}
-        size={size}
-        type="user"
-        hideLiveBadge
-        noBorder
-        moderation={avatarModeration}
-      />
+    <Animated.View
+      style={[
+        a.absolute,
+        a.rounded_full,
+        a.flex_grow_0,
+        includeProfileBorder && {
+          borderColor: t.atoms.text_inverted.color,
+          borderWidth: 2,
+        },
+        zIndex != null && {zIndex},
+        animatedStyle,
+      ]}>
+      {profile && moderationOpts ? (
+        <UserAvatar
+          avatar={profile.avatar}
+          size={size}
+          type="user"
+          hideLiveBadge
+          noBorder
+          moderation={moderateProfile(profile, moderationOpts).ui('avatar')}
+        />
+      ) : (
+        <AvatarPlaceholder size={size} />
+      )}
     </Animated.View>
   )
 }

--- a/src/state/cache/profile-shadow.ts
+++ b/src/state/cache/profile-shadow.ts
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useRef, useState} from 'react'
+import {useEffect, useMemo, useState} from 'react'
 import {type AppBskyActorDefs, type AppBskyNotificationDefs} from '@atproto/api'
 import {type QueryClient} from '@tanstack/react-query'
 import {EventEmitter} from 'eventemitter3'
@@ -54,22 +54,18 @@ const shadows: WeakMap<
 const emitter = new EventEmitter()
 
 type ShadowUpdateEventPayload = {did: string; shadow: Partial<ProfileShadow>}
-export function useOnUpdateProfileShadow(
-  onUpdate: (payload: ShadowUpdateEventPayload) => void,
-) {
-  const onUpdateRef = useRef(onUpdate)
-  // eslint-disable-next-line react-hooks/refs
-  onUpdateRef.current = onUpdate
 
-  useEffect(() => {
-    function listener(payload: ShadowUpdateEventPayload) {
-      onUpdateRef.current(payload)
-    }
-    emitter.addListener('shadow-update', listener)
-    return () => {
-      emitter.removeListener('shadow-update', listener)
-    }
-  }, [])
+/**
+ * Subscribe to all profile shadow updates, regardless of did. Useful for
+ * non-React consumers like the Convo agent. Returns an unlisten function.
+ */
+export function listenProfileShadowUpdate(
+  listener: (payload: ShadowUpdateEventPayload) => void,
+): () => void {
+  emitter.addListener('shadow-update', listener)
+  return () => {
+    emitter.removeListener('shadow-update', listener)
+  }
 }
 
 export function useProfileShadow<
@@ -230,6 +226,39 @@ export function updateProfileShadow(
       shadow: value,
     } satisfies ShadowUpdateEventPayload)
   })
+}
+
+/**
+ * Returns true if merging `shadow` into `profile` would change nothing, i.e.
+ * `mergeShadow` would be a no-op. Object-valued fields are compared by
+ * reference, so this can return false negatives - callers may do redundant
+ * merges, but never skip a real change.
+ */
+export function isProfileShadowApplied<
+  TProfileView extends bsky.profile.AnyProfileView,
+>(profile: TProfileView, shadow: Partial<ProfileShadow>): boolean {
+  if ('followingUri' in shadow) {
+    if (profile.viewer?.following !== shadow.followingUri) return false
+  }
+  if ('muted' in shadow) {
+    if (profile.viewer?.muted !== shadow.muted) return false
+  }
+  if ('blockingUri' in shadow) {
+    if (profile.viewer?.blocking !== shadow.blockingUri) return false
+  }
+  if ('activitySubscription' in shadow) {
+    if (profile.viewer?.activitySubscription !== shadow.activitySubscription) {
+      return false
+    }
+  }
+  if ('verification' in shadow) {
+    if (profile.verification !== shadow.verification) return false
+  }
+  if ('status' in shadow) {
+    const current = 'status' in profile ? profile.status : undefined
+    if (current !== shadow.status) return false
+  }
+  return true
 }
 
 export function mergeShadow<TProfileView extends bsky.profile.AnyProfileView>(

--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -20,7 +20,12 @@ import {
   isNetworkError,
 } from '#/lib/strings/errors'
 import {Logger} from '#/logger'
-import {mergeShadow, type ProfileShadow} from '#/state/cache/profile-shadow'
+import {
+  isProfileShadowApplied,
+  listenProfileShadowUpdate,
+  mergeShadow,
+  type ProfileShadow,
+} from '#/state/cache/profile-shadow'
 import {
   ACTIVE_POLL_INTERVAL,
   BACKGROUND_POLL_INTERVAL,
@@ -119,6 +124,15 @@ export class Convo {
   private deletedMessages: Set<string> = new Set()
   private relatedProfiles: Map<string, ChatBskyActorDefs.ProfileViewBasic> =
     new Map()
+  /**
+   * Accumulated profile shadow state, keyed by did. The profiles this agent
+   * holds come from direct service fetches, so they are invisible to the
+   * shadow cache's react-query scan. We keep our own overlay and re-apply it
+   * whenever server data overwrites `relatedProfiles` or `convo.members`,
+   * otherwise refreshes would revert optimistic state (e.g. a block) until
+   * the server catches up.
+   */
+  private profileShadows: Map<string, Partial<ProfileShadow>> = new Map()
 
   private isProcessingPendingMessages = false
 
@@ -169,15 +183,28 @@ export class Convo {
   private subscribers: (() => void)[] = []
 
   subscribe(subscriber: () => void) {
-    if (this.subscribers.length === 0) this.init()
+    if (this.subscribers.length === 0) {
+      this.cleanupProfileShadowListener = listenProfileShadowUpdate(
+        ({did, shadow}) => {
+          this.mergeProfileShadow(did, shadow)
+        },
+      )
+      this.init()
+    }
 
     this.subscribers.push(subscriber)
 
     return () => {
       this.subscribers = this.subscribers.filter(s => s !== subscriber)
-      if (this.subscribers.length === 0) this.suspend()
+      if (this.subscribers.length === 0) {
+        this.cleanupProfileShadowListener?.()
+        this.cleanupProfileShadowListener = undefined
+        this.suspend()
+      }
     }
   }
+
+  private cleanupProfileShadowListener: (() => void) | undefined
 
   getSnapshot(): ConvoState {
     if (!this.snapshot) this.snapshot = this.generateSnapshot()
@@ -497,6 +524,9 @@ export class Convo {
     this.pendingMessages = new Map()
     this.deletedMessages = new Set()
     this.relatedProfiles = new Map()
+    // Shadow updates fired while suspended are missed, so the overlay may be
+    // stale - drop it and trust the from-scratch refetch.
+    this.profileShadows = new Map()
 
     this.pendingMessageFailure = null
     this.fetchMessageHistoryError = undefined
@@ -528,6 +558,7 @@ export class Convo {
         this.relatedProfiles.set(member.did, member)
       }
     }
+    this.applyProfileShadows()
   }
 
   private updateConvo(convo: Partial<ChatBskyConvoDefs.ConvoView>) {
@@ -538,6 +569,7 @@ export class Convo {
       for (const member of this.convo.members) {
         this.relatedProfiles.set(member.did, member)
       }
+      this.applyProfileShadows()
     }
   }
 
@@ -708,6 +740,7 @@ export class Convo {
         this.relatedProfiles.set(member.did, member)
       }
     } while (cursor)
+    this.applyProfileShadows()
   }
 
   private fetchMessageHistoryError: {retry: () => void} | undefined
@@ -754,6 +787,7 @@ export class Convo {
         for (const profile of relatedProfiles) {
           this.relatedProfiles.set(profile.did, profile)
         }
+        this.applyProfileShadows()
       }
 
       /*
@@ -876,6 +910,7 @@ export class Convo {
             for (const profile of ev.relatedProfiles) {
               this.relatedProfiles.set(profile.did, profile)
             }
+            this.applyProfileShadows()
           }
 
           if (
@@ -1488,10 +1523,84 @@ export class Convo {
   }
 
   mergeProfileShadow(did: string, shadow: Partial<ProfileShadow>) {
-    const related = this.relatedProfiles.get(did)
-    if (related) {
-      this.relatedProfiles.set(did, mergeShadow(related, shadow))
+    // Accumulate even if the did isn't held yet - the profile may arrive
+    // later via message history or the member list, and must get the shadow.
+    this.profileShadows.set(did, {
+      ...this.profileShadows.get(did),
+      ...shadow,
+    })
+    if (this.applyProfileShadow(did, shadow)) {
       this.commit()
+    }
+  }
+
+  /**
+   * Re-applies all accumulated shadows. Must be called after any server data
+   * lands in `relatedProfiles` or `this.convo`, since raw server profiles
+   * would otherwise clobber optimistic state.
+   */
+  private applyProfileShadows() {
+    for (const [did, shadow] of this.profileShadows) {
+      this.applyProfileShadow(did, shadow)
+    }
+  }
+
+  private applyProfileShadow(
+    did: string,
+    shadow: Partial<ProfileShadow>,
+  ): boolean {
+    let changed = false
+
+    const related = this.relatedProfiles.get(did)
+    if (related && !isProfileShadowApplied(related, shadow)) {
+      this.relatedProfiles.set(did, mergeShadow(related, shadow))
+      changed = true
+    }
+
+    if (this.convo) {
+      const next = applyShadowToConvo(this.convo, did, shadow)
+      if (next) {
+        this.convo = next
+        changed = true
+      }
+    }
+
+    return changed
+  }
+}
+
+/**
+ * Returns a new convo with the shadow merged into the matching member (and
+ * `primaryMember`, if it's the same profile), or null if nothing changed.
+ */
+function applyShadowToConvo(
+  convo: ConvoWithDetails,
+  did: string,
+  shadow: Partial<ProfileShadow>,
+): ConvoWithDetails | null {
+  const i = convo.members.findIndex(m => m.did === did)
+  if (i === -1) return null
+  if (isProfileShadowApplied(convo.members[i], shadow)) return null
+
+  // The branches are identical, but narrowing the union is what lets the
+  // member arrays keep their per-kind types.
+  if (convo.kind === 'group') {
+    const members = convo.members.slice()
+    members[i] = mergeShadow(members[i], shadow)
+    return {
+      ...convo,
+      members,
+      primaryMember:
+        convo.primaryMember?.did === did ? members[i] : convo.primaryMember,
+    }
+  } else {
+    const members = convo.members.slice()
+    members[i] = mergeShadow(members[i], shadow)
+    return {
+      ...convo,
+      members,
+      primaryMember:
+        convo.primaryMember.did === did ? members[i] : convo.primaryMember,
     }
   }
 }

--- a/src/state/messages/convo/index.tsx
+++ b/src/state/messages/convo/index.tsx
@@ -11,7 +11,6 @@ import {useFocusEffect} from '@react-navigation/native'
 import {useQueryClient} from '@tanstack/react-query'
 
 import {useAppState} from '#/lib/appState'
-import {useOnUpdateProfileShadow} from '#/state/cache/profile-shadow'
 import {Convo} from '#/state/messages/convo/agent'
 import {
   type ConvoParams,
@@ -112,10 +111,6 @@ export function ConvoProvider({
       }
     }, [isActive, convo, convoId, markAsRead]),
   )
-
-  useOnUpdateProfileShadow(({did, shadow}) => {
-    convo.mergeProfileShadow(did, shadow)
-  })
 
   useEffect(() => {
     return convo.on(event => {

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -42,6 +42,7 @@ import {
   ProgressGuideAction,
   useProgressGuideControls,
 } from '../shell/progress-guide'
+import {RQKEY_ROOT as RQKEY_LIST_CONVOS} from './messages/list-conversations'
 import {RQKEY as RQKEY_MY_BLOCKED} from './my-blocked-accounts'
 import {RQKEY as RQKEY_MY_MUTED} from './my-muted-accounts'
 
@@ -527,6 +528,11 @@ export function useProfileBlockMutationQueue(
       updateProfileShadow(queryClient, did, {
         blockingUri: finalBlockingUri,
       })
+      // The shadow only reaches components that read profiles through shadow
+      // hooks. The convo list is also read raw (e.g. the unread badge's
+      // calculateCount, getMessageInfo), and blocks emit no chat log event,
+      // so without a refetch that data stays stale indefinitely.
+      void queryClient.invalidateQueries({queryKey: [RQKEY_LIST_CONVOS]})
     },
   })
 


### PR DESCRIPTION
Stacked on #10827. Fixes issues found in code review of that branch:

### Placeholder bubbles regression (`AvatarBubbles.tsx`)
`if (!profile) return null` dropped the `AvatarPlaceholder` path for `undefined` entries, but `OutgoingRequestListItem`, `JoinRequest`, and `GroupChatJoinDialog` deliberately pad `profiles` with `Array(n).fill(undefined)` to render placeholder bubbles for unknown group members – they were rendering a lone avatar positioned for a 4-bubble layout. Switched to `useMaybeProfileShadow` so the profile can stay optional, and collapsed the two `Animated.View` returns back into one.

### Convo agent shadow merge could be clobbered (`agent.ts`)
`mergeProfileShadow` baked the shadow into `relatedProfiles` as a one-shot mutation. Any subsequent server write (`setConvo`/`updateConvo`/`fetchMemberList`/`fetchMessageHistory`/firehose ingestion) replaced the merged entry with a raw server profile – and since these objects come from direct service fetches, they're invisible to the shadow cache's react-query scan, so e.g. an optimistic block would visually revert on resume/refresh while the chat server's `viewer` state lagged. Now the agent keeps an accumulating `profileShadows: Map<did, Partial<ProfileShadow>>` overlay and re-applies it after every server write. Also:

- shadows now apply to `convo.members`/`primaryMember` too (previously only message rows updated; ConversationSettings, the group info panel, and ChatStatusInfo kept stale state)
- updates for dids not yet in `relatedProfiles` are no longer silently dropped
- no-op merges (e.g. the finalize after an optimistic update writes the same value) skip `commit()`, avoiding a full items-snapshot rebuild that re-renders every message row
- the subscription moved out of React: `ConvoProvider`'s `useOnUpdateProfileShadow` hook (with its render-time ref write + eslint suppression) is replaced by a plain `listenProfileShadowUpdate` that the agent subscribes to in its own lifecycle, alongside its first subscriber

### Reinstated list-conversations invalidation on block (`profile.ts`)
The shadow path only reaches components that read profiles through shadow hooks. The convo list is also read raw – `calculateCount` (unread badge) and `getMessageInfo` moderate the cached `primaryMember` directly – and blocks emit no chat log event, so with the invalidation removed that data stayed stale indefinitely. Re-added with a comment explaining why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)