### PR TITLE
[Chat] Fix member count in SearchablePeopleList

### DIFF
--- a/src/components/dialogs/SearchablePeopleList.tsx
+++ b/src/components/dialogs/SearchablePeopleList.tsx
@@ -553,7 +553,7 @@ function ExistingChatCard({
                       style={[a.leading_snug, t.atoms.text_contrast_medium]}
                       numberOfLines={2}>
                       <Plural
-                        value={convo.members.length}
+                        value={convo.details.memberCount}
                         one="# member"
                         other="# members"
                       />


### PR DESCRIPTION
Was using `members.length` instead of `memberCount`