### PR TITLE
WSOD when trying to create account from starter pack on non-default provider

### DIFF
--- a/src/state/shell/landing.tsx
+++ b/src/state/shell/landing.tsx
@@ -1,4 +1,10 @@
-import {createContext, useContext, useState} from 'react'
+import {
+  createContext,
+  type Dispatch,
+  type SetStateAction,
+  useContext,
+  useState,
+} from 'react'
 
 import {logger} from '#/logger'
 
@@ -16,11 +22,11 @@ type GroupChatJoinRequestLanding = {
 
 type LandingType = StarterPackLanding | GroupChatJoinRequestLanding | undefined
 
-type SetContext = (v: LandingType) => void
+type SetContext = Dispatch<SetStateAction<LandingType>>
 
 const stateContext = createContext<LandingType>(undefined)
 stateContext.displayName = 'ActiveLandingStateContext'
-const setContext = createContext<SetContext>((_: LandingType) => {})
+const setContext = createContext<SetContext>(() => {})
 setContext.displayName = 'ActiveLandingSetContext'
 
 export function Provider({children}: {children: React.ReactNode}) {
@@ -45,17 +51,18 @@ export const useActiveStarterPack = () => {
 
 export const useSetActiveStarterPack = () => {
   const setLanding = useSetActiveLanding()
-  const currentLanding = useActiveLanding()
   return (pack: {uri: string; isClip?: boolean} | undefined) => {
     if (!pack) {
       setLanding(undefined)
     } else {
-      if (currentLanding && currentLanding.type !== 'starterpack') {
-        logger.debug(
-          `[landing] Replacing ${currentLanding.type} landing with starterpack`,
-        )
-      }
-      setLanding({type: 'starterpack', ...pack})
+      setLanding(currentLanding => {
+        if (currentLanding && currentLanding.type !== 'starterpack') {
+          logger.debug(
+            `[landing] Replacing ${currentLanding.type} landing with starterpack`,
+          )
+        }
+        return {type: 'starterpack', ...pack}
+      })
     }
   }
 }


### PR DESCRIPTION
An infinite update loop in `useSetActiveStarterPack` causes WSOD when trying to create account from starter pack on non-default provider.

### Steps to reproduce
1. When logged out, go to a starter packer, e.g. https://bsky.app/starter-pack/bsky.app/3livawpa7d326
2. Click the _Join Bluesky_ button.
3. Next to _You are creating an account on_, click on _Bluesky Social_.

## Expected result
The _Choose your account provider_ dialogue opens.

## Actual result
White screen of death.

## Fix
`useSetActiveStarterPacks` returned a callback that closed over the current landing (for debugging logging) and wrote a fresh object on every call. Each call changed the landing, which gave the callback a new identity, which re-ran `useLandingEntry`'s effect, which called it again – a loop React aborts with "Maximum update depth exceeded".

Read the previous landing via the functional updater instead of closing over it, so the callback only depends on the stable `setLanding` and keeps a stable identity.