### PR TITLE
Add confirmation prompt before unfollowing

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2235,7 +2235,7 @@
       "count": 3
     },
     "@typescript-eslint/no-misused-promises": {
-      "count": 3
+      "count": 2
     },
     "@typescript-eslint/no-unsafe-member-access": {
       "count": 2

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -41,6 +41,7 @@ import {PlusLarge_Stroke2_Corner0_Rounded as Plus} from '#/components/icons/Plus
 import {Link as InternalLink, type LinkProps} from '#/components/Link'
 import * as Pills from '#/components/Pills'
 import {ProfileBadges} from '#/components/ProfileBadges'
+import * as Prompt from '#/components/Prompt'
 import {RichText} from '#/components/RichText'
 import * as Toast from '#/components/Toast'
 import {Text} from '#/components/Typography'
@@ -488,6 +489,7 @@ export function FollowButtonInner({
     contextProfileDid,
   )
   const isRound = Boolean(rest.shape && rest.shape === 'round')
+  const unfollowPromptControl = Prompt.usePromptControl()
 
   const onPressFollow = async (e: GestureResponderEvent) => {
     e.preventDefault()
@@ -512,9 +514,7 @@ export function FollowButtonInner({
     }
   }
 
-  const onPressUnfollow = async (e: GestureResponderEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
+  const doUnfollow = async () => {
     try {
       await queueUnfollow()
       Toast.show(
@@ -523,7 +523,6 @@ export function FollowButtonInner({
           moderation.ui('displayName'),
         )}`,
       )
-      onPressProp?.(e)
     } catch (e) {
       const err = e as Error
       if (err?.name !== 'AbortError') {
@@ -566,7 +565,9 @@ export function FollowButtonInner({
           color="secondary"
           {...rest}
           onPress={(e: GestureResponderEvent) => {
-            void onPressUnfollow(e)
+            e.preventDefault()
+            e.stopPropagation()
+            unfollowPromptControl.open()
           }}>
           {withIcon && (
             <ButtonIcon icon={Check} position={isRound ? undefined : 'left'} />
@@ -589,6 +590,18 @@ export function FollowButtonInner({
           {isRound ? null : <ButtonText>{followLabel}</ButtonText>}
         </Button>
       )}
+
+      <Prompt.Basic
+        control={unfollowPromptControl}
+        title={l`Unfollow?`}
+        description={l`Are you sure you want to unfollow ${sanitizeDisplayName(
+          profile.displayName || profile.handle,
+          moderation.ui('displayName'),
+        )}?`}
+        onConfirm={() => void doUnfollow()}
+        confirmButtonCta={l`Unfollow`}
+        confirmButtonColor="negative"
+      />
     </View>
   )
 }

--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -37,6 +37,7 @@ import {Loader} from '#/components/Loader'
 import * as Pills from '#/components/Pills'
 import {Portal} from '#/components/Portal'
 import {ProfileBadges} from '#/components/ProfileBadges'
+import * as Prompt from '#/components/Prompt'
 import {RichText} from '#/components/RichText'
 import {Text} from '#/components/Typography'
 import {IS_WEB_TOUCH_DEVICE} from '#/env'
@@ -435,6 +436,7 @@ function Inner({
     profile: profileShadow,
     logContext: 'ProfileHoverCard',
   })
+  const unfollowPromptControl = Prompt.usePromptControl()
   const isBlockedUser =
     profile.viewer?.blocking ||
     profile.viewer?.blockedBy ||
@@ -495,7 +497,11 @@ function Inner({
                   : _(msg`Follow`)
               }
               style={[a.rounded_full]}
-              onPress={profileShadow.viewer?.following ? unfollow : follow}>
+              onPress={
+                profileShadow.viewer?.following
+                  ? () => unfollowPromptControl.open()
+                  : follow
+              }>
               <ButtonIcon
                 position="left"
                 icon={profileShadow.viewer?.following ? Check : Plus}
@@ -601,6 +607,20 @@ function Inner({
             )}
         </>
       )}
+
+      <Prompt.Basic
+        control={unfollowPromptControl}
+        title={_(msg`Unfollow?`)}
+        description={_(
+          msg`Are you sure you want to unfollow ${sanitizeDisplayName(
+            profile.displayName || profile.handle,
+            moderation.ui('displayName'),
+          )}?`,
+        )}
+        onConfirm={unfollow}
+        confirmButtonCta={_(msg`Unfollow`)}
+        confirmButtonColor="negative"
+      />
     </View>
   )
 }

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -253,6 +253,7 @@ export function HeaderStandardButtons({
   const editProfileControl = useDialogControl()
   const inviteFriendsControl = useDialogControl()
   const unblockPromptControl = Prompt.usePromptControl()
+  const unfollowPromptControl = Prompt.usePromptControl()
 
   const isMe = currentAccount?.did === profile.did
 
@@ -417,7 +418,9 @@ export function HeaderStandardButtons({
                   : _(msg`Follow ${profile.handle}`)
               }
               onPress={
-                profile.viewer?.following ? onPressUnfollow : onPressFollow
+                profile.viewer?.following
+                  ? () => unfollowPromptControl.open()
+                  : onPressFollow
               }>
               {!profile.viewer?.following && <ButtonIcon icon={Plus} />}
               <ButtonText>
@@ -445,6 +448,20 @@ export function HeaderStandardButtons({
           void unblockAccount()
         }}
         confirmButtonCta={_(msg`Unblock`)}
+        confirmButtonColor="negative"
+      />
+
+      <Prompt.Basic
+        control={unfollowPromptControl}
+        title={_(msg`Unfollow?`)}
+        description={_(
+          msg`Are you sure you want to unfollow ${sanitizeDisplayName(
+            profile.displayName || profile.handle,
+            moderation.ui('displayName'),
+          )}?`,
+        )}
+        onConfirm={onPressUnfollow}
+        confirmButtonCta={_(msg`Unfollow`)}
         confirmButtonColor="negative"
       />
     </>

--- a/src/view/com/notifications/NotificationFeedItem.tsx
+++ b/src/view/com/notifications/NotificationFeedItem.tsx
@@ -65,6 +65,7 @@ import * as MediaPreview from '#/components/MediaPreview'
 import {ProfileBadges} from '#/components/ProfileBadges'
 import * as ProfileCard from '#/components/ProfileCard'
 import {ProfileHoverCard} from '#/components/ProfileHoverCard'
+import * as Prompt from '#/components/Prompt'
 import {Notification as StarterPackCard} from '#/components/StarterPack/StarterPackCard'
 import {SubtleHover} from '#/components/SubtleHover'
 import * as Toast from '#/components/Toast'
@@ -778,6 +779,7 @@ function FollowBackButton({profile}: {profile: AppBskyActorDefs.ProfileView}) {
     profileShadow,
     'ProfileCard',
   )
+  const unfollowPromptControl = Prompt.usePromptControl()
 
   // Don't show button if not logged in or for own profile
   if (!hasSession || profile.did === currentAccount?.did) {
@@ -806,10 +808,7 @@ function FollowBackButton({profile}: {profile: AppBskyActorDefs.ProfileView}) {
     }
   }
 
-  const onPressUnfollow = async (e: GestureResponderEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-
+  const doUnfollow = async () => {
     try {
       await queueUnfollow()
       Toast.show(
@@ -857,7 +856,11 @@ function FollowBackButton({profile}: {profile: AppBskyActorDefs.ProfileView}) {
           color="secondary"
           size="small"
           style={[a.self_start]}
-          onPress={onPressUnfollow}>
+          onPress={(e: GestureResponderEvent) => {
+            e.preventDefault()
+            e.stopPropagation()
+            unfollowPromptControl.open()
+          }}>
           <ButtonIcon icon={CheckIcon} />
           <ButtonText>
             <Trans>Following</Trans>
@@ -876,6 +879,19 @@ function FollowBackButton({profile}: {profile: AppBskyActorDefs.ProfileView}) {
           </ButtonText>
         </Button>
       )}
+
+      <Prompt.Basic
+        control={unfollowPromptControl}
+        title={_(msg`Unfollow?`)}
+        description={_(
+          msg`Are you sure you want to unfollow ${sanitizeDisplayName(
+            profile.displayName || profile.handle,
+          )}?`,
+        )}
+        onConfirm={() => void doUnfollow()}
+        confirmButtonCta={_(msg`Unfollow`)}
+        confirmButtonColor="negative"
+      />
     </View>
   )
 }

--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -247,6 +247,7 @@ let ProfileMenu = ({
 
   const verificationCreatePromptControl = Prompt.usePromptControl()
   const verificationRemovePromptControl = Prompt.usePromptControl()
+  const unfollowPromptControl = Prompt.usePromptControl()
   const currentAccountVerifications =
     profile.verification?.verifications?.filter(v => {
       return v.issuer === currentAccount?.did
@@ -328,7 +329,7 @@ let ProfileMenu = ({
                         }
                         onPress={
                           isFollowing
-                            ? () => void onPressUnfollowAccount()
+                            ? () => unfollowPromptControl.open()
                             : () => void onPressFollowAccount()
                         }>
                         <Menu.ItemText>
@@ -548,6 +549,16 @@ let ProfileMenu = ({
         description={l`This profile is only visible to logged-in users. It won't be visible to people who aren't signed in.`}
         onConfirm={onPressShare}
         confirmButtonCta={l`Share anyway`}
+      />
+      <Prompt.Basic
+        control={unfollowPromptControl}
+        title={l`Unfollow?`}
+        description={l`Are you sure you want to unfollow ${
+          profile.displayName || profile.handle
+        }?`}
+        onConfirm={() => void onPressUnfollowAccount()}
+        confirmButtonCta={l`Unfollow`}
+        confirmButtonColor="negative"
       />
       <VerificationCreatePrompt
         control={verificationCreatePromptControl}


### PR DESCRIPTION
## Why

Unfollowing is a single-tap action with no confirmation, so it's easy to
unfollow someone by accident (e.g. a mis-tap on the "Following" button).
Most other social apps confirm before unfollowing. This adds a
confirmation dialog for unfollow actions.

## What

Adds a `Prompt.Basic` confirmation ("Unfollow? / Are you sure you want to
unfollow {name}?") before unfollowing. Follows the existing unblock
confirmation pattern already used in the codebase.

Covered entry points:
- Profile header "Following" button
- Profile "..." menu -> Unfollow
- Shared `FollowButton` (user lists, search suggestions, feed interstitials, etc.)
- Web profile hover card
- Notification follow-back button

Following remains a single tap (no new friction); only unfollow is gated.

## Notes

- typecheck and lint pass locally
- New strings left for the nightly intl CI to extract/compile