### PR TITLE
Add circular feed icons to feed navigation

### DIFF
--- a/src/view/com/home/HomeHeader.tsx
+++ b/src/view/com/home/HomeHeader.tsx
@@ -1,10 +1,14 @@
 import {useCallback, useMemo} from 'react'
+import {View} from 'react-native'
 import {useNavigation} from '@react-navigation/native'
 
 import {type NavigationProp} from '#/lib/routes/types'
 import {type FeedSourceInfo} from '#/state/queries/feed'
 import {useSession} from '#/state/session'
 import {type RenderTabBarFnProps} from '#/view/com/pager/Pager'
+import {UserAvatar} from '#/view/com/util/UserAvatar'
+import {atoms as a, useTheme} from '#/alf'
+import {FilterTimeline_Stroke2_Corner0_Rounded as FilterTimeline} from '#/components/icons/FilterTimeline'
 import {TabBar} from '../pager/TabBar'
 import {HomeHeaderLayout} from './HomeHeaderLayout'
 
@@ -35,6 +39,17 @@ export function HomeHeader(
     return pinnedNames
   }, [hasPinnedCustom, feeds])
 
+  const itemIcons = useMemo<React.ReactNode[]>(() => {
+    const icons: React.ReactNode[] = feeds.map(f => (
+      <FeedTabIcon key={f.uri} feed={f} />
+    ))
+    if (!hasPinnedCustom) {
+      // No icon for the trailing "Feeds ✨" link.
+      icons.push(undefined)
+    }
+    return icons
+  }, [feeds, hasPinnedCustom])
+
   const onPressFeedsLink = useCallback(() => {
     navigation.navigate('Feeds')
   }, [navigation])
