### PR TITLE
Fix internal repo sync broken by actions/checkout v6 bump

### DIFF
--- a/.github/workflows/sync-internal.yaml
+++ b/.github/workflows/sync-internal.yaml
@@ -17,6 +17,9 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          # Don't persist the checkout auth header; the push below authenticates
+          # with the app token embedded in the remote URL instead
+          persist-credentials: false
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -33,6 +36,5 @@ jobs:
         run: |
           git config user.name "github-actions"
           git config user.email "test@users.noreply.github.com"
-          git config --unset-all http.https://github.com/.extraheader
           git remote add internal https://x-access-token:${TOKEN}@github.com/bluesky-social/social-app-internal.git
           git push internal main --force


### PR DESCRIPTION
## Problem

The "Sync to internal repo" workflow has been failing on every push to `main` since #10779. The "Push to internal repo" step exits with code 5.

## Root cause

#10779 bumped `actions/checkout` from v5 to v6. The push step runs:

```sh
git config --unset-all http.https://github.com/.extraheader
```

to strip the auth header that checkout injects, so the push uses the app token embedded in the remote URL instead. In checkout **v5** that header lived in the repo's local git config, so the unset succeeded. In **v6**, credentials are stored differently (via `includeIf.gitdir` entries pointing to a separate credentials file, not a local `extraheader`), so `--unset-all` finds nothing and exits with code 5 ("trying to unset an option which does not exist"), failing the step.

## Fix

Set `persist-credentials: false` on the checkout step so no auth header is injected in the first place, and drop the now-unnecessary (and failing) `--unset-all`. The push to the internal repo authenticates via the app token in the remote URL, so it doesn't need the checkout credentials at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)