### PR TITLE
Fix overlapping touch targets for profile header buttons

### DIFF
--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -360,6 +360,10 @@ export function HeaderStandardButtons({
               size="small"
               color="secondary"
               shape="round"
+              // expand the 33pt button toward a 44pt touch target, capped
+              // horizontally at half the 4pt row gap so the target cannot
+              // overlap the neighboring buttons' own targets
+              hitSlop={{top: 6, bottom: 6, left: 2, right: 2}}
               onPress={() => {
                 playHaptic('Light')
                 ax.metric('invite:dialog:open', {logContext: 'ProfileHeader'})

--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -4,7 +4,6 @@ import {Trans, useLingui} from '@lingui/react/macro'
 import {useNavigation} from '@react-navigation/native'
 import {useQueryClient} from '@tanstack/react-query'
 
-import {HITSLOP_20} from '#/lib/constants'
 import {makeProfileLink} from '#/lib/routes/links'
 import {type NavigationProp} from '#/lib/routes/types'
 import {shareText, shareUrl} from '#/lib/sharing'
@@ -264,7 +263,10 @@ let ProfileMenu = ({
                   {...props}
                   testID="profileHeaderDropdownBtn"
                   label={l`More options`}
-                  hitSlop={HITSLOP_20}
+                  // hitSlop reaches outside parent views on iOS, so the
+                  // left inset must stay within half of the 4pt row gap or
+                  // it steals taps from the adjacent header button
+                  hitSlop={{top: 6, bottom: 6, left: 2, right: 12}}
                   variant="solid"
                   color="secondary"
                   size="small"


### PR DESCRIPTION
## Problem

The "More options" (ellipsis) button in the profile header has a 20pt hitSlop on all sides. The header action buttons are 33pt tall (round ones 33x33) and sit 4pt apart, so the ellipsis touch target reached across the gap and covered almost half of its left neighbor: the new invite friends button on your own profile, and the follow button on other profiles. On iOS, a child's hitSlop is not clipped by non-clipping parent views, and later siblings win hit testing, so taps up to the center of the invite button opened the menu instead of the share sheet.

The invite button also had no hitSlop of its own, leaving it a bare 33pt target against the platform 44pt guideline.

## Fix

- Replace the ellipsis `HITSLOP_20` with `{top: 6, bottom: 6, left: 2, right: 12}`: the left inset is capped at half the 4pt row gap so it can no longer overlap a neighbor, and the right side stays generous since there is only container padding beside it.
- Give the invite button `{top: 6, bottom: 6, left: 2, right: 2}`, capped at half the gap on both sides (Edit Profile sits to its left).

The two targets now tile edge to edge with no overlap and no dead zone, and both get 45pt of effective height. This also stops the ellipsis from stealing taps from the follow button on other profiles and from the subscribe button on labeler profiles.

## Test plan

- Verified on the iOS simulator: taps anywhere on the invite button (including the previously stolen right half) open the invite share sheet, taps on and around the ellipsis open the menu.
- `pnpm typecheck`, `pnpm lint`, prettier, and the jest suite all pass.