### PR TITLE
Fix setState-in-render warning from convo cache subscription

### DIFF
--- a/src/state/messages/convo/index.tsx
+++ b/src/state/messages/convo/index.tsx
@@ -132,6 +132,12 @@ export function ConvoProvider({
   useEffect(() => {
     const [root, id] = getConvoKey(convoId)
     return queryClient.getQueryCache().subscribe(event => {
+      // Only react to data updates. Other event types (e.g. `added`) can be
+      // emitted synchronously while another component reads this same query
+      // during its render (React Query builds the query in `getOptimisticResult`),
+      // and committing to the convo store then would set state on this provider
+      // mid-render of that component.
+      if (event.type !== 'updated') return
       const queryKey = event.query.queryKey as string[]
       if (queryKey[0] === root && queryKey[1] === id) {
         const data = event.query.state.data as


### PR DESCRIPTION
## Problem

React logs:

> Cannot update a component (`ConvoProvider`) while rendering a different component (`SettingsInner`).

## Root cause

`ConvoProvider` (`src/state/messages/convo/index.tsx`) subscribes to the React Query cache to keep its `Convo` agent in sync with the `['convo', convoId]` query. The callback mutated the store synchronously (`convo.updateMuted` / `updateGroupName` / ... → `commit()` → notifies its `useSyncExternalStore`).

The conversation settings screen is **stacked above** the conversation screen in the nav stack, so the `Conversation` screen's `ConvoProvider` stays mounted underneath. When `SettingsInner` renders and calls `useConvoQuery({convoId})` for the *same* key, React Query's render-phase `getOptimisticResult` → `getQueryCache().build()` emits a synchronous `added` cache event (no batch transaction is active during render, so `notifyManager` flushes immediately). That fires the subscription mid-render and sets state on the underlying `ConvoProvider`.

Introduced in 8b4a5238b ("Sync convo agent with shadow cache").

## Fix

Only react to `updated` events in the cache subscription. `updated` is dispatched on actual data writes (query resolution, `setQueryData`, `precacheConvoQuery`), so the real sync behavior is fully preserved — we just stop reacting to the render-phase `added` event that triggered the cross-component setState.

🤖 Generated with [Claude Code](https://claude.com/claude-code)