### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-submit-android.yml
+++ b/.github/workflows/build-submit-android.yml
@@ -11,6 +11,10 @@ on:
           - testflight-android
           - production
 
+# Deploys happen via EAS using EXPO_TOKEN; the GITHUB_TOKEN only checks out code
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.repository == 'bluesky-social/social-app'

--- a/.github/workflows/build-submit-ios.yml
+++ b/.github/workflows/build-submit-ios.yml
@@ -11,6 +11,10 @@ on:
           - testflight
           - production
 
+# Deploys happen via EAS using EXPO_TOKEN; the GITHUB_TOKEN only checks out code
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.repository == 'bluesky-social/social-app'

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -18,6 +18,10 @@ on:
         description: Runtime version (in x.x.x format) that this update is for
         required: true
 
+# Deploys happen via EAS using EXPO_TOKEN; the GITHUB_TOKEN only checks out code
+permissions:
+  contents: read
+
 jobs:
   bundleDeploy:
     if: github.repository == 'bluesky-social/social-app'

--- a/.github/workflows/golang-test-lint.yml
+++ b/.github/workflows/golang-test-lint.yml
@@ -10,6 +10,9 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}"
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-comment.yml
+++ b/.github/workflows/pull-request-comment.yml
@@ -5,16 +5,15 @@ on:
   issue_comment:
     types: [created]
 
-# Permissiosn to make comments in the pull request
-permissions:
-  pull-requests: write
-  actions: write
-  contents: read
+# Permissions are granted per-job below; anything unlisted defaults to none
+permissions: {}
 
 jobs:
   handle-comment:
     if: github.event.issue.pull_request
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       should-deploy: ${{ steps.check-org.outputs.result }}
 
@@ -45,7 +44,7 @@ jobs:
             echo "mentioned=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Check organization membership
+      - name: Check commenter has write access
         if: steps.check-mention.outputs.mentioned == 'true'
         id: check-org
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -72,6 +71,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [handle-comment]
     if: needs.handle-comment.outputs.should-deploy == 'true'
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Get PR HEAD SHA
@@ -86,6 +88,16 @@ jobs:
               repo: context.repo.repo,
               pull_number: process.env.ISSUE_NUMBER,
             });
+
+            // This workflow runs with repo secrets in scope, so never build
+            // code from a fork: the commenter authorizes the deploy, but a
+            // fork controls what code would run during it
+            const expected = `${context.repo.owner}/${context.repo.repo}`;
+            const head = pr.data.head.repo?.full_name;
+            if (head !== expected) {
+              core.setFailed(`OTA deploys are only allowed for branches in ${expected}, not forks (got ${head})`);
+              return;
+            }
 
             console.log(`PR HEAD SHA: ${pr.data.head.sha}`);
             console.log(`PR HEAD REF: ${pr.data.head.ref}`);

--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -13,15 +13,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  pull-requests: write
-  actions: write
-  contents: read
+# Permissions are granted per-job below; anything unlisted defaults to none.
+# pull-requests: write is needed by sticky-pull-request-comment to post the
+# bundle-size and fingerprint diffs
+permissions: {}
 
 jobs:
   webpack-analyzer:
     runs-on: ubuntu-22.04
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request'}}
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -108,6 +111,9 @@ jobs:
   fingerprint-native:
     runs-on: ubuntu-22.04
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request'}}
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/sync-internal.yaml
+++ b/.github/workflows/sync-internal.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+# The push to the internal repo uses the app token below, not the GITHUB_TOKEN
+permissions:
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -20,6 +24,9 @@ jobs:
           app-id: ${{ vars.SYNC_INTERNAL_APP_ID }}
           private-key: ${{ secrets.SYNC_INTERNAL_PK }}
           repositories: social-app-internal
+          # Scope the token down from the app's full installation permissions;
+          # pushing is the only thing this token is used for
+          permission-contents: write
       - name: Push to internal repo
         env:
           TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/verify-pnpm-lock.yml
+++ b/.github/workflows/verify-pnpm-lock.yml
@@ -6,6 +6,9 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}"
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   verify-pnpm-lock:
     name: No manual pnpm-lock.yaml edits

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,37 @@
+name: Workflow security
+
+on:
+  push:
+    branches: [main]
+    paths: [".github/**"]
+  pull_request:
+    paths: [".github/**"]
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+# The github.token is only used by zizmor's online audits (read-only API calls)
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Audit workflows with zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          # Annotate the PR directly instead of uploading SARIF to the
+          # security tab, and fail the check on any finding
+          advanced-security: false
+          annotations: true
+          # Low-confidence findings (e.g. artipacked on workflows that never
+          # push) are too noisy to gate CI on
+          min-confidence: medium


### PR DESCRIPTION
Stacked on #10779. Follow-ups from auditing the workflows while pinning actions:

## Block OTA deploys for fork PRs (the important one)

`pull-request-comment.yml` triggers on `issue_comment`, so it always runs in the base repo's context with all secrets in scope. It checked that the *commenter* had write access, but then checked out and built *whatever the PR head pointed at* – including fork branches. A malicious PR with e.g. a `postinstall` script plus a social-engineered "ota" comment would run attacker code with `EXPO_TOKEN`, `SENTRY_AUTH_TOKEN`, `DENIS_API_KEY`, `GOOGLE_SERVICES_TOKEN` and `ENV_TOKEN` available.

The deploy job now fails early unless the PR head branch lives in this repo – the same guard `pull-request-commit.yml` already had.

## Least-privilege permissions everywhere

- Six workflows had no `permissions:` block at all and fell back to the repo default. All now declare `contents: read` (none of them need more – deploys go through EAS tokens, not the `GITHUB_TOKEN`).
- `pull-request-commit.yml` and `pull-request-comment.yml` had workflow-level `actions: write` + `pull-requests: write`; `actions: write` was unused and is gone, and the remaining grants moved down to the specific jobs that comment on PRs.
- `sync-internal.yaml`'s GitHub App token now requests `permission-contents: write` instead of inheriting the app's full installation permissions.

## zizmor in CI

New `zizmor.yml` workflow runs [zizmor](https://docs.zizmor.sh) on changes to `.github/` and fails on medium+ confidence findings (low-confidence is too noisy – mostly `artipacked` warnings on workflows that never push). It posts findings as PR annotations. The tree is clean at this threshold as of this PR; it would have caught everything fixed above, plus the unpinned actions from the parent PR.

Also fixes the misleading "Check organization membership" step name (it checks collaborator permission level) and a "Permissiosn" typo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)