### PR TITLE
fix: truncate long display names in group chat member picker (#10899)

### DIFF
--- a/src/components/dms/components/GroupChatProfileCard.tsx
+++ b/src/components/dms/components/GroupChatProfileCard.tsx
@@ -48,7 +48,7 @@ export function GroupChatProfileCard({
                 size={44}
                 disabledPreview
               />
-              <View>
+              <View style={[a.flex_1]}>
                 <ProfileCard.Name
                   profile={profile}
                   moderationOpts={moderationOpts}


### PR DESCRIPTION
## What was broken

In the **New group chat** member picker, long display names were not being
truncated. The name grew to its full width and pushed the selection
`<Toggle.Checkbox />` out of alignment and off screen (see #10899).

## Root cause

In `GroupChatProfileCard.tsx`, the `<View>` wrapping `ProfileCard.Name` /
`ProfileCard.Handle` had no flex constraint. `ProfileCard.Name` already sets
`numberOfLines={1}`, but truncation only takes effect when the container's
width is constrained. Without `flex_1`, that `View` sized to the name's full
intrinsic width, widening the `ProfileCard.Header` row and shoving the
sibling checkbox out of view.

The two sibling cards in the same flow already wrap this block correctly:

- `DefaultProfileCard` (`InitiateChatFlow.tsx`) → `<View style={[a.flex_1]}>`
- `GroupChatMemberProfileCard` (`InitiateChatFlow.tsx`) → `<View style={[a.flex_1]}>`

Only `GroupChatProfileCard` (the checkbox variant) used a bare `<View>`.

## The fix

Add `a.flex_1` to that wrapper so it matches its siblings and lets the
existing `numberOfLines={1}` truncate the name, keeping the checkbox aligned.

```diff
-              <View>
+              <View style={[a.flex_1]}>
                 <ProfileCard.Name
                   profile={profile}
                   moderationOpts={moderationOpts}
                 />
```

One line, no new imports (`atoms as a` is already imported), no behavior
change beyond the layout fix.

Fixes #10899
