### PR TITLE
[Chat] Update single-convo cache on firehose mute/unmute events

### DIFF
--- a/src/state/queries/messages/list-conversations.tsx
+++ b/src/state/queries/messages/list-conversations.tsx
@@ -510,13 +510,13 @@ export function ListConvosProviderInner({
               },
             )
           } else if (ChatBskyConvoDefs.isLogMuteConvo(log)) {
-            updateConvoInAllLists(log.convoId, convo => ({
+            mutateConvoView(log.convoId, convo => ({
               ...convo,
               muted: true,
               rev: log.rev,
             }))
           } else if (ChatBskyConvoDefs.isLogUnmuteConvo(log)) {
-            updateConvoInAllLists(log.convoId, convo => ({
+            mutateConvoView(log.convoId, convo => ({
               ...convo,
               muted: false,
               rev: log.rev,


### PR DESCRIPTION
## Why

When a mute/unmute event arrives over the firehose (e.g. you muted the chat on another device), the log handler in `list-conversations.tsx` only updated the convo-list and request-list caches via `updateConvoInAllLists`. The single-convo cache used by `useConvoQuery` (`CONVO_KEY`) was never touched, and since that query has `staleTime: STALE.INFINITY` it never refetches on its own.

Previously this was masked because nothing user-facing read `muted` from the single-convo cache, but with the conversation settings screen now powered by `useConvoQuery` (#10853), the mute toggle would show stale state until something else invalidated the query.

## How

Swap `updateConvoInAllLists` → `mutateConvoView` in the `isLogMuteConvo` / `isLogUnmuteConvo` branches, matching what the lock/unlock and member add/remove branches already do. `mutateConvoView` writes the `CONVO_KEY` cache and then calls `updateConvoInAllLists` internally, so list behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)