### PR TITLE
Add reminder to label posts with media

### DIFF
--- a/src/screens/Moderation/index.tsx
+++ b/src/screens/Moderation/index.tsx
@@ -12,6 +12,10 @@ import {
 } from '#/lib/routes/types'
 import {logger} from '#/logger'
 import {useIsBirthdateUpdateAllowed} from '#/state/birthdate'
+import {
+  useLabelReminderEnabled,
+  useSetLabelReminderEnabled,
+} from '#/state/preferences'
 import {useRemoveLabelersMutation} from '#/state/queries/labeler'
 import {
   useMyLabelersQuery,
@@ -171,6 +175,8 @@ export function ModerationScreenInner({
   const aa = useAgeAssurance()
   const isBirthdateUpdateAllowed = useIsBirthdateUpdateAllowed()
   const aaCopy = useAgeAssuranceCopy()
+  const labelReminderEnabled = useLabelReminderEnabled()
+  const setLabelReminderEnabled = useSetLabelReminderEnabled()
 
   const subscribedDids = preferences.moderationPrefs.labelers.map(l => l.did)
   const returnedDids = new Set(labelers?.map(l => l.creator.did))
@@ -349,6 +355,58 @@ export function ModerationScreenInner({
             />
           )}
         </Link>
+      </View>
+
+      <Text
+        style={[
+          a.pt_2xl,
+          a.pb_md,
+          a.text_md,
+          a.font_semi_bold,
+          t.atoms.text_contrast_high,
+        ]}>
+        <Trans>Content labeling</Trans>
+      </Text>
+
+      <View style={[a.gap_md]}>
+        <View
+          style={[
+            a.w_full,
+            a.rounded_md,
+            a.overflow_hidden,
+            t.atoms.bg_contrast_25,
+          ]}>
+          <View
+            style={[
+              a.py_lg,
+              a.px_lg,
+              a.flex_row,
+              a.align_center,
+              a.justify_between,
+            ]}>
+            <Text style={[a.font_semi_bold, t.atoms.text_contrast_high]}>
+              <Trans>Remind me to label media</Trans>
+            </Text>
+            <Toggle.Item
+              label={_(
+                msg`Toggle to enable or disable reminders for adding content labels`,
+              )}
+              name="labelReminder"
+              value={labelReminderEnabled}
+              onChange={setLabelReminderEnabled}>
+              <View style={[a.flex_row, a.align_center, a.gap_sm]}>
+                <Text style={[t.atoms.text_contrast_medium]}>
+                  {labelReminderEnabled ? (
+                    <Trans>Enabled</Trans>
+                  ) : (
+                    <Trans>Disabled</Trans>
+                  )}
+                </Text>
+                <Toggle.Switch />
+              </View>
+            </Toggle.Item>
+          </View>
+        </View>
       </View>
 
       <Text

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -92,6 +92,7 @@ const schema = z.object({
      */
     appLanguage: z.string(),
   }),
+  labelReminderEnabled: z.boolean(), // should move to server
   requireAltTextEnabled: z.boolean(), // should move to server
   largeAltBadgeEnabled: z.boolean().optional(),
   externalEmbeds: z
@@ -156,6 +157,7 @@ export const defaults: Schema = {
       deviceLanguageCodes[0],
     ]),
   },
+  labelReminderEnabled: false,
   requireAltTextEnabled: false,
   largeAltBadgeEnabled: false,
   externalEmbeds: {},

--- a/src/state/preferences/index.tsx
+++ b/src/state/preferences/index.tsx
@@ -5,6 +5,7 @@ import {Provider as ExternalEmbedsProvider} from './external-embeds-prefs'
 import {Provider as HiddenPostsProvider} from './hidden-posts'
 import {Provider as InAppBrowserProvider} from './in-app-browser'
 import {Provider as KawaiiProvider} from './kawaii'
+import {Provider as LabelReminderProvider} from './label-reminder'
 import {Provider as LanguagesProvider} from './languages'
 import {Provider as LargeAltBadgeProvider} from './large-alt-badge'
 import {Provider as SubtitlesProvider} from './subtitles'
@@ -23,6 +24,10 @@ export {
 } from './external-embeds-prefs'
 export {useHiddenPosts, useHiddenPostsApi} from './hidden-posts'
 export {useLabelDefinitions} from './label-defs'
+export {
+  useLabelReminderEnabled,
+  useSetLabelReminderEnabled,
+} from './label-reminder'
 export {useLanguagePrefs, useLanguagePrefsApi} from './languages'
 export {useSetSubtitlesEnabled, useSubtitlesEnabled} from './subtitles'
 
@@ -39,7 +44,11 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
                     <UsedStarterPacksProvider>
                       <SubtitlesProvider>
                         <TrendingSettingsProvider>
-                          <KawaiiProvider>{children}</KawaiiProvider>
+                          <KawaiiProvider>
+                            <LabelReminderProvider>
+                              {children}
+                            </LabelReminderProvider>
+                          </KawaiiProvider>
                         </TrendingSettingsProvider>
                       </SubtitlesProvider>
                     </UsedStarterPacksProvider>

--- a/src/state/preferences/label-reminder.tsx
+++ b/src/state/preferences/label-reminder.tsx
@@ -1,0 +1,58 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react'
+
+import * as persisted from '#/state/persisted'
+
+type StateContext = persisted.Schema['labelReminderEnabled']
+type SetContext = (v: persisted.Schema['labelReminderEnabled']) => void
+
+const stateContext = createContext<StateContext>(
+  persisted.defaults.labelReminderEnabled,
+)
+stateContext.displayName = 'LabelReminderStateContext'
+const setContext = createContext<SetContext>(
+  (_: persisted.Schema['labelReminderEnabled']) => {},
+)
+setContext.displayName = 'LabelReminderSetContext'
+
+export function Provider({children}: React.PropsWithChildren<{}>) {
+  const [state, setState] = useState(persisted.get('labelReminderEnabled'))
+
+  const setStateWrapped = useCallback(
+    (labelReminderEnabled: persisted.Schema['labelReminderEnabled']) => {
+      setState(labelReminderEnabled)
+      void persisted.write('labelReminderEnabled', labelReminderEnabled)
+    },
+    [setState],
+  )
+
+  useEffect(() => {
+    return persisted.onUpdate(
+      'labelReminderEnabled',
+      nextLabelReminderEnabled => {
+        setState(nextLabelReminderEnabled)
+      },
+    )
+  }, [setStateWrapped])
+
+  return (
+    <stateContext.Provider value={state}>
+      <setContext.Provider value={setStateWrapped}>
+        {children}
+      </setContext.Provider>
+    </stateContext.Provider>
+  )
+}
+
+export function useLabelReminderEnabled() {
+  return useContext(stateContext)
+}
+
+export function useSetLabelReminderEnabled() {
+  return useContext(setContext)
+}

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -87,7 +87,10 @@ import {
   pasteImage,
 } from '#/state/gallery'
 import {useModalControls} from '#/state/modals'
-import {useRequireAltTextEnabled} from '#/state/preferences'
+import {
+  useLabelReminderEnabled,
+  useRequireAltTextEnabled,
+} from '#/state/preferences'
 import {
   fromPostLanguages,
   toPostLanguages,
@@ -273,12 +276,15 @@ export const ComposePost = ({
   const {closeComposer} = useComposerControls()
   const {t: l, i18n} = useLingui()
   const requireAltTextEnabled = useRequireAltTextEnabled()
+  const labelReminderEnabled = useLabelReminderEnabled()
   const langPrefs = useLanguagePrefs()
   const setLangPrefs = useLanguagePrefsApi()
   const textInputRef = useRef<TextInputRef>(null)
   const discardPromptControl = Prompt.usePromptControl()
   const emptyPostsPromptControl = Prompt.usePromptControl()
+  const missingLabelsPromptControl = Prompt.usePromptControl()
   const skipEmptyConfirmedRef = useRef(false)
+  const skipMissingLabelsRef = useRef(false)
   const {mutateAsync: saveDraft, isPending: _isSavingDraft} =
     useSaveDraftMutation()
   const {mutate: cleanupPublishedDraft} = useCleanupPublishedDraftMutation()
@@ -874,6 +880,12 @@ export const ComposePost = ({
     }
   }, [thread, requireAltTextEnabled, l])
 
+  const missingLabels =
+    labelReminderEnabled &&
+    thread.posts.some(post => {
+      return post.embed.media !== undefined && post.labels.length === 0
+    })
+
   // Subscribe to the resolve-link cache for any link URIs in the thread so we
   // can detect chat invites that resolved to no preview (revoked/expired) and
   // block publishing - otherwise the post would go out without the embed.
@@ -949,6 +961,11 @@ export const ComposePost = ({
 
     if (emptyType === 'non-trailing' && !skipEmptyConfirmedRef.current) {
       emptyPostsPromptControl.open()
+      return
+    }
+
+    if (missingLabels && !skipMissingLabelsRef.current) {
+      missingLabelsPromptControl.open()
       return
     }
 
@@ -1177,12 +1194,19 @@ export const ComposePost = ({
     cleanupPublishedDraft,
     loadedDraftCreatedAt,
     emptyPostsPromptControl,
+    missingLabels,
+    missingLabelsPromptControl,
     getFilteredThread,
     linkQueries,
   ])
 
   const handleConfirmSkipEmpty = () => {
     skipEmptyConfirmedRef.current = true
+    void onPressPublish()
+  }
+
+  const handleConfirmSkipLabels = () => {
+    skipMissingLabelsRef.current = true
     void onPressPublish()
   }
 
@@ -1470,6 +1494,14 @@ export const ComposePost = ({
           confirmButtonCta={l`Post anyway`}
           cancelButtonCta={l`Keep editing`}
           onConfirm={handleConfirmSkipEmpty}
+        />
+        <Prompt.Basic
+          control={missingLabelsPromptControl}
+          title={l`Post media without labels?`}
+          description={l`Your thread has media posts without content labels. You can keep editing to add labels, or post without them.`}
+          confirmButtonCta={l`Post anyway`}
+          cancelButtonCta={l`Keep editing`}
+          onConfirm={handleConfirmSkipLabels}
         />
       </KeyboardAvoidingView>
     </BottomSheetPortalProvider>


### PR DESCRIPTION
I was having a discussion [with someone](https://bsky.app/profile/thisismissem.social/post/3mo5nnwa64k25) about issues facing adult creators using Bluesky and the "forgetting to add labels" issue came up, so here's an early implementation of adding a reminder to add labels before posting media (sans-making server-side changes to persist the setting across devices)

This fixes #8406, #5628, #6815 (in a slightly different way). Currently I've implemented the preference for this reminder using the persisted state, but if we like this feature, then it should probably be moved into the server-side backed `src/state/preferences/moderation-opts.tsx` (this requires API changes, so I wanted to experiment with the UI side first)

By allowing people using the app to receive a reminder to add labels to media they're posting, it should significantly cut down of the number of posts with media where adult content is not correctly labeled, and acts as a nudge to push people towards the behavior that we want (adult content is correctly labeled).

https://github.com/user-attachments/assets/87de2784-9743-4cd4-b73d-8ac348f650da

#5948 could be a nice follow-up to this, potentially, though I'm less certain of this.

## Open Questions
- is this something we want? (I think so)
- Should this also apply to links? (Since they're the other thing that triggers the labels visibility in the composer)