### PR TITLE
[Chat] fix: enforce convo-present invariant for active convo states

### DIFF
--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -237,22 +237,40 @@ export class Convo {
       removeReaction: undefined,
     }
 
+    /*
+     * Captured as a local so the `if (convo)` narrowing below survives the
+     * `this.getItems()` call - TS discards narrowing on mutable `this` members
+     * after a method call, but not on a const.
+     */
+    const convo = this.convo
+
+    /*
+     * A lifecycle event (e.g. `Background` or `Suspend`) can move us into an
+     * active status before `setup()` has resolved and populated `convo`. The
+     * active states declare `convo` as non-optional, so we can't build one
+     * without it - fall back to reporting `Initializing` until the convo lands.
+     * This keeps the snapshot's type and runtime in agreement, so consumers can
+     * trust that an active status always has a `convo`.
+     */
+    const stillInitializing = (): ConvoState => ({
+      status: ConvoStatus.Initializing,
+      items: [],
+      convo,
+      error: undefined,
+      ...shared,
+      ...emptyMethods,
+    })
+
     switch (this.status) {
       case ConvoStatus.Initializing: {
-        return {
-          status: ConvoStatus.Initializing,
-          items: [],
-          convo: this.convo,
-          error: undefined,
-          ...shared,
-          ...emptyMethods,
-        }
+        return stillInitializing()
       }
       case ConvoStatus.Disabled: {
+        if (!convo) return stillInitializing()
         return {
-          status: this.status,
+          status: ConvoStatus.Disabled,
           items: this.getItems(),
-          convo: this.convo!,
+          convo,
           relatedProfiles: this.relatedProfiles,
           error: undefined,
           ...shared,
@@ -260,10 +278,11 @@ export class Convo {
         }
       }
       case ConvoStatus.Suspended: {
+        if (!convo) return stillInitializing()
         return {
-          status: this.status,
+          status: ConvoStatus.Suspended,
           items: this.getItems(),
-          convo: this.convo!,
+          convo,
           relatedProfiles: this.relatedProfiles,
           error: undefined,
           ...shared,
@@ -271,10 +290,11 @@ export class Convo {
         }
       }
       case ConvoStatus.Backgrounded: {
+        if (!convo) return stillInitializing()
         return {
-          status: this.status,
+          status: ConvoStatus.Backgrounded,
           items: this.getItems(),
-          convo: this.convo!,
+          convo,
           relatedProfiles: this.relatedProfiles,
           error: undefined,
           ...shared,
@@ -282,10 +302,11 @@ export class Convo {
         }
       }
       case ConvoStatus.Ready: {
+        if (!convo) return stillInitializing()
         return {
-          status: this.status,
+          status: ConvoStatus.Ready,
           items: this.getItems(),
-          convo: this.convo!,
+          convo,
           relatedProfiles: this.relatedProfiles,
           error: undefined,
           ...shared,

--- a/src/state/messages/convo/util.ts
+++ b/src/state/messages/convo/util.ts
@@ -21,12 +21,19 @@ export type ActiveConvoStates =
  * Checks if a `Convo` has a `status` that is "active", meaning the chat is
  * loaded and ready to be used, or its in a suspended or background state, and
  * ready for resumption.
+ *
+ * The `convo` object must also be present. The status can transition into an
+ * active state before the convo has finished loading (e.g. `Initializing`
+ * receives a `Background` event before `setup()` resolves), and every
+ * `ActiveConvoStates` member declares `convo` as non-optional, so we guard
+ * against that race here rather than crashing downstream consumers.
  */
 export function isConvoActive(convo: ConvoState): convo is ActiveConvoStates {
   return (
-    convo.status === ConvoStatus.Ready ||
-    convo.status === ConvoStatus.Backgrounded ||
-    convo.status === ConvoStatus.Suspended ||
-    convo.status === ConvoStatus.Disabled
+    convo.convo !== undefined &&
+    (convo.status === ConvoStatus.Ready ||
+      convo.status === ConvoStatus.Backgrounded ||
+      convo.status === ConvoStatus.Suspended ||
+      convo.status === ConvoStatus.Disabled)
   )
 }

--- a/src/state/messages/convo/util.ts
+++ b/src/state/messages/convo/util.ts
@@ -21,19 +21,12 @@ export type ActiveConvoStates =
  * Checks if a `Convo` has a `status` that is "active", meaning the chat is
  * loaded and ready to be used, or its in a suspended or background state, and
  * ready for resumption.
- *
- * The `convo` object must also be present. The status can transition into an
- * active state before the convo has finished loading (e.g. `Initializing`
- * receives a `Background` event before `setup()` resolves), and every
- * `ActiveConvoStates` member declares `convo` as non-optional, so we guard
- * against that race here rather than crashing downstream consumers.
  */
 export function isConvoActive(convo: ConvoState): convo is ActiveConvoStates {
   return (
-    convo.convo !== undefined &&
-    (convo.status === ConvoStatus.Ready ||
-      convo.status === ConvoStatus.Backgrounded ||
-      convo.status === ConvoStatus.Suspended ||
-      convo.status === ConvoStatus.Disabled)
+    convo.status === ConvoStatus.Ready ||
+    convo.status === ConvoStatus.Backgrounded ||
+    convo.status === ConvoStatus.Suspended ||
+    convo.status === ConvoStatus.Disabled
   )
 }


### PR DESCRIPTION
Fixes a TypeError (`Cannot read property 'view' of undefined`) in `MessagesList`'s `getFooterState`.

## The bug

The four "active" convo states (`Ready`, `Backgrounded`, `Suspended`, `Disabled`) all declare `convo` as **non-optional** - they encode the assumption that loading has finished. But the state machine lets `Initializing` transition straight into `Backgrounded`/`Suspended` on a lifecycle event (e.g. the screen blurs before `setup()` resolves), and at that point `this.convo` is still `undefined`.

`generateSnapshot` papered over this with a non-null assertion (`this.convo!`), so `isConvoActive` - which keyed off `status` alone - returned `true`, and downstream consumers rendered against an undefined `convo` and crashed.

## The fix

Rather than guarding at the `isConvoActive` call site (which patches one symptom), make the invalid state unrepresentable in the snapshot itself:

- `generateSnapshot` now reports `Initializing` whenever an active status has no `convo` yet. This lets us drop all four `this.convo!` non-null assertions - the compiler now enforces that an active snapshot always carries a `convo`.
- `isConvoActive` reverts to keying off `status` alone, since the snapshot can no longer produce an active status without a `convo`.

The invariant moves from a runtime guard into the type system at the source: dropping a `convo` check now produces a type error rather than a runtime crash.