### PR TITLE
Fix quote causing chat message to overflow on web

### DIFF
--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -529,6 +529,7 @@ let MessageItem = ({
                           a.rounded_xl,
                           a.py_sm,
                           a.px_md,
+                          a.max_w_full,
                           {
                             marginTop: hasEmbedAndText
                               ? CLUSTERED_MESSAGE_GAP


### PR DESCRIPTION
<img width="683" height="287" alt="Screenshot 2026-06-16 at 23 28 30" src="https://github.com/user-attachments/assets/0e0055ff-cf35-460d-a42a-a7d9b5bc0120" />
