### PR TITLE
Display more information in chat replies

### DIFF
--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -22,7 +22,11 @@ import Animated, {
   ZoomOut,
 } from 'react-native-reanimated'
 import {
+  AppBskyEmbedExternal,
   AppBskyEmbedRecord,
+  AppBskyFeedDefs,
+  AppBskyGraphDefs,
+  AppBskyLabelerDefs,
   type ChatBskyActorDefs,
   ChatBskyConvoDefs,
   ChatBskyEmbedJoinLink,
@@ -36,15 +40,17 @@ import {useQueryClient} from '@tanstack/react-query'
 import {isBlockedOrBlocking} from '#/lib/moderation/blocked-and-muted'
 import {createSanitizedDisplayName} from '#/lib/moderation/create-sanitized-display-name'
 import {sanitizeHandle} from '#/lib/strings/handles'
+import {BSKY_APP_HOST} from '#/lib/strings/url-helpers'
 import {useMaybeProfileShadow} from '#/state/cache/profile-shadow'
 import {type Shadow} from '#/state/cache/types'
 import {type ConvoItem} from '#/state/messages/convo/types'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
+import {isKnownJoinLinkPreview} from '#/state/queries/join-links'
 import {useProfileBlockMutationQueue} from '#/state/queries/profile'
 import {unstableCacheProfileView} from '#/state/queries/unstable-profile-cache'
 import {useSession} from '#/state/session'
 import {PreviewableUserAvatar} from '#/view/com/util/UserAvatar'
-import {atoms as a, native, platform, useTheme, utils} from '#/alf'
+import {atoms as a, native, platform, tokens, useTheme, utils} from '#/alf'
 import {isOnlyEmoji} from '#/alf/typography'
 import {Button} from '#/components/Button'
 import {ActionsWrapper} from '#/components/dms/ActionsWrapper'
@@ -818,6 +824,42 @@ function ReplyCaption({
 }
 
 /**
+ * Describes the embed of a quoted message that has no text of its own, so the
+ * reply preview can show what was shared instead of a generic placeholder. For
+ * a link card we surface the URI directly; otherwise we classify the quoted
+ * record (post/feed/list/etc.) so the caller can render a translated label.
+ */
+type ReplyEmbedSummary =
+  | {type: 'external'; uri: string}
+  | {type: 'post'}
+  | {type: 'feed'}
+  | {type: 'list'}
+  | {type: 'starterPack'}
+  | {type: 'labeler'}
+  | {type: 'unknown'}
+
+function summarizeReplyEmbed(
+  embed: ChatBskyConvoDefs.MessageView['embed'],
+): ReplyEmbedSummary {
+  if (!AppBskyEmbedRecord.isView(embed)) return {type: 'unknown'}
+  const {record} = embed
+  if (AppBskyEmbedRecord.isViewRecord(record)) {
+    const inner = record.embeds?.[0]
+    if (AppBskyEmbedExternal.isView(inner)) {
+      return {type: 'external', uri: inner.external.uri}
+    }
+    return {type: 'post'}
+  }
+  if (AppBskyFeedDefs.isGeneratorView(record)) return {type: 'feed'}
+  if (AppBskyGraphDefs.isListView(record)) return {type: 'list'}
+  if (AppBskyGraphDefs.isStarterPackViewBasic(record)) {
+    return {type: 'starterPack'}
+  }
+  if (AppBskyLabelerDefs.isLabelerView(record)) return {type: 'labeler'}
+  return {type: 'unknown'}
+}
+
+/**
  * The nested quote of the original message, rendered at the top of a reply
  * bubble. Tapping it scrolls to the original (if loaded).
  */
@@ -864,11 +906,55 @@ function ReplyQuote({
     if (!text.trim()) {
       subtle = true
       if (ChatBskyEmbedJoinLink.isView(replyTo.embed)) {
-        text = l`(chat invite link)`
-      } else if (AppBskyEmbedRecord.isView(replyTo.embed)) {
-        text = l`(contains embedded content)`
+        const {joinLinkPreview} = replyTo.embed
+        text = isKnownJoinLinkPreview(joinLinkPreview)
+          ? `${BSKY_APP_HOST}/chat/${joinLinkPreview.code}`
+          : l({
+              message: '(chat invite link)',
+              comment: 'A reply summary in chat',
+            })
       } else {
-        text = l`No text`
+        const summary = summarizeReplyEmbed(replyTo.embed)
+        switch (summary.type) {
+          case 'external':
+            text = summary.uri
+            break
+          case 'post':
+            text = l({
+              message: '(quoted post)',
+              comment: 'A reply summary in chat',
+            })
+            break
+          case 'feed':
+            text = l({
+              message: '(feed)',
+              comment: 'A reply summary in chat',
+            })
+            break
+          case 'list':
+            text = l({
+              message: '(list)',
+              comment: 'A reply summary in chat',
+            })
+            break
+          case 'starterPack':
+            text = l({
+              message: '(starter pack)',
+              comment: 'A reply summary in chat',
+            })
+            break
+          case 'labeler':
+            text = l({
+              message: '(labeler)',
+              comment: 'A reply summary in chat',
+            })
+            break
+          default:
+            text = l({
+              message: '(no text)',
+              comment: 'A reply summary in chat',
+            })
+        }
       }
     }
   } else {
@@ -891,7 +977,7 @@ function ReplyQuote({
         a.flex_col,
         a.align_start,
         a.border,
-        {borderColor, marginHorizontal: -4},
+        {borderColor, marginHorizontal: -4, paddingTop: tokens.space.sm - 2},
       ]}>
       {senderName ? (
         <Text style={[a.text_xs, {color: subtleColor}]} emoji numberOfLines={1}>

--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -880,10 +880,12 @@ function ReplyQuote({
         a.mb_xs,
         a.rounded_md,
         a.p_sm,
+        // The padding above is a little loose, so we tighten it up here.
+        {paddingTop: tokens.space.sm - 2},
         a.flex_col,
         a.align_start,
         a.border,
-        {borderColor, marginHorizontal: -4, paddingTop: tokens.space.sm - 2},
+        {borderColor, marginHorizontal: -4},
       ]}>
       {senderName ? (
         <Text style={[a.text_xs, {color: subtleColor}]} emoji numberOfLines={1}>

--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -22,11 +22,7 @@ import Animated, {
   ZoomOut,
 } from 'react-native-reanimated'
 import {
-  AppBskyEmbedExternal,
   AppBskyEmbedRecord,
-  AppBskyFeedDefs,
-  AppBskyGraphDefs,
-  AppBskyLabelerDefs,
   type ChatBskyActorDefs,
   ChatBskyConvoDefs,
   ChatBskyEmbedJoinLink,
@@ -40,12 +36,10 @@ import {useQueryClient} from '@tanstack/react-query'
 import {isBlockedOrBlocking} from '#/lib/moderation/blocked-and-muted'
 import {createSanitizedDisplayName} from '#/lib/moderation/create-sanitized-display-name'
 import {sanitizeHandle} from '#/lib/strings/handles'
-import {BSKY_APP_HOST} from '#/lib/strings/url-helpers'
 import {useMaybeProfileShadow} from '#/state/cache/profile-shadow'
 import {type Shadow} from '#/state/cache/types'
 import {type ConvoItem} from '#/state/messages/convo/types'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
-import {isKnownJoinLinkPreview} from '#/state/queries/join-links'
 import {useProfileBlockMutationQueue} from '#/state/queries/profile'
 import {unstableCacheProfileView} from '#/state/queries/unstable-profile-cache'
 import {useSession} from '#/state/session'
@@ -56,6 +50,7 @@ import {Button} from '#/components/Button'
 import {ActionsWrapper} from '#/components/dms/ActionsWrapper'
 import {useMessageDialogs} from '#/components/dms/MessageOverlays'
 import {useMessageReplies} from '#/components/dms/MessageReplies'
+import {useReplyPreviewText} from '#/components/dms/replyPreview'
 import {ArrowCornerDownRight_Stroke2_Corner3_Rounded as ArrowCornerDownRightIcon} from '#/components/icons/ArrowCornerDownRight'
 import {InlineLinkText} from '#/components/Link'
 import * as ProfileCard from '#/components/ProfileCard'
@@ -824,42 +819,6 @@ function ReplyCaption({
 }
 
 /**
- * Describes the embed of a quoted message that has no text of its own, so the
- * reply preview can show what was shared instead of a generic placeholder. For
- * a link card we surface the URI directly; otherwise we classify the quoted
- * record (post/feed/list/etc.) so the caller can render a translated label.
- */
-type ReplyEmbedSummary =
-  | {type: 'external'; uri: string}
-  | {type: 'post'}
-  | {type: 'feed'}
-  | {type: 'list'}
-  | {type: 'starterPack'}
-  | {type: 'labeler'}
-  | {type: 'unknown'}
-
-function summarizeReplyEmbed(
-  embed: ChatBskyConvoDefs.MessageView['embed'],
-): ReplyEmbedSummary {
-  if (!AppBskyEmbedRecord.isView(embed)) return {type: 'unknown'}
-  const {record} = embed
-  if (AppBskyEmbedRecord.isViewRecord(record)) {
-    const inner = record.embeds?.[0]
-    if (AppBskyEmbedExternal.isView(inner)) {
-      return {type: 'external', uri: inner.external.uri}
-    }
-    return {type: 'post'}
-  }
-  if (AppBskyFeedDefs.isGeneratorView(record)) return {type: 'feed'}
-  if (AppBskyGraphDefs.isListView(record)) return {type: 'list'}
-  if (AppBskyGraphDefs.isStarterPackViewBasic(record)) {
-    return {type: 'starterPack'}
-  }
-  if (AppBskyLabelerDefs.isLabelerView(record)) return {type: 'labeler'}
-  return {type: 'unknown'}
-}
-
-/**
  * The nested quote of the original message, rendered at the top of a reply
  * bubble. Tapping it scrolls to the original (if loaded).
  */
@@ -876,6 +835,7 @@ function ReplyQuote({
 }) {
   const t = useTheme()
   const {t: l} = useLingui()
+  const getReplyPreviewText = useReplyPreviewText()
 
   const senderProfile = useMaybeProfileShadow(
     relatedProfiles.get(replyTo.sender.did),
@@ -902,61 +862,7 @@ function ReplyQuote({
     text = l`Blocked message hidden`
     subtle = true
   } else if (ChatBskyConvoDefs.isMessageView(replyTo)) {
-    text = replyTo.text
-    if (!text.trim()) {
-      subtle = true
-      if (ChatBskyEmbedJoinLink.isView(replyTo.embed)) {
-        const {joinLinkPreview} = replyTo.embed
-        text = isKnownJoinLinkPreview(joinLinkPreview)
-          ? `${BSKY_APP_HOST}/chat/${joinLinkPreview.code}`
-          : l({
-              message: '(chat invite link)',
-              comment: 'A reply summary in chat',
-            })
-      } else {
-        const summary = summarizeReplyEmbed(replyTo.embed)
-        switch (summary.type) {
-          case 'external':
-            text = summary.uri
-            break
-          case 'post':
-            text = l({
-              message: '(quoted post)',
-              comment: 'A reply summary in chat',
-            })
-            break
-          case 'feed':
-            text = l({
-              message: '(feed)',
-              comment: 'A reply summary in chat',
-            })
-            break
-          case 'list':
-            text = l({
-              message: '(list)',
-              comment: 'A reply summary in chat',
-            })
-            break
-          case 'starterPack':
-            text = l({
-              message: '(starter pack)',
-              comment: 'A reply summary in chat',
-            })
-            break
-          case 'labeler':
-            text = l({
-              message: '(labeler)',
-              comment: 'A reply summary in chat',
-            })
-            break
-          default:
-            text = l({
-              message: '(no text)',
-              comment: 'A reply summary in chat',
-            })
-        }
-      }
-    }
+    ;({text, subtle} = getReplyPreviewText(replyTo))
   } else {
     text = l`Deleted message`
     subtle = true

--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -859,12 +859,15 @@ function ReplyQuote({
   let text: string
   let subtle = false
   if (isBlocked) {
-    text = l`Blocked message hidden`
+    text = l({
+      message: '(blocked message hidden)',
+      comment: 'A reply summary in chat',
+    })
     subtle = true
   } else if (ChatBskyConvoDefs.isMessageView(replyTo)) {
     ;({text, subtle} = getReplyPreviewText(replyTo))
   } else {
-    text = l`Deleted message`
+    text = l({message: '(deleted message)', comment: 'A reply summary in chat'})
     subtle = true
   }
 

--- a/src/components/dms/replyPreview.ts
+++ b/src/components/dms/replyPreview.ts
@@ -1,0 +1,126 @@
+import {
+  AppBskyEmbedExternal,
+  AppBskyEmbedRecord,
+  AppBskyFeedDefs,
+  AppBskyGraphDefs,
+  AppBskyLabelerDefs,
+  type ChatBskyConvoDefs,
+  ChatBskyEmbedJoinLink,
+} from '@atproto/api'
+import {useLingui} from '@lingui/react/macro'
+
+import {BSKY_APP_HOST, toShortUrl} from '#/lib/strings/url-helpers'
+import {isKnownJoinLinkPreview} from '#/state/queries/join-links'
+
+/**
+ * Describes the embed of a quoted message that has no text of its own, so the
+ * reply preview can show what was shared instead of a generic placeholder. For
+ * a link card we surface the URI directly; otherwise we classify the quoted
+ * record (post/feed/list/etc.) so the caller can render a translated label.
+ */
+type ReplyEmbedSummary =
+  | {type: 'external'; uri: string}
+  | {type: 'post'}
+  | {type: 'feed'}
+  | {type: 'list'}
+  | {type: 'starterPack'}
+  | {type: 'labeler'}
+  | {type: 'unknown'}
+
+function summarizeReplyEmbed(
+  embed: ChatBskyConvoDefs.MessageView['embed'],
+): ReplyEmbedSummary {
+  if (!AppBskyEmbedRecord.isView(embed)) return {type: 'unknown'}
+  const {record} = embed
+  if (AppBskyEmbedRecord.isViewRecord(record)) {
+    const inner = record.embeds?.[0]
+    if (AppBskyEmbedExternal.isView(inner)) {
+      return {type: 'external', uri: inner.external.uri}
+    }
+    return {type: 'post'}
+  }
+  if (AppBskyFeedDefs.isGeneratorView(record)) return {type: 'feed'}
+  if (AppBskyGraphDefs.isListView(record)) return {type: 'list'}
+  if (AppBskyGraphDefs.isStarterPackViewBasic(record)) {
+    return {type: 'starterPack'}
+  }
+  if (AppBskyLabelerDefs.isLabelerView(record)) return {type: 'labeler'}
+  return {type: 'unknown'}
+}
+
+/**
+ * Returns a formatter that computes the preview text for a message being quoted
+ * in a reply, shared between the staged-reply composer and the sent reply
+ * bubble so the two stay in sync. When the message has its own text we use it
+ * verbatim; otherwise we summarize the embed.
+ *
+ * `subtle` indicates the text is a placeholder (not real message content), so
+ * callers can render it in a muted/italic style.
+ */
+export function useReplyPreviewText(): (
+  message: ChatBskyConvoDefs.MessageView,
+) => {text: string; subtle: boolean} {
+  const {t: l} = useLingui()
+
+  return (message: ChatBskyConvoDefs.MessageView) => {
+    const text = message.text
+    if (text.trim()) {
+      return {text, subtle: false}
+    }
+
+    if (ChatBskyEmbedJoinLink.isView(message.embed)) {
+      const {joinLinkPreview} = message.embed
+      return {
+        text: isKnownJoinLinkPreview(joinLinkPreview)
+          ? `${BSKY_APP_HOST}/chat/${joinLinkPreview.code}`
+          : l({
+              message: '(chat invite link)',
+              comment: 'A reply summary in chat',
+            }),
+        subtle: true,
+      }
+    }
+
+    const summary = summarizeReplyEmbed(message.embed)
+    switch (summary.type) {
+      case 'external':
+        return {text: toShortUrl(summary.uri), subtle: true}
+      case 'post':
+        return {
+          text: l({
+            message: '(quoted post)',
+            comment: 'A reply summary in chat',
+          }),
+          subtle: true,
+        }
+      case 'feed':
+        return {
+          text: l({message: '(feed)', comment: 'A reply summary in chat'}),
+          subtle: true,
+        }
+      case 'list':
+        return {
+          text: l({message: '(list)', comment: 'A reply summary in chat'}),
+          subtle: true,
+        }
+      case 'starterPack':
+        return {
+          text: l({
+            message: '(starter pack)',
+            comment: 'A reply summary in chat',
+          }),
+          subtle: true,
+        }
+      case 'labeler':
+        return {
+          text: l({message: '(labeler)', comment: 'A reply summary in chat'}),
+          subtle: true,
+        }
+      default:
+        return {
+          text: l({message: '(no text)', comment: 'A reply summary in chat'}),
+          subtle: true,
+        }
+    }
+  }
+}

--- a/src/components/dms/replyPreview.ts
+++ b/src/components/dms/replyPreview.ts
@@ -6,11 +6,11 @@ import {
   AppBskyLabelerDefs,
   type ChatBskyConvoDefs,
   ChatBskyEmbedJoinLink,
+  ChatBskyGroupDefs,
 } from '@atproto/api'
 import {useLingui} from '@lingui/react/macro'
 
 import {BSKY_APP_HOST, toShortUrl} from '#/lib/strings/url-helpers'
-import {isKnownJoinLinkPreview} from '#/state/queries/join-links'
 
 /**
  * Describes the embed of a quoted message that has no text of its own, so the
@@ -70,13 +70,29 @@ export function useReplyPreviewText(): (
 
     if (ChatBskyEmbedJoinLink.isView(message.embed)) {
       const {joinLinkPreview} = message.embed
+      if (ChatBskyGroupDefs.isJoinLinkPreviewView(joinLinkPreview)) {
+        return {
+          text: `${BSKY_APP_HOST}/chat/${joinLinkPreview.code}`,
+          subtle: true,
+        }
+      }
+      if (
+        ChatBskyGroupDefs.isDisabledJoinLinkPreviewView(joinLinkPreview) ||
+        ChatBskyGroupDefs.isInvalidJoinLinkPreviewView(joinLinkPreview)
+      ) {
+        return {
+          text: l({
+            message: '(expired chat invite link)',
+            comment: 'A reply summary in chat',
+          }),
+          subtle: true,
+        }
+      }
       return {
-        text: isKnownJoinLinkPreview(joinLinkPreview)
-          ? `${BSKY_APP_HOST}/chat/${joinLinkPreview.code}`
-          : l({
-              message: '(chat invite link)',
-              comment: 'A reply summary in chat',
-            }),
+        text: l({
+          message: '(chat invite link)',
+          comment: 'A reply summary in chat',
+        }),
         subtle: true,
       }
     }
@@ -91,29 +107,6 @@ export function useReplyPreviewText(): (
             message: '(quoted post)',
             comment: 'A reply summary in chat',
           }),
-          subtle: true,
-        }
-      case 'feed':
-        return {
-          text: l({message: '(feed)', comment: 'A reply summary in chat'}),
-          subtle: true,
-        }
-      case 'list':
-        return {
-          text: l({message: '(list)', comment: 'A reply summary in chat'}),
-          subtle: true,
-        }
-      case 'starterPack':
-        return {
-          text: l({
-            message: '(starter pack)',
-            comment: 'A reply summary in chat',
-          }),
-          subtle: true,
-        }
-      case 'labeler':
-        return {
-          text: l({message: '(labeler)', comment: 'A reply summary in chat'}),
           subtle: true,
         }
       default:

--- a/src/components/dms/replyPreview.ts
+++ b/src/components/dms/replyPreview.ts
@@ -1,9 +1,6 @@
 import {
   AppBskyEmbedExternal,
   AppBskyEmbedRecord,
-  AppBskyFeedDefs,
-  AppBskyGraphDefs,
-  AppBskyLabelerDefs,
   type ChatBskyConvoDefs,
   ChatBskyEmbedJoinLink,
   ChatBskyGroupDefs,
@@ -21,10 +18,6 @@ import {BSKY_APP_HOST, toShortUrl} from '#/lib/strings/url-helpers'
 type ReplyEmbedSummary =
   | {type: 'external'; uri: string}
   | {type: 'post'}
-  | {type: 'feed'}
-  | {type: 'list'}
-  | {type: 'starterPack'}
-  | {type: 'labeler'}
   | {type: 'unknown'}
 
 function summarizeReplyEmbed(
@@ -39,12 +32,6 @@ function summarizeReplyEmbed(
     }
     return {type: 'post'}
   }
-  if (AppBskyFeedDefs.isGeneratorView(record)) return {type: 'feed'}
-  if (AppBskyGraphDefs.isListView(record)) return {type: 'list'}
-  if (AppBskyGraphDefs.isStarterPackViewBasic(record)) {
-    return {type: 'starterPack'}
-  }
-  if (AppBskyLabelerDefs.isLabelerView(record)) return {type: 'labeler'}
   return {type: 'unknown'}
 }
 
@@ -76,13 +63,19 @@ export function useReplyPreviewText(): (
           subtle: true,
         }
       }
-      if (
-        ChatBskyGroupDefs.isDisabledJoinLinkPreviewView(joinLinkPreview) ||
-        ChatBskyGroupDefs.isInvalidJoinLinkPreviewView(joinLinkPreview)
-      ) {
+      if (ChatBskyGroupDefs.isDisabledJoinLinkPreviewView(joinLinkPreview)) {
         return {
           text: l({
-            message: '(expired chat invite link)',
+            message: '(disabled chat invite link)',
+            comment: 'A reply summary in chat',
+          }),
+          subtle: true,
+        }
+      }
+      if (ChatBskyGroupDefs.isInvalidJoinLinkPreviewView(joinLinkPreview)) {
+        return {
+          text: l({
+            message: '(invalid chat invite link)',
             comment: 'A reply summary in chat',
           }),
           subtle: true,
@@ -111,7 +104,7 @@ export function useReplyPreviewText(): (
         }
       default:
         return {
-          text: l({message: '(no text)', comment: 'A reply summary in chat'}),
+          text: l({message: 'No text', comment: 'A reply summary in chat'}),
           subtle: true,
         }
     }

--- a/src/components/dms/replyPreview.ts
+++ b/src/components/dms/replyPreview.ts
@@ -104,7 +104,7 @@ export function useReplyPreviewText(): (
         }
       default:
         return {
-          text: l({message: 'No text', comment: 'A reply summary in chat'}),
+          text: l({message: '(no text)', comment: 'A reply summary in chat'}),
           subtle: true,
         }
     }

--- a/src/screens/Messages/components/MessageInputReply.tsx
+++ b/src/screens/Messages/components/MessageInputReply.tsx
@@ -82,7 +82,7 @@ export function MessageInputReply() {
       <Button
         label={l`Cancel reply`}
         onPress={onRemove}
-        style={[a.px_2xs]}
+        style={[a.px_2xs, {transform: [{translateX: 2}]}]}
         hitSlop={HITSLOP_20}>
         <XIcon size="xs" style={t.atoms.text_contrast_high} />
       </Button>

--- a/src/screens/Messages/components/MessageInputReply.tsx
+++ b/src/screens/Messages/components/MessageInputReply.tsx
@@ -1,5 +1,5 @@
 import {LayoutAnimation, View} from 'react-native'
-import {AppBskyEmbedRecord, ChatBskyEmbedJoinLink} from '@atproto/api'
+import {type ChatBskyConvoDefs} from '@atproto/api'
 import {useLingui} from '@lingui/react/macro'
 
 import {HITSLOP_20} from '#/lib/constants'
@@ -8,6 +8,7 @@ import {useConvoActive} from '#/state/messages/convo'
 import {atoms as a, useTheme} from '#/alf'
 import {Button} from '#/components/Button'
 import {useMessageReplies} from '#/components/dms/MessageReplies'
+import {useReplyPreviewText} from '#/components/dms/replyPreview'
 import {TimesLarge_Stroke2_Corner0_Rounded as XIcon} from '#/components/icons/Times'
 import {Text} from '#/components/Typography'
 
@@ -16,14 +17,26 @@ import {Text} from '#/components/Typography'
  * being replied to, with a button to cancel the reply.
  */
 export function MessageInputReply() {
-  const t = useTheme()
-  const {t: l} = useLingui()
-  const convo = useConvoActive()
-  const {replyTo, clearReply} = useMessageReplies()
+  const {replyTo} = useMessageReplies()
 
   if (!replyTo) {
     return null
   }
+
+  return <MessageInputReplyInner replyTo={replyTo} />
+}
+
+function MessageInputReplyInner({
+  replyTo,
+}: {
+  replyTo: ChatBskyConvoDefs.MessageView
+}) {
+  const t = useTheme()
+  const {t: l} = useLingui()
+  const convo = useConvoActive()
+  const {clearReply} = useMessageReplies()
+  const getReplyPreviewText = useReplyPreviewText()
+  const {text, subtle} = getReplyPreviewText(replyTo)
 
   const onRemove = () => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
@@ -34,19 +47,6 @@ export function MessageInputReply() {
   const displayName = senderProfile
     ? createSanitizedDisplayName(senderProfile, false)
     : null
-
-  let text = replyTo.text
-  let subtle = false
-  if (!text.trim()) {
-    subtle = true
-    if (ChatBskyEmbedJoinLink.isView(replyTo.embed)) {
-      text = l`(chat invite link)`
-    } else if (AppBskyEmbedRecord.isView(replyTo.embed)) {
-      text = l`(contains embedded content)`
-    } else {
-      text = l`No text`
-    }
-  }
 
   return (
     <View


### PR DESCRIPTION
Rather than a catch-all “(contains embedded content)” for replies:
* Displays chat links.
* Displays external links.
* For all other embeds, displays the type of embed.

Also slightly reduces the padding above the original senders name and tweaks position of the X icon on reply previews, per design.