### PR TITLE
Fixes follow buttons inside notification bundles not changing state on follow

### DIFF
--- a/src/state/queries/notifications/feed.ts
+++ b/src/state/queries/notifications/feed.ts
@@ -319,12 +319,15 @@ export function* findAllProfilesInQueryData(
     }
     for (const page of queryData?.pages) {
       for (const item of page.items) {
-        if (
-          (item.type === 'follow' || item.type === 'contact-match') &&
-          item.notification.author.did === did
-        ) {
+        if (item.notification.author.did === did) {
           yield item.notification.author
-        } else if (
+        }
+        for (const notification of item.additional ?? []) {
+          if (notification.author.did === did) {
+            yield notification.author
+          }
+        }
+        if (
           item.type !== 'starterpack-joined' &&
           item.subject?.author.did === did
         ) {


### PR DESCRIPTION
## Problem

When the `notifications:expanded_profile_card:enable` gate is enabled, "Follow" buttons appear inside expanded notification bundles on the Notifications page. When you clicked these, they did not update to a "Following" state. This should now be fixed. 

## Testing

Requires the `NotificationsExpandedProfileCardEnable` gate enabled, and an account with a grouped notification (e.g. "X and 2 others followed you" or "X and 2 others liked your post").

1. Go to Notifications and expand a grouped notification (tap the chevron)
2. Press **+ Follow** on one of the bundled (non-first) users
3. Button should immediately change to **Following** (previously: toast appeared but button stayed **+ Follow**)
4. Also verify the first author in a *like/repost* bundle updates on follow, and that pressing **Following** reverts it (unfollow)
5. Sanity-check the ungated path: a single (non-bundled) "followed you" notification's follow-back button still updates as before