### PR TITLE
Keep lightbox image index on device rotation

### DIFF
--- a/src/components/Lightbox/pager/ImagePager.tsx
+++ b/src/components/Lightbox/pager/ImagePager.tsx
@@ -91,6 +91,9 @@ export default function ImageViewRoot({
   'use no memo'
   const ref = useAnimatedRef<View>()
   const [activeLightbox, setActiveLightbox] = useState(nextLightbox)
+  // Lives here rather than in ImageView so it survives the remount
+  // when the orientation-based key below changes on rotation.
+  const [imageIndex, setImageIndex] = useState(nextLightbox?.index ?? 0)
   const [orientation, setOrientation] = useState<'portrait' | 'landscape'>(
     'portrait',
   )
@@ -101,6 +104,7 @@ export default function ImageViewRoot({
 
   if (!activeLightbox && nextLightbox) {
     setActiveLightbox(nextLightbox)
+    setImageIndex(nextLightbox.index)
   }
 
   useEffect(() => {
@@ -193,6 +197,8 @@ export default function ImageViewRoot({
           <ImageView
             key={activeLightbox.id + '-' + orientation}
             lightbox={activeLightbox}
+            imageIndex={imageIndex}
+            setImageIndex={setImageIndex}
             orientation={orientation}
             onRequestClose={onRequestClose}
             onPressSave={onPressSave}
@@ -210,6 +216,8 @@ export default function ImageViewRoot({
 
 function ImageView({
   lightbox,
+  imageIndex,
+  setImageIndex,
   orientation,
   onRequestClose,
   onPressSave,
@@ -220,6 +228,8 @@ function ImageView({
   thumbRects,
 }: {
   lightbox: Lightbox
+  imageIndex: number
+  setImageIndex: React.Dispatch<React.SetStateAction<number>>
   orientation: 'portrait' | 'landscape'
   onRequestClose: () => void
   onPressSave: (uri: string) => void
@@ -229,12 +239,14 @@ function ImageView({
   openProgress: SharedValue<number>
   thumbRects: SharedValue<Record<number, MeasuredDimensions | null>>
 }) {
-  const {images, index: initialImageIndex, metricsContext} = lightbox
+  const {images, metricsContext} = lightbox
+  // Capture at mount: after a rotation remount this is the preserved
+  // current index, so the pager re-opens on the same image.
+  const [initialImageIndex] = useState(imageIndex)
   const ax = useAnalytics()
   const isAnimated = useMemo(() => canAnimate(lightbox), [lightbox])
   const [isScaled, setIsScaled] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
-  const [imageIndex, setImageIndex] = useState(initialImageIndex)
   const [showControls, setShowControls] = useState(true)
   const [isAltExpanded, setIsAltExpanded] = useState(false)
   const dismissSwipeTranslateY = useSharedValue(0)


### PR DESCRIPTION
## Why

Rotating the device while the lightbox is open snaps the pager back to the originally tapped image. Repro: open a post with multiple photos, tap the first photo, swipe to a later one, rotate the device. The lightbox jumps back to the first photo.

## Root cause

`ImageView` is rendered with `key={activeLightbox.id + '-' + orientation}`, so rotation intentionally remounts it to re-layout the transition transforms. The current image index lived inside `ImageView` as `useState(lightbox.index)`, so the remount reset it to the opening index and `PagerView` re-opened at `initialPage = lightbox.index`.

## Fix

Lift `imageIndex` up into `ImageViewRoot`, which survives rotation, and have `ImageView` capture the pager's `initialPage` from the preserved index at mount. The orientation-keyed remount itself is unchanged.

This takes the same approach as the earlier `samuel/lightbox-rotate-keep-index` branch, which fixed this in the pre-redesign lightbox but never landed; the redesign carried the bug forward. That branch can likely be deleted once this merges.

Notes from checking side effects: the swipe analytic does not fire on the rotation remount (prev and next are equal), the close animation measures the correct thumbnail after rotating, and Android gets the fix too since this is the shared native pager.