### PR TITLE
signup: align "Contact support" to the right on larger displays

### DIFF
--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -222,21 +222,27 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
                       a.align_center,
                     ]}>
                     <AppLanguageDropdown />
-                    <Text
-                      style={[
-                        a.flex_1,
-                        a.text_right,
-                        t.atoms.text_contrast_medium,
-                        !gtMobile && a.text_md,
-                      ]}>
-                      <Trans>Having trouble?</Trans>{' '}
-                      <InlineLinkText
-                        label={l`Contact support`}
-                        to={FEEDBACK_FORM_URL({email: state.email})}
-                        style={[!gtMobile && a.text_md]}>
-                        <Trans>Contact support</Trans>
-                      </InlineLinkText>
-                    </Text>
+                    <View
+                      style={
+                        gtMobile
+                          ? [a.flex_1, a.flex, a.flex_row, a.justify_end]
+                          : []
+                      }>
+                      <Text
+                        style={[
+                          a.flex_shrink,
+                          t.atoms.text_contrast_medium,
+                          !gtMobile && a.text_md,
+                        ]}>
+                        <Trans>Having trouble?</Trans>{' '}
+                        <InlineLinkText
+                          label={l`Contact support`}
+                          to={FEEDBACK_FORM_URL({email: state.email})}
+                          style={[!gtMobile && a.text_md]}>
+                          <Trans>Contact support</Trans>
+                        </InlineLinkText>
+                      </Text>
+                    </View>
                   </View>
                 </View>
               </ScreenTransition>

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -225,6 +225,7 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
                     <Text
                       style={[
                         a.flex_1,
+                        a.text_right,
                         t.atoms.text_contrast_medium,
                         !gtMobile && a.text_md,
                       ]}>

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -231,7 +231,6 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
                       }>
                       <Text
                         style={[
-                          a.flex_shrink,
                           t.atoms.text_contrast_medium,
                           !gtMobile && a.text_md,
                           {paddingInline: tokens.space.sm},

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -3,6 +3,7 @@ import {AppState, type AppStateStatus, View} from 'react-native'
 import ReactNativeDeviceAttest from 'react-native-device-attest'
 import Animated, {FadeIn, LayoutAnimationConfig} from 'react-native-reanimated'
 import {AppBskyGraphStarterpack} from '@atproto/api'
+import {tokens} from '@bsky.app/alf'
 import {Trans, useLingui} from '@lingui/react/macro'
 
 import {FEEDBACK_FORM_URL} from '#/lib/constants'
@@ -233,6 +234,7 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
                           a.flex_shrink,
                           t.atoms.text_contrast_medium,
                           !gtMobile && a.text_md,
+                          {paddingInline: tokens.space.sm},
                         ]}>
                         <Trans>Having trouble?</Trans>{' '}
                         <InlineLinkText


### PR DESCRIPTION
Related to #10977

Realigns the "Contact support" text to the right on the signup flow. Improves clarity versus squishing it against the language picker

**Only tested on web**

## Screenshots

Before:
<img width="1408" height="862" alt="Signup flow with left aligned support hint, next to language picker" src="https://github.com/user-attachments/assets/7c0fe6aa-a87d-4f6a-b546-78f4e2c5f013" />

After (this PR):
<img width="1379" height="799" alt="Signup flow with right aligned support hint, below Next button" src="https://github.com/user-attachments/assets/398cde59-508f-495c-8af9-81b56cedbec3" />
