### PR TITLE
Add light haptics to Edit Profile Button for labellers

### DIFF
--- a/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
@@ -292,7 +292,10 @@ export function HeaderLabelerButtons({
             testID="profileHeaderEditProfileButton"
             size="small"
             color="secondary"
-            onPress={editProfileControl.open}
+            onPress={() => {
+              playHaptic('Light')
+              editProfileControl.open()
+            }}
             label={_(msg`Edit profile`)}
             style={a.rounded_full}>
             <ButtonText>


### PR DESCRIPTION
Currently only the Edit Profile on regular profiles plays any form of haptic when pressed, unlike labellers that have none

This just adds consistancy between the two 🐙

