### PR TITLE
Tweak strings and context

### DIFF
--- a/src/ageAssurance/components/NoAccessScreen.tsx
+++ b/src/ageAssurance/components/NoAccessScreen.tsx
@@ -399,7 +399,7 @@ function AccessSection() {
                       locationControl.open()
                     })}>
                     Tap here to update your location with GPS.
-                  </SimpleInlineLinkText>{' '}
+                  </SimpleInlineLinkText>
                 </Trans>
               </Admonition>
 

--- a/src/components/dialogs/nuxs/GroupChatsAnnouncement.tsx
+++ b/src/components/dialogs/nuxs/GroupChatsAnnouncement.tsx
@@ -168,7 +168,7 @@ export function GroupChatsAnnouncement() {
                   a.font_medium,
                   {color: t.palette.primary_500},
                 ]}>
-                <Trans>New</Trans>
+                <Trans context="nux-description">New</Trans>
               </Text>
             </View>
             <Text

--- a/src/components/moderation/BlockDialog.tsx
+++ b/src/components/moderation/BlockDialog.tsx
@@ -362,14 +362,14 @@ function MutualGroupChat({
         <Button
           color="negative_subtle"
           disabled={isRemovePending}
-          label={l`Kick member`}
+          label={l`Remove member`}
           size="small"
           onPress={() => {
             onOptimisticallyRemoveConvo(view.id)
             removeMembers({members: [profileDid]})
           }}>
           <ButtonText>
-            <Trans>Kick member</Trans>
+            <Trans>Remove member</Trans>
           </ButtonText>
           {isRemovePending ? <ButtonIcon icon={Loader} /> : null}
         </Button>

--- a/src/screens/Messages/JoinRequests.tsx
+++ b/src/screens/Messages/JoinRequests.tsx
@@ -212,7 +212,7 @@ function JoinRequestsList({
     useJoinRequestMutation('reject', convoId, {
       onSuccess: () => {
         ax.metric('groupchat:owner:joinRequest:reject', {convoId})
-        Toast.show(l`Request ignored.`)
+        Toast.show(l`Request rejected.`)
         if (getRemainingRequestCount() < 1) {
           navigation.replace('MessagesConversationSettings', {
             conversation: convoId,
@@ -220,7 +220,7 @@ function JoinRequestsList({
         }
       },
       onError: error => {
-        let errorMessage = l`Failed to ignore join request`
+        let errorMessage = l`Failed to reject join request`
         if (isNetworkError(error)) {
           errorMessage = l`A network error occurred. Please check your internet connection.`
         } else if (
@@ -230,7 +230,7 @@ function JoinRequestsList({
         } else if (
           error instanceof ChatBskyGroupRejectJoinRequest.InsufficientRoleError
         ) {
-          errorMessage = l`Only admins can ignore join requests.`
+          errorMessage = l`Only admins can reject join requests.`
         }
         Toast.show(errorMessage, {type: 'error'})
       },

--- a/src/screens/Messages/components/MessageComposer.tsx
+++ b/src/screens/Messages/components/MessageComposer.tsx
@@ -243,7 +243,7 @@ export function MessageComposer({
                 placeholder={
                   loading
                     ? l({message: 'Loading chat…', context: 'placeholder'})
-                    : l({message: 'Message', context: 'action'})
+                    : l({message: 'Message', context: 'description'})
                 }
                 autocompletePlacement="top-start"
                 internalApiRef={composerInternalApiRef}


### PR DESCRIPTION
In response to [feedback on the Translators Discord](https://discord.com/channels/1338165055992107061/1338165056596082731/1514933672321613886), this PR proposes a few string and `context` tweaks:

- Change toast strings that refer to `ignore`/`ignored` to `reject`/`rejected` to align with `Reject join request`
- Tweak `context` for the `Message` string that appears as placeholder text in the DM input
- Add `context` to the `New` string that appears in the group chats NUX, to distinguish it from other usages of `New`
- Change `Kick member` to `Remove member` to align with other strings that refer to removing members

And one other tiny change:
- Remove the trailing space from the `Is your location not accurate? <0>Tap here to update your location with GPS.</0> ` string

cc: @nilaallj