### PR TITLE
Fix scroll edge effects on iOS 27

### DIFF
--- a/src/components/dms/MessagesListHeader.tsx
+++ b/src/components/dms/MessagesListHeader.tsx
@@ -20,10 +20,10 @@ import * as Layout from '#/components/Layout'
 import {Link} from '#/components/Link'
 import {ProfileBadges} from '#/components/ProfileBadges'
 import {Text} from '#/components/Typography'
-import {IS_LIQUID_GLASS, IS_WEB} from '#/env'
+import {IS_LIQUID_GLASS} from '#/env'
 import {type ConvoWithDetails} from './util'
 
-const PFP_SIZE = IS_WEB ? 40 : Layout.HEADER_SLOT_SIZE
+const PFP_SIZE = 40
 
 export function MessagesListHeader({convo}: {convo?: ConvoWithDetails | null}) {
   const t = useTheme()

--- a/src/components/dms/MessagesListHeader.tsx
+++ b/src/components/dms/MessagesListHeader.tsx
@@ -176,7 +176,7 @@ function GroupHeaderReady({
                   },
                 }
           }>
-          <AvatarBubbles size={40} profiles={convo.members} />
+          <AvatarBubbles size={PFP_SIZE} profiles={convo.members} />
           <View style={[a.flex_row, a.flex_1, a.align_center]}>
             <Text
               style={[a.text_lg, a.font_semi_bold, a.flex_shrink]}

--- a/src/screens/Messages/Conversation.tsx
+++ b/src/screens/Messages/Conversation.tsx
@@ -262,6 +262,7 @@ function InnerReady({
       {IS_LIQUID_GLASS ? (
         <ScrollEdgeEffect
           edge="top"
+          effect="soft"
           style={[a.absolute, a.w_full, a.z_10, {paddingTop: topInset}]}
           onLayout={onHeaderLayout}>
           {header}

--- a/src/screens/Messages/components/MessageComposer.tsx
+++ b/src/screens/Messages/components/MessageComposer.tsx
@@ -326,7 +326,7 @@ export function ComposerContainer({children}: {children: React.ReactNode}) {
 
   if (IS_LIQUID_GLASS) {
     return (
-      <ScrollEdgeEffect edge="bottom">
+      <ScrollEdgeEffect edge="bottom" effect="soft">
         <Animated.View style={[a.w_full, animatedContainerStyle, a.pb_lg]}>
           {children}
         </Animated.View>


### PR DESCRIPTION
The default has changed from `soft` to `hard`, but we want `soft`. Also fixes an issue where the skeleton didn't match the final render