### PR TITLE
Redirect to messages after leaving a chat

### DIFF
--- a/src/screens/Messages/components/ChatEnded.tsx
+++ b/src/screens/Messages/components/ChatEnded.tsx
@@ -1,6 +1,6 @@
 import {Pressable} from 'react-native'
 import {Trans, useLingui} from '@lingui/react/macro'
-import {StackActions, useNavigation} from '@react-navigation/native'
+import {useNavigation} from '@react-navigation/native'
 
 import {HITSLOP_10} from '#/lib/constants'
 import {type NavigationProp} from '#/lib/routes/types'
@@ -34,8 +34,7 @@ export function ChatEnded({
 
   const {mutate: leaveConvo} = useLeaveConvo(convo.view.id, {
     onSuccess: () => {
-      // Settings > Chat > Chat list
-      navigation.dispatch(StackActions.pop(2))
+      navigation.replace('Messages', {animation: 'pop'})
     },
     onError: e => {
       logger.error('Failed to leave group chat', {message: e})

--- a/src/screens/Messages/components/ChatLocked.tsx
+++ b/src/screens/Messages/components/ChatLocked.tsx
@@ -1,7 +1,7 @@
 import {Pressable} from 'react-native'
 import {ChatBskyConvoUnlockConvo} from '@atproto/api'
 import {Trans, useLingui} from '@lingui/react/macro'
-import {StackActions, useNavigation} from '@react-navigation/native'
+import {useNavigation} from '@react-navigation/native'
 
 import {HITSLOP_10} from '#/lib/constants'
 import {type NavigationProp} from '#/lib/routes/types'
@@ -54,8 +54,7 @@ export function ChatLocked({
 
   const {mutate: leaveConvo} = useLeaveConvo(convo.view.id, {
     onSuccess: () => {
-      // Settings > Chat > Chat list
-      navigation.dispatch(StackActions.pop(2))
+      navigation.replace('Messages', {animation: 'pop'})
     },
     onError: e => {
       logger.error('Failed to leave group chat', {message: e})


### PR DESCRIPTION
This works even when there’s no stack history, e.g., direct URL.