### PR TITLE
Bump font size for disabled invite link dialog text

### DIFF
--- a/src/components/intents/GroupChatJoinDialog.tsx
+++ b/src/components/intents/GroupChatJoinDialog.tsx
@@ -262,7 +262,7 @@ function GroupChatJoinDialogContent({code}: {code?: string}) {
               style={[
                 a.mb_2xs,
                 a.text_center,
-                a.text_sm,
+                a.text_lg,
                 a.font_medium,
                 t.atoms.text_contrast_high,
               ]}>


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="1206" height="2622" alt="before" src="https://github.com/user-attachments/assets/c520595c-01de-4cd6-bfbd-098a559c85dd" /> | <img width="1206" height="2622" alt="after" src="https://github.com/user-attachments/assets/98569a16-517f-47f0-a7e8-278fdf992b3f" /> |