### PR TITLE
[Chat] Hide unread state for selected chat list item

### DIFF
--- a/src/screens/Messages/components/ChatListItem.tsx
+++ b/src/screens/Messages/components/ChatListItem.tsx
@@ -282,6 +282,7 @@ function BaseChatItem({
   const playHaptic = useHaptics()
   const queryClient = useQueryClient()
   const hasUnread =
+    !selected &&
     !isDeletedAccount &&
     (convo.view.unreadCount > 0 ||
       (convo.kind === 'group' &&


### PR DESCRIPTION
## What

In split view the chat list stays mounted alongside the open conversation, so the selected item is visible while you're reading it. Its unread indicator could flicker `read -> unread -> read` over a couple of seconds after opening.

## Why

The unread state on a `ChatListItem` is driven by `convo.unreadCount` in the `convo-list` query cache, which is fed by two unsynchronized channels: optimistic/log-event writes that set `unreadCount: 0`, and wholesale `listConvos` refetches that replace the cache with the server's current view. The server's read receipt is eventually-consistent, so a refetch that lands before the receipt commits resurrects `unreadCount > 0`, then a later poll/refetch corrects it back to `0`.

Rather than reconcile the two channels, we just suppress the unread affordances for the chat you currently have open — `selected` is a presentation state, and a chat you're actively viewing shouldn't render as unread regardless.

## How

Gate `hasUnread` on `!selected`. Since `hasUnread` is the single source for all unread affordances, this cleanly hides the background tint, the blue dot, the bold last-message styling, and the swipe-to-mark-read action for the open chat. The `ConvoMenu`'s `showMarkAsRead` reads `unreadCount` directly (not `hasUnread`), so the long-press "mark as read" option is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)