### PR TITLE
[Chat] Fix block dialog overflow issues

### DIFF
--- a/src/components/moderation/BlockDialog.tsx
+++ b/src/components/moderation/BlockDialog.tsx
@@ -244,7 +244,8 @@ function BlockDialogInner({
       scrollIndicatorInsets={{top: headerHeight, bottom: footerHeight}}
       onEndReached={() => void onEndReached()}
       onEndReachedThreshold={0.5}
-      style={[web([{maxWidth: 420}])]}
+      style={[web([{height: '100vh', maxHeight: 600}])]}
+      webInnerStyle={[{maxWidth: 420}]}
     />
   )
 }
@@ -340,11 +341,10 @@ function MutualGroupChat({
         a.py_sm,
         native(a.px_2xl),
       ]}>
-      <View style={[a.flex_row, a.align_center, a.gap_sm]}>
+      <View style={[a.flex_1, a.flex_row, a.align_center, a.gap_sm]}>
         <AvatarBubbles profiles={convo.members} size={40} />
-        <View>
-          <Text
-            style={[a.text_md, a.font_semi_bold, a.leading_snug, t.atoms.text]}>
+        <View style={[a.flex_1]}>
+          <Text style={[a.text_md, a.font_semi_bold]} emoji numberOfLines={1}>
             {convo.details.name}
           </Text>
           {isViewerOwner ? (


### PR DESCRIPTION
If you had too many chats, the dialog overflowed without scrolling on web. Also fixes a chat name overflow issue

## After

<img width="558" height="734" alt="Screenshot 2026-06-12 at 12 07 30" src="https://github.com/user-attachments/assets/31ff0ee3-cc5e-4787-a71d-4ca3fa3ae88b" />
