### PR TITLE
Replace setup-cocoapods action with inline version assert

### DIFF
--- a/.github/workflows/build-submit-ios.yml
+++ b/.github/workflows/build-submit-ios.yml
@@ -61,10 +61,16 @@ jobs:
         with:
           xcode-version: "26.4"
 
-      - name: ☕️ Setup Cocoapods
-        uses: maxim-lobanov/setup-cocoapods@8e97e1e98e6ccf42564fdf5622c8feec74199377 # v1.4.0
-        with:
-          version: 1.16.2
+      - name: ☕️ Assert Cocoapods version
+        run: |
+          EXPECTED=1.16.2
+          ACTUAL=$(pod --version)
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "Expected Cocoapods $EXPECTED but runner has $ACTUAL."
+            echo "The version ships preinstalled with the macOS runner image: https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md"
+            echo "If the runner image changed, update EXPECTED here or reinstall the pinned version."
+            exit 1
+          fi
 
       - name: 💾 Cache Pods
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -197,10 +197,16 @@ jobs:
         with:
           xcode-version: "26.4"
 
-      - name: ☕️ Setup Cocoapods
-        uses: maxim-lobanov/setup-cocoapods@8e97e1e98e6ccf42564fdf5622c8feec74199377 # v1.4.0
-        with:
-          version: 1.16.2
+      - name: ☕️ Assert Cocoapods version
+        run: |
+          EXPECTED=1.16.2
+          ACTUAL=$(pod --version)
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "Expected Cocoapods $EXPECTED but runner has $ACTUAL."
+            echo "The version ships preinstalled with the macOS runner image: https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md"
+            echo "If the runner image changed, update EXPECTED here or reinstall the pinned version."
+            exit 1
+          fi
 
       - name: 💾 Cache Pods
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
## What

The `maxim-lobanov/setup-cocoapods` action is outdated (Node 20) and, on our runners, a no-op. Its only behavior is: run `pod --version`, and if it already matches the requested version, return without doing anything. It only uninstalls/reinstalls on a mismatch.

Both workflows that use it run on `macos-26` / `macos-26-xlarge`, and that [runner image ships CocoaPods 1.16.2 preinstalled](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md) — exactly the version we request. So the action does nothing but pull in a deprecated Node 20 third-party action.

## Change

Replaced it in `build-submit-ios.yml` and `bundle-deploy-eas-update.yml` with an inline assert that fails loudly (linking the runner image doc) if the preinstalled version ever drifts:

```yaml
- name: ☕️ Assert Cocoapods version
  run: |
    EXPECTED=1.16.2
    ACTUAL=$(pod --version)
    if [ "$ACTUAL" != "$EXPECTED" ]; then
      ...
      exit 1
    fi
```

## Note

This is strictly an assert, not a fallback — the old action *would* have reinstalled on a mismatch; this just fails. Since the pod cache key is tied to `pnpm-lock.yaml` and assumes a stable pod version anyway, failing loudly seemed like the better behavior. Easy to switch to self-healing (reinstall the pinned version) if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)