### PR TITLE
Fix invite card avatar pile not reflecting member count

### DIFF
--- a/src/components/AvatarBubbles.tsx
+++ b/src/components/AvatarBubbles.tsx
@@ -31,6 +31,7 @@ export function AvatarBubbles({
   profiles: allProfiles,
   self = false,
   size = 120,
+  count,
 }: {
   animate?: boolean
   profiles: (bsky.profile.AnyProfileView | undefined)[]
@@ -42,12 +43,21 @@ export function AvatarBubbles({
    */
   self?: boolean
   size?: number
+  /**
+   * The true number of members, used to decide how many bubbles to render when
+   * it exceeds the number of `profiles` we have on hand (e.g. an invite preview
+   * that only carries a few member profiles for a much larger group). Slots
+   * without a profile render as placeholders. Defaults to `profiles.length`.
+   */
+  count?: number
 }) {
   const {currentAccount} = useSession()
   const profiles =
     !self && allProfiles.length > 2
       ? allProfiles.filter(p => !p || p.did !== currentAccount?.did)
       : allProfiles
+
+  const bubbleCount = Math.max(profiles.length, count ?? 0)
 
   const scale = size / 120
   const marginOffset = size < 120 ? -2 : 0
@@ -79,7 +89,7 @@ export function AvatarBubbles({
   }, [animate, p0, p1, p2, p3])
 
   const scales = [p0, p1, p2, p3]
-  const layouts = getLayouts(profiles.length)
+  const layouts = getLayouts(bubbleCount)
 
   return (
     <Animated.View style={[a.p_2xs, {height: size, width: size}]}>

--- a/src/components/AvatarBubbles.tsx
+++ b/src/components/AvatarBubbles.tsx
@@ -34,7 +34,7 @@ export function AvatarBubbles({
   count,
 }: {
   animate?: boolean
-  profiles: (bsky.profile.AnyProfileView | undefined)[]
+  profiles: bsky.profile.AnyProfileView[]
   /**
    * By default, when there are more than 2 profiles, the current user is
    * filtered out (so you don't see yourself among your own group's members).
@@ -54,7 +54,7 @@ export function AvatarBubbles({
   const {currentAccount} = useSession()
   const profiles =
     !self && allProfiles.length > 2
-      ? allProfiles.filter(p => !p || p.did !== currentAccount?.did)
+      ? allProfiles.filter(p => p.did !== currentAccount?.did)
       : allProfiles
 
   const bubbleCount = Math.max(profiles.length, count ?? 0)

--- a/src/components/dms/ChatInvite/Card.tsx
+++ b/src/components/dms/ChatInvite/Card.tsx
@@ -29,7 +29,12 @@ export function Card({size}: {size: 'large' | 'small'}) {
 
   return (
     <View style={[a.flex_row, a.gap_md, a.align_center]}>
-      <AvatarBubbles size={56} self profiles={avatarProfiles} />
+      <AvatarBubbles
+        size={56}
+        self
+        profiles={avatarProfiles}
+        count={preview.memberCount}
+      />
       <View style={[a.flex_1, size === 'large' ? a.gap_2xs : a.gap_xs]}>
         <Text
           emoji

--- a/src/components/intents/GroupChatJoinDialog.tsx
+++ b/src/components/intents/GroupChatJoinDialog.tsx
@@ -315,10 +315,8 @@ function GroupChatJoinDialogContent({code}: {code?: string}) {
     <>
       <View style={[a.w_full, a.py_lg, a.align_center]}>
         <AvatarBubbles
-          profiles={[
-            joinLinkPreview.owner,
-            ...Array(joinLinkPreview.memberCount - 1).fill(undefined),
-          ]}
+          profiles={[joinLinkPreview.owner]}
+          count={joinLinkPreview.memberCount}
           self
           size={135}
         />

--- a/src/screens/Messages/JoinRequest.tsx
+++ b/src/screens/Messages/JoinRequest.tsx
@@ -103,12 +103,8 @@ export function JoinRequest({setScreenState}: Props) {
             ChatBskyGroupDefs.isJoinLinkPreviewView(joinLinkPreview) ? (
             <Wrapper>
               <AvatarBubbles
-                profiles={[
-                  joinLinkPreview.owner,
-                  ...Array(
-                    Math.min(3, Math.max(0, joinLinkPreview.memberCount - 1)),
-                  ).fill(undefined),
-                ]}
+                profiles={[joinLinkPreview.owner]}
+                count={joinLinkPreview.memberCount}
                 size={135}
               />
               <View style={[a.gap_2xs]}>

--- a/src/screens/Messages/components/OutgoingRequestListItem.tsx
+++ b/src/screens/Messages/components/OutgoingRequestListItem.tsx
@@ -63,7 +63,7 @@ export function OutgoingRequestListItem({
               (hovered || pressed || focused) && t.atoms.bg_contrast_25,
             ]}>
             <AvatarBubbles
-              profiles={[convoView?.owner ?? undefined]}
+              profiles={[convoView.owner]}
               count={convoView.memberCount}
               size={48}
             />

--- a/src/screens/Messages/components/OutgoingRequestListItem.tsx
+++ b/src/screens/Messages/components/OutgoingRequestListItem.tsx
@@ -63,12 +63,8 @@ export function OutgoingRequestListItem({
               (hovered || pressed || focused) && t.atoms.bg_contrast_25,
             ]}>
             <AvatarBubbles
-              profiles={[
-                convoView?.owner ?? undefined,
-                ...Array(
-                  Math.min(3, Math.max(0, convoView.memberCount - 1)),
-                ).fill(undefined),
-              ]}
+              profiles={[convoView?.owner ?? undefined]}
+              count={convoView.memberCount}
               size={48}
             />
             <View style={[a.flex_1]}>


### PR DESCRIPTION
Fixes APP-2399.

## Problem

In group chats, the invite card's avatar preview only showed two avatars (one of which was a grey placeholder), even for a 21-member group.

The root cause isn't slicing in `AvatarBubbles` — it's the data. The join link preview API only includes `convo.members` when the viewer is *already a member* of the group, but invite previews are shown precisely to people who aren't members yet. For them, the profile list collapses to just `[preview.owner]`. Since `AvatarBubbles` always draws at least 2 bubbles, you got owner + one placeholder.

## Fix

Add an optional `count` prop to `AvatarBubbles` representing the true member total. The component now renders `Math.max(profiles.length, count)` bubbles (still capped at the existing 4-bubble layout), padding empty slots with the existing placeholder. So a large group now shows a full pile of bubbles even when only the owner's profile is available.

- `AvatarBubbles`: new optional `count?: number` prop. Now that `count` drives the placeholder slots, the `profiles` prop is also tightened to non-nullable `AnyProfileView[]` — callers no longer pad the array with `undefined`.
- The four invite-preview surfaces that receive a partial member list (often just the owner) pass `count`: `ChatInvite/Card.tsx` (the reported bug), `JoinRequest.tsx`, `OutgoingRequestListItem.tsx`, and `GroupChatJoinDialog.tsx`. The latter three were previously hand-padding the array with `Array(memberCount - 1).fill(undefined)` (and `GroupChatJoinDialog` lacked a zero guard, so `memberCount === 0` would throw) — the `count` prop replaces all of that.

The in-group `AvatarBubbles` usages (`ChatListItem`, `MessagesListGroupInfoPanel`, `ConversationSettings`, etc.) are for groups the viewer is in, where `convo.members` already carries enough relevant members to fill the pile, so they're left unchanged.

### Before

<img width="607" height="215" alt="Screenshot 2026-06-12 at 15 57 07" src="https://github.com/user-attachments/assets/f452c4f9-f0bc-40b8-9779-3b9b36b0a97e" />


### After

<img width="617" height="219" alt="Screenshot 2026-06-12 at 15 56 55" src="https://github.com/user-attachments/assets/3122e03f-816f-4194-a765-7895d4f13926" />


## Test plan

- [ ] Open an invite link/embed for a large group as a non-member → avatar pile shows 4 bubbles (owner + placeholders) instead of 2
- [ ] Existing in-group surfaces (chat list, group info panel, settings) still render member avatars as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
