### PR TITLE
Fix issue with stale unread message counts

### DIFF
--- a/src/screens/Messages/ChatList.tsx
+++ b/src/screens/Messages/ChatList.tsx
@@ -300,7 +300,10 @@ export function ChatList({
     isError,
     error,
     refetch,
-  } = useListConvosQuery({status: 'accepted'})
+  } = useListConvosQuery({
+    status: 'accepted',
+    kind: aa.flags.groupChatDisabled ? 'direct' : 'all',
+  })
 
   const {refetch: refetchInbox} = useListConvosQuery({
     status: 'request',

--- a/src/state/queries/messages/conversation.ts
+++ b/src/state/queries/messages/conversation.ts
@@ -15,7 +15,11 @@ import {DM_SERVICE_HEADERS} from '#/lib/constants'
 import {STALE} from '#/state/queries'
 import {useOnMarkAsRead} from '#/state/queries/messages/list-conversations'
 import {useAgent} from '#/state/session'
-import {RQKEY_PARTIAL as UNREAD_COUNTS_PARTIAL_KEY} from './get-unread-counts'
+import {
+  RQKEY_PARTIAL as UNREAD_COUNTS_PARTIAL_KEY,
+  UNREAD_ACCEPTED_CAP,
+  UNREAD_REQUEST_CAP,
+} from './get-unread-counts'
 import {
   type ConvoListQueryData,
   getConvoFromQueryData,
@@ -24,14 +28,6 @@ import {
 
 export const RQKEY_ROOT = 'convo'
 export const RQKEY = (convoId: string) => [RQKEY_ROOT, convoId]
-
-// the badge counts are sentinel-capped by the server: unreadAcceptedConvos
-// maxes at 31 (meaning "more than 30") and unreadRequestConvos at 11 (meaning
-// "more than 10"). at the cap the value is no longer an exact count, so a naive
-// -1 decrement is wrong - skip the optimistic decrement and let onSuccess
-// invalidation reconcile with the server instead.
-const UNREAD_ACCEPTED_CAP = 31
-const UNREAD_REQUEST_CAP = 11
 
 export function useConvoQuery({convoId}: {convoId: string}) {
   const agent = useAgent()

--- a/src/state/queries/messages/conversation.ts
+++ b/src/state/queries/messages/conversation.ts
@@ -77,16 +77,21 @@ export function useMarkAsReadMutation() {
     onMutate({convoId}) {
       if (!convoId) throw new Error('No convoId provided')
 
-      // find the convo so we know which badge counter (if any) to decrement
-      let unreadStatus: ChatBskyConvoDefs.ConvoView['status'] | undefined
-      const listQueries = queryClient.getQueriesData<ConvoListQueryData>({
+      // snapshot the list caches before the optimistic update so onError can
+      // restore the convo rows alongside the badge count
+      const prevListQueries = queryClient.getQueriesData<ConvoListQueryData>({
         queryKey: [LIST_CONVOS_KEY],
       })
-      for (const [, data] of listQueries) {
+
+      // find the convo so we know which badge counter (if any) to decrement.
+      // keep scanning past a stale unreadCount === 0 cache so another cache
+      // holding the true unread state still drives the decrement
+      let unreadStatus: ChatBskyConvoDefs.ConvoView['status'] | undefined
+      for (const [, data] of prevListQueries) {
         if (!data) continue
         const convo = getConvoFromQueryData(convoId, data)
-        if (convo) {
-          if (convo.unreadCount > 0) unreadStatus = convo.status
+        if (convo?.unreadCount) {
+          unreadStatus = convo.status
           break
         }
       }
@@ -123,9 +128,14 @@ export function useMarkAsReadMutation() {
           },
         )
       }
-      return {prevUnreadCountsQueries}
+      return {prevListQueries, prevUnreadCountsQueries}
     },
     onError(_, __, context) {
+      if (context?.prevListQueries) {
+        for (const [queryKey, prevData] of context.prevListQueries) {
+          queryClient.setQueryData(queryKey, prevData)
+        }
+      }
       if (context?.prevUnreadCountsQueries) {
         for (const [queryKey, prevData] of context.prevUnreadCountsQueries) {
           queryClient.setQueryData(queryKey, prevData)

--- a/src/state/queries/messages/conversation.ts
+++ b/src/state/queries/messages/conversation.ts
@@ -25,6 +25,14 @@ import {
 export const RQKEY_ROOT = 'convo'
 export const RQKEY = (convoId: string) => [RQKEY_ROOT, convoId]
 
+// the badge counts are sentinel-capped by the server: unreadAcceptedConvos
+// maxes at 31 (meaning "more than 30") and unreadRequestConvos at 11 (meaning
+// "more than 10"). at the cap the value is no longer an exact count, so a naive
+// -1 decrement is wrong - skip the optimistic decrement and let onSuccess
+// invalidation reconcile with the server instead.
+const UNREAD_ACCEPTED_CAP = 31
+const UNREAD_REQUEST_CAP = 11
+
 export function useConvoQuery({convoId}: {convoId: string}) {
   const agent = useAgent()
 
@@ -113,16 +121,16 @@ export function useMarkAsReadMutation() {
               ...old,
               ...(unreadStatus === 'request'
                 ? {
-                    unreadRequestConvos: Math.max(
-                      0,
-                      old.unreadRequestConvos - 1,
-                    ),
+                    unreadRequestConvos:
+                      old.unreadRequestConvos >= UNREAD_REQUEST_CAP
+                        ? old.unreadRequestConvos
+                        : Math.max(0, old.unreadRequestConvos - 1),
                   }
                 : {
-                    unreadAcceptedConvos: Math.max(
-                      0,
-                      old.unreadAcceptedConvos - 1,
-                    ),
+                    unreadAcceptedConvos:
+                      old.unreadAcceptedConvos >= UNREAD_ACCEPTED_CAP
+                        ? old.unreadAcceptedConvos
+                        : Math.max(0, old.unreadAcceptedConvos - 1),
                   }),
             }
           },
@@ -144,6 +152,12 @@ export function useMarkAsReadMutation() {
     },
     onSuccess(_, {convoId}) {
       if (!convoId) return
+
+      // the optimistic badge arithmetic can drift from the server (e.g. a convo
+      // whose status differs between caches, or a sentinel-capped count). invalidate
+      // so the 15s-stale count query self-corrects on next access rather than
+      // waiting for a log event
+      void queryClient.invalidateQueries({queryKey: UNREAD_COUNTS_PARTIAL_KEY})
 
       queryClient.setQueriesData(
         {queryKey: [LIST_CONVOS_KEY]},

--- a/src/state/queries/messages/conversation.ts
+++ b/src/state/queries/messages/conversation.ts
@@ -2,6 +2,7 @@ import {
   type ChatBskyActorDefs,
   type ChatBskyConvoDefs,
   type ChatBskyConvoGetConvo,
+  type ChatBskyConvoGetUnreadCounts,
 } from '@atproto/api'
 import {
   type QueryClient,
@@ -14,6 +15,7 @@ import {DM_SERVICE_HEADERS} from '#/lib/constants'
 import {STALE} from '#/state/queries'
 import {useOnMarkAsRead} from '#/state/queries/messages/list-conversations'
 import {useAgent} from '#/state/session'
+import {RQKEY_PARTIAL as UNREAD_COUNTS_PARTIAL_KEY} from './get-unread-counts'
 import {
   type ConvoListQueryData,
   getConvoFromQueryData,
@@ -74,7 +76,61 @@ export function useMarkAsReadMutation() {
     },
     onMutate({convoId}) {
       if (!convoId) throw new Error('No convoId provided')
+
+      // find the convo so we know which badge counter (if any) to decrement
+      let unreadStatus: ChatBskyConvoDefs.ConvoView['status'] | undefined
+      const listQueries = queryClient.getQueriesData<ConvoListQueryData>({
+        queryKey: [LIST_CONVOS_KEY],
+      })
+      for (const [, data] of listQueries) {
+        if (!data) continue
+        const convo = getConvoFromQueryData(convoId, data)
+        if (convo) {
+          if (convo.unreadCount > 0) unreadStatus = convo.status
+          break
+        }
+      }
+
       optimisticUpdate(convoId)
+
+      // the badge count query is a separate server query that the list caches
+      // don't feed, so decrement it here to keep the badge in sync
+      const prevUnreadCountsQueries =
+        queryClient.getQueriesData<ChatBskyConvoGetUnreadCounts.OutputSchema>({
+          queryKey: UNREAD_COUNTS_PARTIAL_KEY,
+        })
+      if (unreadStatus) {
+        queryClient.setQueriesData<ChatBskyConvoGetUnreadCounts.OutputSchema>(
+          {queryKey: UNREAD_COUNTS_PARTIAL_KEY},
+          old => {
+            if (!old) return old
+            return {
+              ...old,
+              ...(unreadStatus === 'request'
+                ? {
+                    unreadRequestConvos: Math.max(
+                      0,
+                      old.unreadRequestConvos - 1,
+                    ),
+                  }
+                : {
+                    unreadAcceptedConvos: Math.max(
+                      0,
+                      old.unreadAcceptedConvos - 1,
+                    ),
+                  }),
+            }
+          },
+        )
+      }
+      return {prevUnreadCountsQueries}
+    },
+    onError(_, __, context) {
+      if (context?.prevUnreadCountsQueries) {
+        for (const [queryKey, prevData] of context.prevUnreadCountsQueries) {
+          queryClient.setQueryData(queryKey, prevData)
+        }
+      }
     },
     onSuccess(_, {convoId}) {
       if (!convoId) return

--- a/src/state/queries/messages/get-unread-counts.ts
+++ b/src/state/queries/messages/get-unread-counts.ts
@@ -10,6 +10,14 @@ export const RQKEY = (includeGroupChats: boolean) =>
   [RQKEY_ROOT, includeGroupChats] as const
 export const RQKEY_PARTIAL = [RQKEY_ROOT] as const
 
+// the server sentinel-caps the badge counts: unreadAcceptedConvos maxes at 31
+// (meaning "more than 30") and unreadRequestConvos at 11 (meaning "more than
+// 10"). at the cap the value is no longer an exact count, so consumers must not
+// treat it as one - both the optimistic decrement and the badge display ceiling
+// key off these.
+export const UNREAD_ACCEPTED_CAP = 31
+export const UNREAD_REQUEST_CAP = 11
+
 export function useUnreadCountsQuery() {
   const agent = useAgent()
   const {hasSession} = useSession()

--- a/src/state/queries/messages/list-conversations.tsx
+++ b/src/state/queries/messages/list-conversations.tsx
@@ -23,6 +23,7 @@ import * as bsky from '#/types/bsky'
 import {RQKEY as CONVO_KEY} from './conversation'
 import {
   RQKEY_PARTIAL as UNREAD_COUNTS_RQKEY_PARTIAL,
+  UNREAD_ACCEPTED_CAP,
   useUnreadCountsQuery,
 } from './get-unread-counts'
 import {
@@ -858,7 +859,12 @@ export function useUnreadMessageCount(): {
     const total = accepted + Math.min(request, 1)
     return {
       count: total,
-      numUnread: total > 10 ? '10+' : String(total),
+      // accepted is sentinel-capped at UNREAD_ACCEPTED_CAP (meaning "more than
+      // cap - 1"), so show that as the overflow label rather than an exact count
+      numUnread:
+        total >= UNREAD_ACCEPTED_CAP
+          ? `${UNREAD_ACCEPTED_CAP - 1}+`
+          : String(total),
       // only needed when numUnread is undefined
       hasNew: false,
     }

--- a/src/state/queries/messages/list-conversations.tsx
+++ b/src/state/queries/messages/list-conversations.tsx
@@ -860,11 +860,14 @@ export function useUnreadMessageCount(): {
     return {
       count: total,
       // accepted is sentinel-capped at UNREAD_ACCEPTED_CAP (meaning "more than
-      // cap - 1"), so show that as the overflow label rather than an exact count
+      // cap - 1"). show the "+" overflow label only when accepted is actually
+      // capped - the +1 request nudge must not trip it at exactly cap - 1
+      // accepted convos. otherwise clamp the number to cap - 1 so the nudge
+      // never surfaces the sentinel value (31) itself
       numUnread:
-        total >= UNREAD_ACCEPTED_CAP
+        accepted >= UNREAD_ACCEPTED_CAP
           ? `${UNREAD_ACCEPTED_CAP - 1}+`
-          : String(total),
+          : String(Math.min(total, UNREAD_ACCEPTED_CAP - 1)),
       // only needed when numUnread is undefined
       hasNew: false,
     }

--- a/src/state/queries/messages/update-all-read.ts
+++ b/src/state/queries/messages/update-all-read.ts
@@ -122,6 +122,10 @@ export function useUpdateAllRead(
       }
     },
     onSuccess: () => {
+      // the optimistic badge zeroing can drift from the server, so invalidate
+      // the count query to let it self-correct on next access rather than
+      // waiting for a log event
+      void queryClient.invalidateQueries({queryKey: UNREAD_COUNTS_PARTIAL_KEY})
       void queryClient.invalidateQueries({
         queryKey: CONVO_LIST_PARTIAL_KEY(status),
       })

--- a/src/state/queries/messages/update-all-read.ts
+++ b/src/state/queries/messages/update-all-read.ts
@@ -1,8 +1,10 @@
+import {type ChatBskyConvoGetUnreadCounts} from '@atproto/api'
 import {useMutation, useQueryClient} from '@tanstack/react-query'
 
 import {DM_SERVICE_HEADERS} from '#/lib/constants'
 import {logger} from '#/logger'
 import {useAgent} from '#/state/session'
+import {RQKEY_PARTIAL as UNREAD_COUNTS_PARTIAL_KEY} from './get-unread-counts'
 import {
   type ConvoRequestListQueryData,
   markAllRead as markAllRequestsRead,
@@ -94,8 +96,30 @@ export function useUpdateAllRead(
           markAllRequestsRead,
         )
       }
+      // zero out the badge count query that actually drives the unread badge,
+      // since it's a separate server query that the list caches don't feed
+      const prevUnreadCountsQueries =
+        queryClient.getQueriesData<ChatBskyConvoGetUnreadCounts.OutputSchema>({
+          queryKey: UNREAD_COUNTS_PARTIAL_KEY,
+        })
+      queryClient.setQueriesData<ChatBskyConvoGetUnreadCounts.OutputSchema>(
+        {queryKey: UNREAD_COUNTS_PARTIAL_KEY},
+        old => {
+          if (!old) return old
+          return {
+            ...old,
+            ...(status === 'accepted'
+              ? {unreadAcceptedConvos: 0}
+              : {unreadRequestConvos: 0}),
+          }
+        },
+      )
       onMutate?.()
-      return {prevConvoListQueries, prevRequestsQueries}
+      return {
+        prevConvoListQueries,
+        prevRequestsQueries,
+        prevUnreadCountsQueries,
+      }
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({
@@ -118,6 +142,11 @@ export function useUpdateAllRead(
       }
       if (context?.prevRequestsQueries) {
         for (const [queryKey, prevData] of context.prevRequestsQueries) {
+          queryClient.setQueryData(queryKey, prevData)
+        }
+      }
+      if (context?.prevUnreadCountsQueries) {
+        for (const [queryKey, prevData] of context.prevUnreadCountsQueries) {
           queryClient.setQueryData(queryKey, prevData)
         }
       }


### PR DESCRIPTION
The only thing that refreshes the new `getUnreadCounts` query is `debouncedInvalidateUnreadCounts()` inside the log-event handler, which means the count is only corrected if/when a log event happens to arrive, and even then it's gated by a 15-second stale time. As a result, the count could end up forever stale in some cases.

By optimistically updating the count (with rollback on error) we can ensure the badge stays in sync when conversations and requests are read.

Also updates the max “10+” badge value to use the same cap as the API (31, so “30+”).