@@ -59,10 +74,43 @@ export function HomeHeader(
         onSelect={onSelect}
         testID={props.testID}
         items={items}
+        itemIcons={itemIcons}
         dragProgress={props.dragProgress}
         dragState={props.dragState}
         transparent
       />
     </HomeHeaderLayout>
+  )
+}
+
+function FeedTabIcon({feed}: {feed: FeedSourceInfo}) {
+  const t = useTheme()
+
+  if (feed.uri === 'following' || feed.feedDescriptor === 'following') {
+    return (
+      <View
+        style={[
+          a.align_center,
+          a.justify_center,
+          a.rounded_full,
+          {width: 20, height: 20, backgroundColor: t.palette.primary_500},
+        ]}>
+        <FilterTimeline
+          style={{width: 14, height: 14}}
+          fill={t.palette.white}
+        />
+      </View>
+    )
+  }
+
+  return (
+    <View style={[a.rounded_full, a.overflow_hidden, {width: 20, height: 20}]}>
+      <UserAvatar
+        type={feed.type === 'list' ? 'list' : 'algo'}
+        size={20}
+        avatar={feed.avatar}
+        noBorder
+      />
+    </View>
   )
 }

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -1,4 +1,4 @@
-import {useCallback} from 'react'
+import {type ReactNode, useCallback} from 'react'
 import {
   type LayoutChangeEvent,
   ScrollView,
@@ -26,6 +26,8 @@ export interface TabBarProps {
   testID?: string
   selectedPage: number
   items: string[]
+  // Optional icon rendered before each item's label, aligned by index.
+  itemIcons?: ReactNode[]
   onSelect?: (index: number) => void
   onPressSelected?: (index: number) => void
   dragProgress: SharedValue<number>
@@ -43,6 +45,7 @@ export function TabBar({
   testID,
   selectedPage,
   items,
+  itemIcons,
   onSelect,
   onPressSelected,
   dragProgress,
@@ -348,6 +351,7 @@ export function TabBar({
                   testID={testID}
                   dragProgress={dragProgress}
                   item={item}
+                  icon={itemIcons?.[i]}
                   onPressItem={onPressItem}
                   onItemLayout={onItemLayout}
                   onTextLayout={onTextLayout}
@@ -380,6 +384,7 @@ function TabBarItem({
   testID,
   dragProgress,
   item,
+  icon,
   onPressItem,
   onItemLayout,
   onTextLayout,
@@ -388,6 +393,7 @@ function TabBarItem({
   testID: string | undefined
   dragProgress: SharedValue<number>
   item: string
+  icon?: ReactNode
   onPressItem: (index: number) => void
   onItemLayout: (index: number, layout: {x: number; width: number}) => void
   onTextLayout: (index: number, layout: {width: number}) => void
@@ -429,7 +435,15 @@ function TabBarItem({
         hoverStyle={t.atoms.bg_contrast_25}
         onPress={() => onPressItem(index)}
         accessibilityRole="tab">
-        <Animated.View style={[style, styles.itemInner]}>
+        <Animated.View
+          style={[
+            style,
+            styles.itemInner,
+            a.flex_row,
+            a.align_start,
+            a.gap_xs,
+          ]}>
+          {icon}
           <Text
             emoji
             testID={testID ? `${testID}-${item}` : undefined}

--- a/src/view/com/pager/TabBar.web.tsx
+++ b/src/view/com/pager/TabBar.web.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef} from 'react'
+import {type ReactNode, useCallback, useEffect, useRef} from 'react'
 import {type ScrollView, StyleSheet, View} from 'react-native'
 
 import {atoms as a, useBreakpoints, useTheme, web} from '#/alf'
@@ -10,6 +10,8 @@ export interface TabBarProps {
   testID?: string
   selectedPage: number
   items: string[]
+  // Optional icon rendered before each item's label, aligned by index.
+  itemIcons?: ReactNode[]
   indicatorColor?: string
   backgroundColor?: string
 
@@ -25,6 +27,7 @@ export function TabBar({
   testID,
   selectedPage,
   items,
+  itemIcons,
   onSelect,
   onPressSelected,
 }: TabBarProps) {
@@ -113,7 +116,9 @@ export function TabBar({
               hoverStyle={t.atoms.bg_contrast_25}
               onPress={() => onPressItem(i)}
               accessibilityRole="tab">
-              <View style={styles.itemInner}>
+              <View
+                style={[styles.itemInner, a.flex_row, a.align_start, a.gap_xs]}>
+                {itemIcons?.[i]}
                 <Text
                   emoji
                   testID={testID ? `${testID}-${item}` : undefined}

--- a/src/view/shell/desktop/Feeds.tsx
+++ b/src/view/shell/desktop/Feeds.tsx
@@ -200,7 +200,7 @@ function FeedItem({
           style={[
             a.align_center,
             a.justify_center,
-            a.rounded_xs,
+            a.rounded_full,
             {
               width: 20,
               height: 20,
@@ -213,12 +213,15 @@ function FeedItem({
           />
         </View>
       ) : (
-        <UserAvatar
-          type={feedInfo.type === 'list' ? 'list' : 'algo'}
-          size={20}
-          avatar={feedInfo.avatar}
-          noBorder
-        />
+        <View
+          style={[a.rounded_full, a.overflow_hidden, {width: 20, height: 20}]}>
+          <UserAvatar
+            type={feedInfo.type === 'list' ? 'list' : 'algo'}
+            size={20}
+            avatar={feedInfo.avatar}
+            noBorder
+          />
+        </View>
       )}
       <Text
         style={[


### PR DESCRIPTION
## Summary

Adds a small round icon before each feed's name in both the desktop right rail and the home feed tabs, so feeds are easier to recognize at a glance.

## Motivation

- Feed tabs/links were text-only, which made it harder to scan and distinguish feeds.
- A round avatar/icon per feed makes navigation clearer and friendlier, and matches the circular avatar styling used elsewhere.
- It also makes the feed navigation look cuter and more polished, giving the UI a friendlier, more delightful feel.

## What changed

- **Desktop right rail** (`src/view/shell/desktop/Feeds.tsx`): feed avatars are clipped to circles (image and no-image/default avatar alike); the Following item's icon is a filled circle.
- **Home feed tabs**: each tab shows a round icon before its label.
  - The Following feed uses the timeline glyph in a filled primary circle.
  - Custom feeds and lists use their avatar clipped to a circle.

## Implementation notes

- Reuses `UserAvatar` (`src/view/com/util/UserAvatar.tsx`); the default avatar for `algo`/`list` types renders as a rounded square, so icons are wrapped in an `overflow: hidden` + `rounded_full` view to guarantee a circular clip.
- `TabBar` gains an optional `itemIcons?: ReactNode[]` prop (native + web); icons are built in `HomeHeader` (`FeedTabIcon`) and rendered before each label, top-aligned with the text.

## Changed files
- `src/view/shell/desktop/Feeds.tsx`
- `src/view/com/home/HomeHeader.tsx`
- `src/view/com/pager/TabBar.tsx`
- `src/view/com/pager/TabBar.web.tsx`

## Test plan
- [ ] Desktop right rail: every feed shows a round icon; Following is a filled circle
- [ ] Home feed tabs: every feed tab shows a round icon before the label
- [ ] Icons line up vertically with their labels
- [ ] Feeds without a custom avatar still render as circles (no square corners)
- [ ] Verified on Web (and native if applicable)
