### PR TITLE
Use add-only photo permission when saving QR codes

### DIFF
--- a/src/components/StarterPack/QrCodeDialog.tsx
+++ b/src/components/StarterPack/QrCodeDialog.tsx
@@ -1,8 +1,7 @@
 import {Suspense, useRef, useState} from 'react'
 import {View} from 'react-native'
 import type ViewShot from 'react-native-view-shot'
-import {requestMediaLibraryPermissionsAsync} from 'expo-image-picker'
-import {createAssetAsync} from 'expo-media-library'
+import {requestPermissionsAsync, saveToLibraryAsync} from 'expo-media-library'
 import * as Sharing from 'expo-sharing'
 import {type AppBskyGraphDefs, AppBskyGraphStarterpack} from '@atproto/api'
 import {msg} from '@lingui/core/macro'
@@ -60,7 +59,9 @@ export function QrCodeDialog({
   const onSavePress = async () => {
     ref.current?.capture?.().then(async (uri: string) => {
       if (IS_NATIVE) {
-        const res = await requestMediaLibraryPermissionsAsync()
+        // Write-only permission - saving the QR image does not require read
+        // access to the user's photo library.
+        const res = await requestPermissionsAsync(true)
 
         if (!res.granted) {
           Toast.show(
@@ -73,7 +74,9 @@ export function QrCodeDialog({
 
         // Incase of a FS failure, don't crash the app
         try {
-          await createAssetAsync(`file://${uri}`)
+          // saveToLibraryAsync writes without reading the asset back, so it
+          // works with the add-only permission on iOS (APP-2374)
+          await saveToLibraryAsync(`file://${uri}`)
         } catch (e: unknown) {
           Toast.show(_(msg`An error occurred while saving the QR code!`), {
             type: 'error',

--- a/src/features/inviteFriends/InviteFriendsDialogInner.tsx
+++ b/src/features/inviteFriends/InviteFriendsDialogInner.tsx
@@ -2,7 +2,7 @@ import {Suspense, useRef, useState} from 'react'
 import {Pressable, View} from 'react-native'
 import type ViewShot from 'react-native-view-shot'
 import {setStringAsync} from 'expo-clipboard'
-import {createAssetAsync, requestPermissionsAsync} from 'expo-media-library'
+import {requestPermissionsAsync, saveToLibraryAsync} from 'expo-media-library'
 import {useLingui} from '@lingui/react/macro'
 import {useNavigation} from '@react-navigation/native'
 
@@ -92,7 +92,10 @@ export function InviteFriendsDialogInner({
     }
 
     try {
-      await createAssetAsync(`file://${uri}`)
+      // saveToLibraryAsync writes without reading the asset back, so it works
+      // with the add-only permission. createAssetAsync fetches the created
+      // asset, which triggers the full library read prompt on iOS (APP-2374).
+      await saveToLibraryAsync(`file://${uri}`)
       ax.metric('invite:action:download', {})
       Toast.show(l`QR code saved to your camera roll!`)
     } catch (err) {


### PR DESCRIPTION
## Problem

On a fresh iOS install, pressing Download in the invite friends dialog showed the full photo library read permission prompt and a failure toast at the same time, and the save did not complete.

The handler already requested the add-only permission (`requestPermissionsAsync(true)`), but then called `createAssetAsync`. In expo-media-library's iOS module, `createAssetAsync` fetches the created asset back via `PHAsset.fetchAssets` to resolve the promise with asset metadata. That fetch is a photo library read: with read-write authorization still undetermined, the Photos framework auto-prompts for full library access, the fetch returns nil, and the promise rejects, which produced the simultaneous prompt and error toast.

## Fix

Use `saveToLibraryAsync` instead, which writes via `UIImageWriteToSavedPhotosAlbum` and never reads the library. This matches the existing lightbox image download flow (`save-image.ios.ts`).

The starter pack QR dialog had the same pattern, plus it requested the read-scoped media library permission from expo-image-picker. It now uses the same add-only request and `saveToLibraryAsync`.

## Android

Checked against expo-media-library's Android source: `saveToLibraryAsync` uses the same `createAssetWithAlbumId` write path as `createAssetAsync`, minus resolving the asset info back to JS. Its permission gate passes unconditionally on API 33+, and on older API levels it needs `WRITE_EXTERNAL_STORAGE`, which is exactly what `requestPermissionsAsync(true)` requests there. The starter pack dialog no longer prompts for read access on Android either.

## Testing

`pnpm typecheck`, `pnpm lint`, and `prettier --check` pass. Permission state is sticky per install, so this should get a QA pass on a fresh install via TestFlight to confirm only the "Add Photos Only" prompt appears and the save completes.