### PR TITLE
Fix chat firehose event handling and error recovery

### DIFF
--- a/src/state/messages/events/agent.ts
+++ b/src/state/messages/events/agent.ts
@@ -211,17 +211,9 @@ export class MessagesEventBus {
       }
       case MessagesEventBusStatus.Error: {
         switch (action.event) {
-          case MessagesEventBusDispatchEvent.UpdatePoll: {
-            // basically reset
-            this.status = MessagesEventBusStatus.Initializing
-            this.latestRev = undefined
-            this.init()
-            break
-          }
+          case MessagesEventBusDispatchEvent.UpdatePoll:
           case MessagesEventBusDispatchEvent.Resume: {
-            this.status = MessagesEventBusStatus.Ready
-            this.resetPoll()
-            this.emitter.emit('event', {type: 'connect'})
+            this.recoverFromError()
             break
           }
         }
@@ -236,6 +228,31 @@ export class MessagesEventBus {
       prev: prevStatus,
       next: this.status,
     })
+  }
+
+  private recoverFromError() {
+    logger.debug(`recoverFromError`, {hasRev: !!this.latestRev})
+
+    if (this.latestRev === undefined) {
+      /*
+       * init() never succeeded, so we have no cursor to resume from. Re-run
+       * init() to seed latestRev. Its success path dispatches Ready, which from
+       * Initializing transitions us to Ready + resetPoll + emit connect.
+       */
+      this.status = MessagesEventBusStatus.Initializing
+      this.init()
+    } else {
+      /*
+       * A poll failed mid-session but we still have a valid cursor. Resume
+       * polling from it directly. We must NOT route through init() here: its
+       * seeding logic takes the max of the existing rev and the server's
+       * current cursor, which would skip any events that arrived while we were
+       * offline.
+       */
+      this.status = MessagesEventBusStatus.Ready
+      this.resetPoll()
+      this.emitter.emit('event', {type: 'connect'})
+    }
   }
 
   private async init() {
@@ -337,6 +354,9 @@ export class MessagesEventBus {
     //   },
     // )
 
+    let needsEmit = false
+    let batch: ChatBskyConvoGetLog.OutputSchema['logs'] = []
+
     try {
       const response = await networkRetry(2, () => {
         return this.agent.chat.bsky.convo.getLog(
@@ -350,9 +370,6 @@ export class MessagesEventBus {
       // throw new Error('UNCOMMENT TO TEST POLL FAILURE')
 
       const {logs: events} = response.data
-
-      let needsEmit = false
-      let batch: ChatBskyConvoGetLog.OutputSchema['logs'] = []
 
       for (const ev of events) {
         /*
@@ -373,10 +390,6 @@ export class MessagesEventBus {
           }
         }
       }
-
-      if (needsEmit) {
-        this.emitter.emit('event', {type: 'logs', logs: batch})
-      }
     } catch (e: any) {
       if (!isNetworkError(e) && !isErrorMaybeAppPasswordPermissions(e)) {
         logger.error(`poll events failed`, {
@@ -396,6 +409,23 @@ export class MessagesEventBus {
       })
     } finally {
       this.isPolling = false
+    }
+
+    /*
+     * Emit outside the try/catch above so a throwing subscriber is not
+     * misreported as a poll failure (which would show a network-error banner
+     * and drop the batch, since the revs have already been consumed). poll()
+     * runs from setInterval, so we must not let the exception escape - log it
+     * and move on without dispatching Error.
+     */
+    if (needsEmit) {
+      try {
+        this.emitter.emit('event', {type: 'logs', logs: batch})
+      } catch (e) {
+        logger.error(`subscriber error handling chat events`, {
+          safeMessage: e instanceof Error ? e.message : String(e),
+        })
+      }
     }
   }
 }

--- a/src/state/queries/messages/list-conversations.tsx
+++ b/src/state/queries/messages/list-conversations.tsx
@@ -282,8 +282,11 @@ export function ListConvosProviderInner({
           mutateMembers(convoId, list =>
             list.some(m => m.did === did) ? list : list.concat(newMember),
           )
-          mutateConvoView(convoId, convo =>
-            addMemberToConvoView(convo, newMember, rev, alreadyKnownMember),
+          mutateConvoView(
+            convoId,
+            withRevGuard(rev, convo =>
+              addMemberToConvoView(convo, newMember, rev, alreadyKnownMember),
+            ),
           )
         }
 
@@ -301,8 +304,11 @@ export function ListConvosProviderInner({
               >(listConvoMembersQueryKey(convoId))
               ?.some(m => m.did === did) === false
           mutateMembers(convoId, list => list.filter(m => m.did !== did))
-          mutateConvoView(convoId, convo =>
-            removeMemberFromConvoView(convo, did, rev, alreadyRemovedMember),
+          mutateConvoView(
+            convoId,
+            withRevGuard(rev, convo =>
+              removeMemberFromConvoView(convo, did, rev, alreadyRemovedMember),
+            ),
           )
         }
 
@@ -317,24 +323,27 @@ export function ListConvosProviderInner({
             // link preview so its viewer state reflects the lost membership.
             void invalidateJoinLinkPreviewsForConvo(queryClient, log.convoId)
           } else if (ChatBskyConvoDefs.isLogDeleteMessage(log)) {
-            updateConvoInAllLists(log.convoId, convo => {
-              if (
-                (ChatBskyConvoDefs.isDeletedMessageView(log.message) ||
-                  ChatBskyConvoDefs.isMessageView(log.message)) &&
-                (ChatBskyConvoDefs.isDeletedMessageView(convo.lastMessage) ||
-                  ChatBskyConvoDefs.isMessageView(convo.lastMessage))
-              ) {
-                return log.message.id === convo.lastMessage.id
-                  ? {
-                      ...convo,
-                      rev: log.rev,
-                      lastMessage: log.message,
-                    }
-                  : convo
-              } else {
-                return convo
-              }
-            })
+            updateConvoInAllLists(
+              log.convoId,
+              withRevGuard(log.rev, convo => {
+                if (
+                  (ChatBskyConvoDefs.isDeletedMessageView(log.message) ||
+                    ChatBskyConvoDefs.isMessageView(log.message)) &&
+                  (ChatBskyConvoDefs.isDeletedMessageView(convo.lastMessage) ||
+                    ChatBskyConvoDefs.isMessageView(convo.lastMessage))
+                ) {
+                  return log.message.id === convo.lastMessage.id
+                    ? {
+                        ...convo,
+                        rev: log.rev,
+                        lastMessage: log.message,
+                      }
+                    : convo
+                } else {
+                  return convo
+                }
+              }),
+            )
           } else if (ChatBskyConvoDefs.isLogCreateMessage(log)) {
             // Store in a new var to avoid TS errors due to closures.
             const logRef: ChatBskyConvoDefs.LogCreateMessage = log
@@ -356,9 +365,20 @@ export function ListConvosProviderInner({
             }
 
             if (!foundConvo) {
-              // Convo not found, trigger refetch
+              // Convo not found, trigger refetch. Use continue (not return) so
+              // the remaining logs in this batch still apply - the bus advances
+              // its cursor past this batch, so a dropped log is never
+              // redelivered.
               debouncedRefetch()
-              return
+              continue
+            }
+
+            // Rev guard. updatedConvo is built once from foundConvo and applied
+            // across caches, so guarding here (rather than per-cache) is both
+            // simplest and correct - skip if the log isn't newer than the
+            // cached convo.
+            if (logRef.rev <= foundConvo.rev) {
+              continue
             }
 
             // add relatedProfiles to members list, but making sure to dedupe
@@ -449,17 +469,23 @@ export function ListConvosProviderInner({
               )
             }
           } else if (ChatBskyConvoDefs.isLogReadMessage(log)) {
-            updateConvoInAllLists(log.convoId, convo => ({
-              ...convo,
-              unreadCount: 0,
-              rev: log.rev,
-            }))
+            updateConvoInAllLists(
+              log.convoId,
+              withRevGuard(log.rev, convo => ({
+                ...convo,
+                unreadCount: 0,
+                rev: log.rev,
+              })),
+            )
           } else if (ChatBskyConvoDefs.isLogReadConvo(log)) {
-            updateConvoInAllLists(log.convoId, convo => ({
-              ...convo,
-              unreadCount: 0,
-              rev: log.rev,
-            }))
+            updateConvoInAllLists(
+              log.convoId,
+              withRevGuard(log.rev, convo => ({
+                ...convo,
+                unreadCount: 0,
+                rev: log.rev,
+              })),
+            )
           } else if (ChatBskyConvoDefs.isLogAcceptConvo(log)) {
             const requestQueries =
               queryClient.getQueriesData<ConvoListQueryData>({
@@ -472,13 +498,37 @@ export function ListConvosProviderInner({
               if (foundConvo) break
             }
             if (!foundConvo) {
+              // Use continue (not return) so the remaining logs in this batch
+              // still apply - the bus advances its cursor past this batch, so a
+              // dropped log is never redelivered.
               debouncedRefetch()
-              return
+              continue
+            }
+            if (log.rev <= foundConvo.rev) {
+              continue
             }
             const acceptedConvo: ChatBskyConvoDefs.ConvoView = {
               ...foundConvo,
               status: 'accepted',
+              rev: log.rev,
             }
+            // Flip status to 'accepted' in every cache that already holds this
+            // convo - including 'all'-status caches like the provider's
+            // always-mounted unread query, which the request->accepted move
+            // below otherwise never touches. Without this the stale 'all' copy
+            // keeps status: 'request', and the next isLogCreateMessage can seed
+            // foundConvo from it and resurrect the convo in the requests inbox.
+            // Runs before the delete-from-request below: it updates in place
+            // (never inserts), so the 'request' caches get the accepted copy and
+            // are then cleared by the delete, leaving no stale request entries.
+            updateConvoInAllLists(
+              log.convoId,
+              withRevGuard(log.rev, convo => ({
+                ...convo,
+                status: 'accepted',
+                rev: log.rev,
+              })),
+            )
             queryClient.setQueriesData(
               {queryKey: RQKEY_PARTIAL('request')},
               (old?: ConvoListQueryData) => optimisticDelete(log.convoId, old),
@@ -519,60 +569,75 @@ export function ListConvosProviderInner({
               },
             )
           } else if (ChatBskyConvoDefs.isLogMuteConvo(log)) {
-            mutateConvoView(log.convoId, convo => ({
-              ...convo,
-              muted: true,
-              rev: log.rev,
-            }))
+            mutateConvoView(
+              log.convoId,
+              withRevGuard(log.rev, convo => ({
+                ...convo,
+                muted: true,
+                rev: log.rev,
+              })),
+            )
           } else if (ChatBskyConvoDefs.isLogUnmuteConvo(log)) {
-            mutateConvoView(log.convoId, convo => ({
-              ...convo,
-              muted: false,
-              rev: log.rev,
-            }))
+            mutateConvoView(
+              log.convoId,
+              withRevGuard(log.rev, convo => ({
+                ...convo,
+                muted: false,
+                rev: log.rev,
+              })),
+            )
           } else if (ChatBskyConvoDefs.isLogLockConvo(log)) {
-            mutateConvoView(log.convoId, convo => {
-              if (ChatBskyConvoDefs.isGroupConvo(convo.kind)) {
-                return {
-                  ...convo,
-                  kind: {...convo.kind, lockStatus: 'locked'},
-                  rev: log.rev,
+            mutateConvoView(
+              log.convoId,
+              withRevGuard(log.rev, convo => {
+                if (ChatBskyConvoDefs.isGroupConvo(convo.kind)) {
+                  return {
+                    ...convo,
+                    kind: {...convo.kind, lockStatus: 'locked'},
+                    rev: log.rev,
+                  }
                 }
-              }
-              return {...convo, rev: log.rev}
-            })
+                return {...convo, rev: log.rev}
+              }),
+            )
             // The log event doesn't say whether the lock is forced by a
             // moderation override, so refetch to pick up the flag.
             void queryClient.invalidateQueries({
               queryKey: CONVO_KEY(log.convoId),
             })
           } else if (ChatBskyConvoDefs.isLogUnlockConvo(log)) {
-            mutateConvoView(log.convoId, convo => {
-              if (ChatBskyConvoDefs.isGroupConvo(convo.kind)) {
-                return {
-                  ...convo,
-                  kind: {
-                    ...convo.kind,
-                    lockStatus: 'unlocked',
-                    // An unlocked convo cannot be moderation-locked.
-                    lockStatusModerationOverride: false,
-                  },
-                  rev: log.rev,
+            mutateConvoView(
+              log.convoId,
+              withRevGuard(log.rev, convo => {
+                if (ChatBskyConvoDefs.isGroupConvo(convo.kind)) {
+                  return {
+                    ...convo,
+                    kind: {
+                      ...convo.kind,
+                      lockStatus: 'unlocked',
+                      // An unlocked convo cannot be moderation-locked.
+                      lockStatusModerationOverride: false,
+                    },
+                    rev: log.rev,
+                  }
                 }
-              }
-              return {...convo, rev: log.rev}
-            })
+                return {...convo, rev: log.rev}
+              }),
+            )
           } else if (ChatBskyConvoDefs.isLogLockConvoPermanently(log)) {
-            mutateConvoView(log.convoId, convo => {
-              if (ChatBskyConvoDefs.isGroupConvo(convo.kind)) {
-                return {
-                  ...convo,
-                  kind: {...convo.kind, lockStatus: 'locked-permanently'},
-                  rev: log.rev,
+            mutateConvoView(
+              log.convoId,
+              withRevGuard(log.rev, convo => {
+                if (ChatBskyConvoDefs.isGroupConvo(convo.kind)) {
+                  return {
+                    ...convo,
+                    kind: {...convo.kind, lockStatus: 'locked-permanently'},
+                    rev: log.rev,
+                  }
                 }
-              }
-              return {...convo, rev: log.rev}
-            })
+                return {...convo, rev: log.rev}
+              }),
+            )
           } else if (
             ChatBskyConvoDefs.isLogCreateJoinLink(log) ||
             ChatBskyConvoDefs.isLogEditJoinLink(log) ||
@@ -592,30 +657,39 @@ export function ListConvosProviderInner({
             // Route through mutateConvoView (not updateConvoInAllLists) so the
             // single-convo cache updates too, keeping the in-convo requests
             // banner in sync.
-            mutateConvoView(log.convoId, convo =>
-              applyJoinRequestCountDelta(convo, log.rev, -1),
+            mutateConvoView(
+              log.convoId,
+              withRevGuard(log.rev, convo =>
+                applyJoinRequestCountDelta(convo, log.rev, -1),
+              ),
             )
           } else if (ChatBskyConvoDefs.isLogIncomingJoinRequest(log)) {
             // Route through mutateConvoView (not updateConvoInAllLists) so the
             // single-convo cache updates too, letting the in-convo requests
             // banner appear live.
-            mutateConvoView(log.convoId, convo =>
-              applyJoinRequestCountDelta(convo, log.rev, 1),
+            mutateConvoView(
+              log.convoId,
+              withRevGuard(log.rev, convo =>
+                applyJoinRequestCountDelta(convo, log.rev, 1),
+              ),
             )
           } else if (ChatBskyConvoDefs.isLogReadJoinRequests(log)) {
             // The owner marked join requests as read (possibly on another
             // device). Zero the unread count but keep the total, mirroring the
             // useMarkJoinRequestsRead mutation.
-            mutateConvoView(log.convoId, convo => {
-              if (!ChatBskyConvoDefs.isGroupConvo(convo.kind)) {
-                return {...convo, rev: log.rev}
-              }
-              return {
-                ...convo,
-                kind: {...convo.kind, unreadJoinRequestCount: 0},
-                rev: log.rev,
-              }
-            })
+            mutateConvoView(
+              log.convoId,
+              withRevGuard(log.rev, convo => {
+                if (!ChatBskyConvoDefs.isGroupConvo(convo.kind)) {
+                  return {...convo, rev: log.rev}
+                }
+                return {
+                  ...convo,
+                  kind: {...convo.kind, unreadJoinRequestCount: 0},
+                  rev: log.rev,
+                }
+              }),
+            )
           } else if (ChatBskyConvoDefs.isLogOutgoingJoinRequest(log)) {
             // Viewer isn't in the chat yet, but the inbox surfaces outgoing
             // requests, so refetch to pick up the new entry.
@@ -623,8 +697,11 @@ export function ListConvosProviderInner({
           } else if (ChatBskyConvoDefs.isLogWithdrawIncomingJoinRequest(log)) {
             // A requester rescinded their request to a group the viewer owns.
             // Mirror of isLogIncomingJoinRequest: decrement the counts.
-            mutateConvoView(log.convoId, convo =>
-              applyJoinRequestCountDelta(convo, log.rev, -1),
+            mutateConvoView(
+              log.convoId,
+              withRevGuard(log.rev, convo =>
+                applyJoinRequestCountDelta(convo, log.rev, -1),
+              ),
             )
           } else if (ChatBskyConvoDefs.isLogWithdrawOutgoingJoinRequest(log)) {
             // The viewer rescinded their own outgoing join request (possibly on
@@ -634,25 +711,28 @@ export function ListConvosProviderInner({
               old => optimisticDeleteJoinRequest(log.convoId, old),
             )
           } else if (ChatBskyConvoDefs.isLogAddReaction(log)) {
-            updateConvoInAllLists(log.convoId, convo => {
-              // add relatedProfiles to members list, but making sure to dedupe
-              const relatedProfilesSansMembers = (
-                log.relatedProfiles ?? []
-              ).filter(
-                profile =>
-                  !convo.members.some(member => member.did === profile.did),
-              )
-              return {
-                ...convo,
-                members: [...convo.members, ...relatedProfilesSansMembers],
-                lastReaction: {
-                  $type: 'chat.bsky.convo.defs#messageAndReactionView',
-                  reaction: log.reaction,
-                  message: log.message,
-                },
-                rev: log.rev,
-              }
-            })
+            updateConvoInAllLists(
+              log.convoId,
+              withRevGuard(log.rev, convo => {
+                // add relatedProfiles to members list, but making sure to dedupe
+                const relatedProfilesSansMembers = (
+                  log.relatedProfiles ?? []
+                ).filter(
+                  profile =>
+                    !convo.members.some(member => member.did === profile.did),
+                )
+                return {
+                  ...convo,
+                  members: [...convo.members, ...relatedProfilesSansMembers],
+                  lastReaction: {
+                    $type: 'chat.bsky.convo.defs#messageAndReactionView',
+                    reaction: log.reaction,
+                    message: log.message,
+                  },
+                  rev: log.rev,
+                }
+              }),
+            )
           } else if (ChatBskyConvoDefs.isLogAddMember(log)) {
             const data = log.message.data
             if (
@@ -725,31 +805,35 @@ export function ListConvosProviderInner({
             queryClient.setQueriesData(
               {queryKey: [RQKEY_ROOT]},
               (old?: ConvoListQueryData) =>
-                optimisticUpdate(log.convoId, old, convo => {
-                  if (
-                    // if the convo is the same
-                    log.convoId === convo.id &&
-                    ChatBskyConvoDefs.isMessageAndReactionView(
-                      convo.lastReaction,
-                    ) &&
-                    ChatBskyConvoDefs.isMessageView(log.message) &&
-                    // ...and the message is the same
-                    convo.lastReaction.message.id === log.message.id &&
-                    // ...and the reaction is the same
-                    convo.lastReaction.reaction.sender.did ===
-                      log.reaction.sender.did &&
-                    convo.lastReaction.reaction.value === log.reaction.value
-                  ) {
-                    return {
-                      ...convo,
-                      // ...remove the reaction. hopefully they didn't react twice in a row!
-                      lastReaction: undefined,
-                      rev: log.rev,
+                optimisticUpdate(
+                  log.convoId,
+                  old,
+                  withRevGuard(log.rev, convo => {
+                    if (
+                      // if the convo is the same
+                      log.convoId === convo.id &&
+                      ChatBskyConvoDefs.isMessageAndReactionView(
+                        convo.lastReaction,
+                      ) &&
+                      ChatBskyConvoDefs.isMessageView(log.message) &&
+                      // ...and the message is the same
+                      convo.lastReaction.message.id === log.message.id &&
+                      // ...and the reaction is the same
+                      convo.lastReaction.reaction.sender.did ===
+                        log.reaction.sender.did &&
+                      convo.lastReaction.reaction.value === log.reaction.value
+                    ) {
+                      return {
+                        ...convo,
+                        // ...remove the reaction. hopefully they didn't react twice in a row!
+                        lastReaction: undefined,
+                        rev: log.rev,
+                      }
+                    } else {
+                      return convo
                     }
-                  } else {
-                    return convo
-                  }
-                }),
+                  }),
+                ),
             )
           }
         }
@@ -903,6 +987,25 @@ export function useOnMarkAsRead() {
     },
     [queryClient],
   )
+}
+
+/**
+ * Wraps a log-driven convo update so it's skipped when the log is not newer
+ * than the cached convo. Lists are fed by two unsynchronized channels (full
+ * listConvos refetches and the log stream), so a stale refetch snapshot can be
+ * written after a log already applied, or a refetch can already include a
+ * message whose log then arrives and double-counts. Rev comparison as plain
+ * string comparison is safe here - revs are fixed-width. ConvoView.rev is a
+ * required field per the lexicon, so convo.rev always exists.
+ *
+ * Only used in the log-event paths (which have a log.rev), never in the generic
+ * optimisticUpdate helper, which mutations without a rev also call.
+ */
+function withRevGuard(
+  rev: string,
+  fn: (convo: ChatBskyConvoDefs.ConvoView) => ChatBskyConvoDefs.ConvoView,
+): (convo: ChatBskyConvoDefs.ConvoView) => ChatBskyConvoDefs.ConvoView {
+  return convo => (rev <= convo.rev ? convo : fn(convo))
 }
 
 function optimisticUpdate(


### PR DESCRIPTION
Fixes the highest-impact findings from a deep review of the chat firehose → React Query sync layer.

## Event bus (`src/state/messages/events/agent.ts`)

**Failed-init recovery produced a permanent "zombie" firehose.** If `init()` failed (e.g. cold start on flaky connectivity), `latestRev` was never seeded, and recovering via `Resume` went straight to `Ready` without re-running `init()`. The bus then polled forever with `cursor: undefined` — which the server treats as "fast-forward to now, return nothing" — so every event for the rest of the session was silently skipped while the UI reported healthy. Meanwhile the `UpdatePoll` recovery arm had the opposite flaw: it discarded a perfectly good cursor and re-seeded from "now", permanently skipping the offline gap. Both arms now share cursor-aware logic: re-run `init()` when there's no cursor, resume polling from the existing cursor when there is one.

**A throwing subscriber faked a network error.** `emitter.emit` sat inside `poll()`'s try/catch, and eventemitter3 propagates handler exceptions synchronously — so any bug in a subscriber was caught as `PollFailed`: error banner shown, later subscribers never received the batch, revs already consumed. The emit now lives outside the try/catch in its own narrow guard that logs the subscriber error without dispatching a bus error.

## List sync (`src/state/queries/messages/list-conversations.tsx`)

**`return` instead of `continue` dropped the rest of every affected batch.** The two "convo not found → refetch" paths exited the whole handler, discarding every remaining log in the batch — and the bus advances its cursor past the batch before emitting, so dropped logs are never redelivered. This fired routinely (a new convo's first message arrives in the same batch as its `logBeginConvo`; locally accepting a chat empties the request caches before the echoed `logAcceptConvo` arrives). The fallback refetch heals the list caches but not the infinite-staleTime single-convo cache or the members cache, so e.g. a `logMuteConvo` later in the same batch left the convo menu showing the wrong mute state indefinitely.

**Accepted convos could resurrect in the request inbox.** `logAcceptConvo` moved the convo between 'request' and 'accepted' caches but never touched 'all'-status caches — including the provider's always-mounted unread query, which kept `status: 'request'` indefinitely. The next `logCreateMessage` could then seed its convo from that stale copy and prepend the already-accepted convo back into the requests inbox, Accept/Reject buttons and all. The handler now also flips `status: 'accepted'` in every cache holding the convo.

**No rev guard on cache writes.** Lists are fed by two unsynchronized channels (full `listConvos` refetches and the log stream), so a refetch snapshot taken before a message could land after the log applied it — reverting it with the rev already consumed — or a refetch could already include a message whose log then arrived and double-counted `unreadCount`. Log-driven updates now skip when `log.rev <= convo.rev` via a `withRevGuard` wrapper (only on log paths; rev-less mutations like `useOnMarkAsRead` are untouched).

## Test plan

- `pnpm typecheck`, `pnpm lint`, `pnpm test` all pass (the only failing suites are from a stale `.claude/worktrees/` directory unrelated to this change)
- No existing test coverage for these modules; changes verified by review

🤖 Generated with [Claude Code](https://claude.com/claude-code)