### PR TITLE
Fix embeds overlapping each other in chat

### DIFF
--- a/src/components/Post/Embed/index.tsx
+++ b/src/components/Post/Embed/index.tsx
@@ -40,11 +40,7 @@ import {ModeratedFeedEmbed} from './FeedEmbed'
 import {ImageEmbed} from './ImageEmbed'
 import {ModeratedListEmbed} from './ListEmbed'
 import {PostPlaceholder as PostPlaceholderText} from './PostPlaceholder'
-import {
-  type CommonProps,
-  type EmbedProps,
-  type PostEmbedViewContext,
-} from './types'
+import {type CommonProps, type EmbedProps, PostEmbedViewContext} from './types'
 import {VideoEmbed} from './VideoEmbed'
 
 export {PostEmbedViewContext} from './types'
@@ -356,7 +352,7 @@ export function QuoteEmbed({
   return (
     <GalleryBleed>
       <View
-        style={[a.mt_sm]}
+        style={[viewContext !== PostEmbedViewContext.ChatMessage && a.mt_sm]}
         onPointerEnter={linkDisabled ? undefined : onPointerEnter}
         onPointerLeave={linkDisabled ? undefined : onPointerLeave}>
         <ContentHider

--- a/src/components/dms/MessageItemEmbed.tsx
+++ b/src/components/dms/MessageItemEmbed.tsx
@@ -77,9 +77,6 @@ let MessageItemEmbed = ({
             minWidth: 280,
             maxWidth: 360,
           }),
-          // Cancel out the embed's internal a.mt_sm so the container's
-          // CLUSTERED_MESSAGE_GAP (2px) is the only spacing applied
-          {marginTop: -a.mt_sm.marginTop},
         ]}>
         <Animated.View
           style={[a.rounded_xl, a.overflow_hidden, radiiStyle, highlightStyle]}>


### PR DESCRIPTION
This negative margin is no longer needed and causes layout issues. Tested on Android, iOS, and web.

| Before | After |
| - | - |
| <img width="430" height="716" alt="before" src="https://github.com/user-attachments/assets/e77b4011-fcfd-4a43-938b-3f38801f2481" /> | <img width="425" height="740" alt="after" src="https://github.com/user-attachments/assets/eaa09453-c6c6-4ae6-918e-81c2352935d6" /> |

