### PR TITLE
Enable Google Translate in post overflow menu

### DIFF
--- a/src/components/PostControls/PostMenu/PostMenuItems.tsx
+++ b/src/components/PostControls/PostMenu/PostMenuItems.tsx
@@ -551,9 +551,13 @@ let PostMenuItems = ({
               ) : (
                 <Menu.Item
                   testID="postDropdownTranslateBtn"
-                  label={l`Translate`}
+                  label={
+                    forceGoogleTranslate ? l`Google Translate` : l`Translate`
+                  }
                   onPress={onPressTranslate}>
-                  <Menu.ItemText>{l`Translate`}</Menu.ItemText>
+                  <Menu.ItemText>
+                    {forceGoogleTranslate ? l`Google Translate` : l`Translate`}
+                  </Menu.ItemText>
                   <Menu.ItemIcon icon={Translate} position="right" />
                 </Menu.Item>
               )}

--- a/src/components/PostControls/PostMenu/PostMenuItems.tsx
+++ b/src/components/PostControls/PostMenu/PostMenuItems.tsx
@@ -552,11 +552,15 @@ let PostMenuItems = ({
                 <Menu.Item
                   testID="postDropdownTranslateBtn"
                   label={
-                    forceGoogleTranslate ? l`Google Translate` : l`Translate`
+                    forceGoogleTranslate
+                      ? l`Open in Google Translate`
+                      : l`Translate`
                   }
                   onPress={onPressTranslate}>
                   <Menu.ItemText>
-                    {forceGoogleTranslate ? l`Google Translate` : l`Translate`}
+                    {forceGoogleTranslate
+                      ? l`Open in Google Translate`
+                      : l`Translate`}
                   </Menu.ItemText>
                   <Menu.ItemIcon icon={Translate} position="right" />
                 </Menu.Item>

--- a/src/components/PostControls/index.tsx
+++ b/src/components/PostControls/index.tsx
@@ -54,7 +54,7 @@ let PostControls = ({
   onShowLess,
   viaRepost,
   variant,
-  forceGoogleTranslate = false,
+  forceGoogleTranslate = true,
 }: {
   big?: boolean
   post: Shadow<AppBskyFeedDefs.PostView>


### PR DESCRIPTION
Flips the default from `false` to `true`. This is just an alternative to inline translation, which still uses on-device APIs (when available).