### PR TITLE
Persist selected QR code color theme in invite friends dialog

### DIFF
--- a/src/features/inviteFriends/InviteFriendsDialogInner.tsx
+++ b/src/features/inviteFriends/InviteFriendsDialogInner.tsx
@@ -1,4 +1,4 @@
-import {Suspense, useRef, useState} from 'react'
+import {Suspense, useRef} from 'react'
 import {Pressable, View} from 'react-native'
 import type ViewShot from 'react-native-view-shot'
 import {setStringAsync} from 'expo-clipboard'
@@ -25,6 +25,7 @@ import {IS_NATIVE} from '#/env'
 import {ActionButtons} from './components/ActionButtons'
 import {ThemedQrCard} from './components/ThemedQrCard'
 import {ThemePicker} from './components/ThemePicker'
+import {useInviteThemeKey} from './hooks/useInviteThemeKey'
 import {getInviteTheme, type InviteThemeKey} from './themes'
 import {getInviteDisplayUrl, getInviteShareUrl} from './urls'
 
@@ -39,7 +40,7 @@ export function InviteFriendsDialogInner({
   const navigation = useNavigation<NavigationProp>()
   const {currentAccount} = useSession()
   const profileQuery = useProfileQuery({did: currentAccount?.did})
-  const [themeKey, setThemeKey] = useState<InviteThemeKey>('day')
+  const [themeKey, setThemeKey] = useInviteThemeKey()
   const captureRef = useRef<ViewShot>(null)
 
   const theme = getInviteTheme(themeKey)

--- a/src/features/inviteFriends/hooks/useInviteThemeKey.ts
+++ b/src/features/inviteFriends/hooks/useInviteThemeKey.ts
@@ -1,0 +1,14 @@
+import {device, useStorage} from '#/storage'
+import {INVITE_THEMES, type InviteThemeKey} from '../themes'
+
+/**
+ * Persisted color theme for the Invite Friends QR card (APP-2409). Falls back
+ * to 'day' when nothing is stored or the stored key is no longer a valid
+ * theme.
+ */
+export function useInviteThemeKey() {
+  const [stored, setThemeKey] = useStorage(device, ['inviteFriendsThemeKey'])
+  const themeKey: InviteThemeKey =
+    stored && stored in INVITE_THEMES ? stored : 'day'
+  return [themeKey, setThemeKey] as const
+}

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -1,5 +1,6 @@
 import {type ID as PolicyUpdate202508} from '#/components/PolicyUpdateOverlay/updates/202508/config'
 import {type Gif} from '#/features/gifPicker/types'
+import {type InviteThemeKey} from '#/features/inviteFriends/themes'
 import {type Geolocation} from '#/geolocation/types'
 
 /**
@@ -62,6 +63,10 @@ export type Device = {
   activitySubscriptionsNudged?: boolean
   threadgateNudged?: boolean
   inviteFriendsFollowersPromoDismissed?: boolean
+  /**
+   * Selected color theme for the Invite Friends QR card.
+   */
+  inviteFriendsThemeKey?: InviteThemeKey
 
   /**
    * Policy update overlays. New IDs are required for each new announcement.


### PR DESCRIPTION
## Why

The color picker in the invite friends dialog kept its selection in component state, which resets whenever the sheet closes. Reopening the dialog always showed the default blue (day) theme regardless of what was previously picked.

## How

- Added an optional `inviteFriendsThemeKey` to the `Device` storage schema
- Added a `useInviteThemeKey` hook (same pattern as `useFollowersPromoDismissed`) that persists the selection on device and falls back to `day` when nothing is stored or the stored key is no longer a valid theme
- Swapped the dialog's `useState` for the hook

## Test plan

- `pnpm typecheck`, `pnpm lint`, prettier, and invite friends test suites pass
- Manual: open invite friends, pick a non-default color, close and reopen the sheet, and the selection is retained (including across app restarts)