### PR TITLE
Add icon to AppLanguageDropdown

### DIFF
--- a/src/components/AppLanguageDropdown.tsx
+++ b/src/components/AppLanguageDropdown.tsx
@@ -9,7 +9,8 @@ import {useLanguagePrefs, useLanguagePrefsApi} from '#/state/preferences'
 import {resetPostsFeedQueries} from '#/state/queries/post-feed'
 import {atoms as a, platform, useTheme, web} from '#/alf'
 import * as Select from '#/components/Select'
-import {Button} from './Button'
+import {Button, ButtonIcon} from './Button'
+import {Earth_Stroke2_Corner2_Rounded as EarthIcon} from './icons/Globe'
 
 export function AppLanguageDropdown() {
   const t = useTheme()
@@ -57,6 +58,7 @@ export function AppLanguageDropdown() {
                 native: [a.gap_xs],
               }),
             ]}>
+            <ButtonIcon icon={EarthIcon} size="md" />
             <Select.ValueText
               placeholder={_(msg`Select an app language`)}
               style={[t.atoms.text_contrast_medium]}

--- a/src/components/AppLanguageDropdown.tsx
+++ b/src/components/AppLanguageDropdown.tsx
@@ -7,7 +7,7 @@ import {sanitizeAppLanguageSetting} from '#/locale/helpers'
 import {APP_LANGUAGES} from '#/locale/languages'
 import {useLanguagePrefs, useLanguagePrefsApi} from '#/state/preferences'
 import {resetPostsFeedQueries} from '#/state/queries/post-feed'
-import {atoms as a, platform, useTheme} from '#/alf'
+import {atoms as a, platform, useTheme, web} from '#/alf'
 import * as Select from '#/components/Select'
 import {Button} from './Button'
 
@@ -68,7 +68,7 @@ export function AppLanguageDropdown() {
       <Select.Content
         label={_(msg`Select language`)}
         renderItem={({label, value}) => (
-          <Select.Item value={value} label={label}>
+          <Select.Item value={value} label={label} style={web([a.pointer])}>
             <Select.ItemIndicator />
             <Select.ItemText>{label}</Select.ItemText>
           </Select.Item>


### PR DESCRIPTION
Related to #10978 

Adds the Earth icon (from the Languages page in Settings) to the language picker.

The goal is to signify that "this is the language picker" without requiring the user to parse "English"

**Also bundled in:** Improves the language picker to use `cursor: pointer` for hovered items in the list. Right now, it uses the default cursor and switches to the I-beam when hovering the text of an item.

## Screenshots

### RightNav

<img width="951" height="702" alt="Logged-out feed with expanded right nav" src="https://github.com/user-attachments/assets/696a5c1e-06ba-43f9-98e9-49dbd5df7ec6" />

### LeftNav

<img width="1255" height="672" alt="Logged-out feed" src="https://github.com/user-attachments/assets/1cac285f-6f31-4c43-8646-ce10332b1fcd" />

### Signup

<img width="1394" height="703" alt="Signup page" src="https://github.com/user-attachments/assets/edaa4ed7-b579-4493-ab42-745edbba079a" />

### SplashScreen

<img width="765" height="1073" alt="Splash screen" src="https://github.com/user-attachments/assets/216795cf-d246-442f-8776-e1c802cb2686" />
