### PR TITLE
signup (info page): fix back button, rename to Cancel when destructive

### DIFF
--- a/src/screens/Signup/BackNextButtons.tsx
+++ b/src/screens/Signup/BackNextButtons.tsx
@@ -15,6 +15,7 @@ export interface BackNextButtonsProps {
   onBackPress: () => void
   onNextPress?: () => void
   onRetryPress?: () => void
+  overrideBackText?: string
   overrideNextText?: string
 }
 
@@ -26,6 +27,7 @@ export function BackNextButtons({
   onBackPress,
   onNextPress,
   onRetryPress,
+  overrideBackText,
   overrideNextText,
 }: BackNextButtonsProps) {
   const {_} = useLingui()
@@ -39,7 +41,7 @@ export function BackNextButtons({
         size="large"
         onPress={onBackPress}>
         <ButtonText>
-          <Trans>Back</Trans>
+          {overrideBackText ? overrideBackText : <Trans>Back</Trans>}
         </ButtonText>
       </Button>
       {!hideNext &&

--- a/src/screens/Signup/StepInfo/index.tsx
+++ b/src/screens/Signup/StepInfo/index.tsx
@@ -367,6 +367,7 @@ export function StepInfo({
         onBackPress={onPressBack}
         onNextPress={onNextPress}
         onRetryPress={refetchServer}
+        overrideBackText={l`Cancel`}
         overrideNextText={hasWarnedEmail ? l`It's correct` : undefined}
       />
     </>

--- a/src/view/com/auth/LoggedOut.tsx
+++ b/src/view/com/auth/LoggedOut.tsx
@@ -89,6 +89,15 @@ export function LoggedOut({onDismiss}: {onDismiss?: () => void}) {
     setActiveLanding(undefined)
   }, [clearRequestedAccount, onDismiss, setActiveLanding])
 
+  const onPressBack = useCallback(() => {
+    if (screenState === initialScreenState) {
+      onDismiss?.()
+      return
+    }
+
+    setScreenState(initialScreenState)
+  }, [screenState, initialScreenState, setScreenState, onDismiss])
+
   return (
     <View
       testID="noSessionView"
@@ -136,14 +145,10 @@ export function LoggedOut({onDismiss}: {onDismiss?: () => void}) {
           />
         ) : undefined}
         {screenState === ScreenState.S_Login ? (
-          <Login
-            onPressBack={() => {
-              setScreenState(initialScreenState)
-            }}
-          />
+          <Login onPressBack={onPressBack} />
         ) : undefined}
         {screenState === ScreenState.S_CreateAccount ? (
-          <Signup onPressBack={() => setScreenState(initialScreenState)} />
+          <Signup onPressBack={onPressBack} />
         ) : undefined}
       </ErrorBoundary>
     </View>


### PR DESCRIPTION
There are two changes in this PR. I'm happy to split any of these changes out if bundling them together is undesired for any reason

## [fix] Back does not exit signup flow on first page

Extracted onPressBack to a function that will call onDismiss() when Back (now Cancel) is pressed on the first page of signup

## "Cancel" label on first page

When on the first page, signup now shows a "Cancel" button label.

This more clearly signals to the user that anything previously entered into the form will be deleted - "Back" implies that you can go "Forward" to the same state again

<img width="615" height="586" alt="Initial signup form page, cancellation button says Cancel" src="https://github.com/user-attachments/assets/e93b5d96-c4aa-4b1d-95fa-9d45a6e9a6c4" />

Subsequent pages retain "Back" label
<img width="623" height="364" alt="Handle select page, cancellation button says Back" src="https://github.com/user-attachments/assets/9068c13f-d114-4405-bc2b-c39299dcfa39" />

I'm not sure translation implications of this change, please flag anything I may need to do for readiness
