### PR TITLE
Add a "+" button to home feed tabs for discovering and adding feeds

### DIFF
--- a/src/screens/Search/Explore.tsx
+++ b/src/screens/Search/Explore.tsx
@@ -215,9 +215,14 @@ type ExploreScreenItems =
 
 export function Explore({
   focusSearchInput,
+  feedsOnly = false,
 }: {
   focusSearchInput: (tab: 'user' | 'profile' | 'feed') => void
   headerHeight: number
+  // When true, only show the "Discover new feeds" section, omitting interests,
+  // trending, and suggested accounts. Used to embed feed discovery inline
+  // (e.g. from the home tab bar).
+  feedsOnly?: boolean
 }) {
   const ax = useAnalytics()
   const {_} = useLingui()
@@ -722,6 +727,13 @@ export function Explore({
     // Dynamic module ordering
 
     i.push(topBorder)
+
+    if (feedsOnly) {
+      // Only the "Discover new feeds" section (header + suggested feeds list).
+      i.push(...suggestedFeedsModule)
+      return i
+    }
+
     i.push(...interestsNuxModule)
 
     i.push({type: 'liveEventFeedsBanner', key: 'liveEventFeedsBanner'})
@@ -746,6 +758,7 @@ export function Explore({
     feedPreviewsModule,
     interestsNuxModule,
     useFullExperience,
+    feedsOnly,
   ])
 
   const renderItem = useCallback(

--- a/src/view/com/home/HomeHeader.tsx
+++ b/src/view/com/home/HomeHeader.tsx
@@ -12,6 +12,8 @@ export function HomeHeader(
   props: RenderTabBarFnProps & {
     testID?: string
     onPressSelected: () => void
+    onPressAdd?: () => void
+    addActive?: boolean
     feeds: FeedSourceInfo[]
   },
 ) {
@@ -61,6 +63,8 @@ export function HomeHeader(
         items={items}
         dragProgress={props.dragProgress}
         dragState={props.dragState}
+        onPressAdd={hasSession ? props.onPressAdd : undefined}
+        addActive={props.addActive}
         transparent
       />
     </HomeHeaderLayout>

--- a/src/view/com/pager/Pager.tsx
+++ b/src/view/com/pager/Pager.tsx
@@ -8,7 +8,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import {View} from 'react-native'
+import {StyleSheet, View} from 'react-native'
 import {DrawerGestureContext} from 'react-native-drawer-layout'
 import {Gesture, GestureDetector} from 'react-native-gesture-handler'
 import PagerView, {
@@ -48,6 +48,10 @@ interface Props {
   ref?: React.Ref<PagerRef>
   initialPage?: number
   renderTabBar: RenderTabBarFn
+  // Optional content rendered as an overlay on top of the pages, filling the
+  // area below the tab bar. Used to show inline content (e.g. Explore) without
+  // changing the selected page.
+  renderContentOverlay?: () => JSX.Element | null
   // tab pressed, yet to scroll to page
   onTabPressed?: (index: number) => void
   // scroll settled
@@ -66,6 +70,7 @@ export function Pager({
   children,
   initialPage = 0,
   renderTabBar,
+  renderContentOverlay,
   onPageSelected: parentOnPageSelected,
   onTabPressed: parentOnTabPressed,
   onPageScrollStateChanged: parentOnPageScrollStateChanged,
@@ -151,15 +156,20 @@ export function Pager({
         dragProgress,
         dragState,
       })}
-      <DrawerGestureRequireFail>
-        <MemoizedAnimatedPagerView
-          ref={pagerView}
-          style={a.flex_1}
-          initialPage={initialPage}
-          onPageScroll={handlePageScroll}>
-          {children}
-        </MemoizedAnimatedPagerView>
-      </DrawerGestureRequireFail>
+      <View style={a.flex_1}>
+        <DrawerGestureRequireFail>
+          <MemoizedAnimatedPagerView
+            ref={pagerView}
+            style={a.flex_1}
+            initialPage={initialPage}
+            onPageScroll={handlePageScroll}>
+            {children}
+          </MemoizedAnimatedPagerView>
+        </DrawerGestureRequireFail>
+        {renderContentOverlay && (
+          <View style={StyleSheet.absoluteFill}>{renderContentOverlay()}</View>
+        )}
+      </View>
     </View>
   )
 }

--- a/src/view/com/pager/Pager.web.tsx
+++ b/src/view/com/pager/Pager.web.tsx
@@ -27,6 +27,9 @@ interface Props {
   ref?: React.Ref<PagerRef>
   initialPage?: number
   renderTabBar: RenderTabBarFn
+  // Optional content rendered in place of the pages, below the tab bar. Used to
+  // show inline content (e.g. Explore) without changing the selected page.
+  renderContentOverlay?: () => JSX.Element | null
   onPageSelected?: (index: number) => void
 }
 
@@ -35,6 +38,7 @@ export function Pager({
   children,
   initialPage = 0,
   renderTabBar,
+  renderContentOverlay,
   onPageSelected,
 }: React.PropsWithChildren<Props>) {
   const [selectedPage, setSelectedPage] = useState(initialPage)
@@ -80,6 +84,8 @@ export function Pager({
     [selectedPage, setSelectedPage, onPageSelected],
   )
 
+  const overlay = renderContentOverlay?.()
+
   return (
     <View style={s.hContentRegion}>
       {renderTabBar({
@@ -89,11 +95,12 @@ export function Pager({
       })}
       {Children.map(children, (child, i) => (
         <View
-          style={selectedPage === i ? a.flex_1 : a.hidden}
+          style={selectedPage === i && !overlay ? a.flex_1 : a.hidden}
           key={`page-${i}`}>
           {child}
         </View>
       ))}
+      {overlay && <View style={a.flex_1}>{overlay}</View>}
     </View>
   )
 }

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -16,10 +16,12 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated'
+import {useLingui} from '@lingui/react/macro'
 
 import {PressableWithHover} from '#/view/com/util/PressableWithHover'
 import {BlockDrawerGesture} from '#/view/shell/BlockDrawerGesture'
 import {atoms as a, useTheme} from '#/alf'
+import {PlusLarge_Stroke2_Corner0_Rounded as PlusIcon} from '#/components/icons/Plus'
 import {Text} from '#/components/Typography'
 
 export interface TabBarProps {
@@ -31,6 +33,11 @@ export interface TabBarProps {
   dragProgress: SharedValue<number>
   dragState: SharedValue<'idle' | 'dragging' | 'settling'>
   transparent?: boolean
+  // When provided, an "add" button is shown at the right end of the tab bar.
+  onPressAdd?: () => void
+  // When true, the add button is shown as selected and the feed tabs are
+  // shown as unselected.
+  addActive?: boolean
 }
 
 const ITEM_PADDING = 10
@@ -48,8 +55,11 @@ export function TabBar({
   dragProgress,
   dragState,
   transparent,
+  onPressAdd,
+  addActive,
 }: TabBarProps) {
   const t = useTheme()
+  const {t: l} = useLingui()
   const scrollElRef = useAnimatedRef<ScrollView>()
   const syncScrollState = useSharedValue<'synced' | 'unsynced' | 'needs-sync'>(
     'synced',
@@ -235,6 +245,10 @@ export function TabBar({
     if (!_WORKLET) {
       return {opacity: 0}
     }
+    if (addActive) {
+      // The add button is selected, so hide the feed selection indicator.
+      return {opacity: 0}
+    }
     const layoutsValue = layouts.get()
     const textLayoutsValue = textLayouts.get()
     if (
@@ -323,6 +337,7 @@ export function TabBar({
           horizontal={true}
           showsHorizontalScrollIndicator={false}
           ref={scrollElRef}
+          style={a.flex_1}
           contentContainerStyle={styles.contentContainer}
           onLayout={e => {
             containerSize.set(e.nativeEvent.layout.width)
@@ -370,6 +385,28 @@ export function TabBar({
           </Animated.View>
         </ScrollView>
       </BlockDrawerGesture>
+      {onPressAdd && (
+        <PressableWithHover
+          testID={`${testID}-add`}
+          style={styles.addButton}
+          hoverStyle={t.atoms.bg_contrast_25}
+          onPress={onPressAdd}
+          accessibilityRole="button"
+          accessibilityState={{selected: addActive}}
+          accessibilityLabel={l`Discover new feeds`}
+          accessibilityHint="">
+          <PlusIcon
+            size="md"
+            fill={addActive ? t.palette.primary_500 : t.atoms.text.color}
+          />
+          <View
+            style={[
+              styles.addIndicator,
+              addActive && {borderColor: t.palette.primary_500},
+            ]}
+          />
+        </PressableWithHover>
+      )}
       <View style={[t.atoms.border_contrast_low, styles.outerBottomBorder]} />
     </View>
   )
@@ -454,6 +491,21 @@ const styles = StyleSheet.create({
     paddingTop: 10,
     paddingHorizontal: ITEM_PADDING,
     justifyContent: 'center',
+  },
+  addButton: {
+    paddingTop: 10,
+    paddingBottom: 10,
+    paddingHorizontal: ITEM_PADDING,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  addIndicator: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    borderBottomWidth: 2,
+    borderColor: 'transparent',
   },
   itemInner: {
     alignItems: 'center',

--- a/src/view/com/pager/TabBar.web.tsx
+++ b/src/view/com/pager/TabBar.web.tsx
@@ -1,7 +1,9 @@
 import {useCallback, useEffect, useRef} from 'react'
 import {type ScrollView, StyleSheet, View} from 'react-native'
+import {useLingui} from '@lingui/react/macro'
 
 import {atoms as a, useBreakpoints, useTheme, web} from '#/alf'
+import {PlusLarge_Stroke2_Corner0_Rounded as PlusIcon} from '#/components/icons/Plus'
 import {Text} from '#/components/Typography'
 import {PressableWithHover} from '../util/PressableWithHover'
 import {DraggableScrollView} from './DraggableScrollView'
@@ -15,6 +17,11 @@ export interface TabBarProps {
 
   onSelect?: (index: number) => void
   onPressSelected?: (index: number) => void
+  // When provided, an "add" button is shown at the right end of the tab bar.
+  onPressAdd?: () => void
+  // When true, the add button is shown as selected and the feed tabs are
+  // shown as unselected.
+  addActive?: boolean
 }
 
 // How much of the previous/next item we're showing
@@ -27,8 +34,11 @@ export function TabBar({
   items,
   onSelect,
   onPressSelected,
+  onPressAdd,
+  addActive,
 }: TabBarProps) {
   const t = useTheme()
+  const {t: l} = useLingui()
   const scrollElRef = useRef<ScrollView>(null)
   const itemRefs = useRef<Array<Element>>([])
   const {gtMobile} = useBreakpoints()
@@ -99,9 +109,10 @@ export function TabBar({
         horizontal={true}
         showsHorizontalScrollIndicator={false}
         ref={scrollElRef}
+        style={a.flex_1}
         contentContainerStyle={styles.contentContainer}>
         {items.map((item, i) => {
-          const selected = i === selectedPage
+          const selected = i === selectedPage && !addActive
           return (
             <PressableWithHover
               testID={`${testID}-selector-${i}`}
@@ -139,6 +150,32 @@ export function TabBar({
           )
         })}
       </DraggableScrollView>
+      {onPressAdd && (
+        <PressableWithHover
+          testID={`${testID}-add`}
+          style={styles.addButton}
+          hoverStyle={t.atoms.bg_contrast_25}
+          onPress={onPressAdd}
+          accessibilityRole="button"
+          accessibilityState={{selected: addActive}}
+          accessibilityLabel={l`Discover new feeds`}
+          accessibilityHint="">
+          <PlusIcon
+            size="md"
+            fill={
+              addActive
+                ? t.atoms.text.color
+                : t.atoms.text_contrast_medium.color
+            }
+          />
+          <View
+            style={[
+              styles.itemIndicator,
+              addActive && {backgroundColor: t.palette.primary_500},
+            ]}
+          />
+        </PressableWithHover>
+      )}
       <View style={[t.atoms.border_contrast_low, styles.outerBottomBorder]} />
     </View>
   )
@@ -160,6 +197,13 @@ const desktopStyles = StyleSheet.create({
     paddingTop: 14,
     paddingHorizontal: 14,
     justifyContent: 'center',
+  },
+  addButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: 14,
+    paddingHorizontal: 14,
+    paddingBottom: 10 + 3,
   },
   itemInner: {
     alignItems: 'center',
@@ -202,6 +246,13 @@ const mobileStyles = StyleSheet.create({
     paddingTop: 10,
     paddingHorizontal: 10,
     justifyContent: 'center',
+  },
+  addButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: 10,
+    paddingHorizontal: 10,
+    paddingBottom: 10 + 3,
   },
   itemInner: {
     flexGrow: 1,

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -1,7 +1,14 @@
-import {useCallback, useEffect, useLayoutEffect, useMemo, useRef} from 'react'
-import {ActivityIndicator, StyleSheet} from 'react-native'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import {ActivityIndicator, StyleSheet, View} from 'react-native'
 import {withSpring} from 'react-native-reanimated'
-import {useFocusEffect} from '@react-navigation/native'
+import {useFocusEffect, useNavigation} from '@react-navigation/native'
 
 import {PROD_DEFAULT_FEED} from '#/lib/constants'
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
@@ -11,6 +18,7 @@ import {useRequestNotificationsPermission} from '#/lib/notifications/notificatio
 import {
   type HomeTabNavigatorParams,
   type NativeStackScreenProps,
+  type NavigationProp,
 } from '#/lib/routes/types'
 import {emitSoftReset} from '#/state/events'
 import {
@@ -38,6 +46,9 @@ import {
   useHomeHeaderMode,
 } from '#/view/com/util/MainScrollProvider'
 import {NoFeedsPinned} from '#/screens/Home/NoFeedsPinned'
+import {Explore} from '#/screens/Search/Explore'
+import {useTheme} from '#/alf'
+import {useHeaderOffset} from '#/components/hooks/useHeaderOffset'
 import * as Layout from '#/components/Layout'
 import {useAnalytics} from '#/analytics'
 import {IS_LIQUID_GLASS, IS_WEB} from '#/env'
@@ -50,6 +61,32 @@ export function HomeScreen(props: Props) {
   const {currentAccount} = useSession()
   const {data: pinnedFeedInfos, isLoading: isPinnedFeedsLoading} =
     usePinnedFeedsInfos()
+  const setSelectedFeed = useSetSelectedFeed()
+
+  // Inline "Discover new feeds" (Explore) state lives here rather than in
+  // HomeScreenReady because pinning a feed changes the usePinnedFeedsInfos query
+  // key, which briefly unmounts HomeScreenReady -- losing any state held there.
+  const [showExplore, setShowExplore] = useState(false)
+  const prevPinnedCountRef = useRef(0)
+  useEffect(() => {
+    if (!pinnedFeedInfos) return
+    const prevCount = prevPinnedCountRef.current
+    prevPinnedCountRef.current = pinnedFeedInfos.length
+    // When a custom feed is pinned while Explore is open, select the last pinned
+    // custom feed (the rightmost non-Following tab) and close Explore.
+    if (showExplore && prevCount > 0 && pinnedFeedInfos.length > prevCount) {
+      let lastCustomIndex = -1
+      for (let i = 0; i < pinnedFeedInfos.length; i++) {
+        if (pinnedFeedInfos[i].feedDescriptor !== 'following') {
+          lastCustomIndex = i
+        }
+      }
+      if (lastCustomIndex !== -1) {
+        setSelectedFeed(pinnedFeedInfos[lastCustomIndex].feedDescriptor)
+      }
+      setShowExplore(false)
+    }
+  }, [pinnedFeedInfos, showExplore, setSelectedFeed])
 
   useEffect(() => {
     if (IS_WEB && !currentAccount) {
@@ -89,6 +126,8 @@ export function HomeScreen(props: Props) {
             {...props}
             preferences={preferences}
             pinnedFeedInfos={pinnedFeedInfos}
+            showExplore={showExplore}
+            setShowExplore={setShowExplore}
           />
         </HomeHeaderModeProvider>
       </Layout.Screen>
@@ -107,11 +146,18 @@ export function HomeScreen(props: Props) {
 function HomeScreenReady({
   preferences,
   pinnedFeedInfos,
+  showExplore,
+  setShowExplore,
 }: Props & {
   preferences: UsePreferencesQueryResponse
   pinnedFeedInfos: SavedFeedSourceInfo[]
+  showExplore: boolean
+  setShowExplore: React.Dispatch<React.SetStateAction<boolean>>
 }) {
   const ax = useAnalytics()
+  const t = useTheme()
+  const navigation = useNavigation<NavigationProp>()
+  const headerOffset = useHeaderOffset()
   const allFeeds = useMemo(
     () => pinnedFeedInfos.map(f => f.feedDescriptor),
     [pinnedFeedInfos],
@@ -172,6 +218,8 @@ function HomeScreenReady({
   const onPageSelected = useCallback(
     (index: number) => {
       showHeader()
+      // Selecting a feed dismisses the inline Explore view.
+      setShowExplore(false)
       const maybeFeed = allFeeds[index]
 
       // Mutate the ref before setting state to avoid the imperative syncing effect
@@ -193,6 +241,19 @@ function HomeScreenReady({
   const onPressSelected = useCallback(() => {
     emitSoftReset()
   }, [])
+
+  const onPressAdd = useCallback(() => {
+    setShowExplore(show => !show)
+  }, [])
+
+  const focusSearchInput = useCallback(() => {
+    setShowExplore(false)
+    if (IS_WEB) {
+      navigation.navigate('Search', {})
+    } else {
+      navigation.navigate('SearchTab')
+    }
+  }, [navigation])
 
   const onPageScrollStateChanged = useCallback(
     (state: 'idle' | 'dragging' | 'settling') => {
@@ -226,12 +287,29 @@ function HomeScreenReady({
           {...props}
           testID="homeScreenFeedTabs"
           onPressSelected={onPressSelected}
+          onPressAdd={onPressAdd}
+          addActive={showExplore}
           feeds={pinnedFeedInfos}
         />
       )
     },
-    [onPressSelected, pinnedFeedInfos, demoMode],
+    [onPressSelected, onPressAdd, showExplore, pinnedFeedInfos, demoMode],
   )
+
+  const renderContentOverlay = useCallback(() => {
+    if (!showExplore) {
+      return null
+    }
+    return (
+      <View style={[{flex: 1, paddingTop: headerOffset}, t.atoms.bg]}>
+        <Explore
+          focusSearchInput={focusSearchInput}
+          headerHeight={0}
+          feedsOnly
+        />
+      </View>
+    )
+  }, [showExplore, headerOffset, focusSearchInput, t.atoms.bg])
 
   const renderFollowingEmptyState = useCallback(() => {
     return <FollowingEmptyState />
@@ -288,7 +366,8 @@ function HomeScreenReady({
       initialPage={selectedIndex}
       onPageSelected={onPageSelected}
       onPageScrollStateChanged={onPageScrollStateChanged}
-      renderTabBar={renderTabBar}>
+      renderTabBar={renderTabBar}
+      renderContentOverlay={renderContentOverlay}>
       {pinnedFeedInfos.length ? (
         pinnedFeedInfos.map((feedInfo, index) => {
           const feed = feedInfo.feedDescriptor


### PR DESCRIPTION
## Summary

Adds a "+" button at the right end of the home feed tab bar so users can discover and add new feeds without leaving Home. After a feed is added, its tab is selected and shown automatically.

## Motivation

- The home feed tabs only switched between pinned feeds, so it was not clear that feeds can be added at all.
- Putting an "add" affordance directly on the tab bar makes growing your feeds discoverable and intuitive.

## What changed

**1. UI improvement — "+" button on the tab bar**
- A fixed "+" button is shown at the right end of the home feed tab bar (signed-in only, Home only — not shown on the shared tab bar used by Notifications, Search results, etc.).

**2. Make it clear that feeds can be added**
- Tapping "+" shows the "Discover new feeds" section inline in the feed area (no navigation away). While open, "+" is shown as selected and the feed selection indicator is hidden. Tapping "+" again or selecting a feed tab dismisses it.

**3. Move to the added feed**
- Pinning a feed from the inline list selects the newly added custom feed (the rightmost tab) and shows it, dismissing the discovery view.

## Implementation notes

- Reuses the existing `Explore` screen via a new `feedsOnly` prop — no new discovery UI was built.
- `Pager` gets a `renderContentOverlay` prop to draw inline content below the tab bar (native + web).
- Pin detection lives in `HomeScreen` (not `HomeScreenReady`): pinning a feed changes the `usePinnedFeedsInfos` query key, which briefly unmounts `HomeScreenReady`. Keeping the state in the parent and selecting via the global `setSelectedFeed` ensures the newly pinned feed is shown across that remount.

## Changed files
- `src/screens/Search/Explore.tsx` — `feedsOnly` prop
- `src/view/com/pager/Pager.tsx` / `Pager.web.tsx` — `renderContentOverlay`
- `src/view/screens/Home.tsx` — inline Explore overlay + auto-select after pin
- `src/view/com/home/HomeHeader.tsx` — forwards `onPressAdd` / `addActive`
- `src/view/com/pager/TabBar.tsx` / `TabBar.web.tsx` — "+" button + selected state

## Test plan
- [ ] "+" appears at the right end of the home feed tab bar (signed in)
- [ ] "+" is hidden when signed out
- [ ] "+" is not shown on other tab bars (Notifications, Search results, etc.)
- [ ] Tapping "+" shows "Discover new feeds" inline and marks "+" selected
- [ ] Pinning a feed selects and shows the new tab (works for repeated adds)
- [ ] Verified on iOS / Android / Web
