### PR TITLE
Add TestFlight group selection to iOS build workflow

### DIFF
--- a/.github/workflows/build-submit-ios.yml
+++ b/.github/workflows/build-submit-ios.yml
@@ -10,20 +10,24 @@ on:
         options:
           - testflight
           - production
-      assignTestFlightGroup:
-        type: boolean
-        description: Assign the build to the "QA Team" TestFlight group after submitting
-        default: false
+      testFlightGroup:
+        type: choice
+        description: TestFlight group to assign the build to after submitting
+        options:
+          - none
+          - QA Team
+          - Software Mansion
+        default: none
   workflow_call:
     inputs:
       profile:
         type: string
         description: Build profile to use
         required: true
-      assignTestFlightGroup:
-        type: boolean
-        description: Assign the build to the "QA Team" TestFlight group after submitting
-        default: false
+      testFlightGroup:
+        type: string
+        description: TestFlight group to assign the build to after submitting ("none" to skip)
+        default: none
     outputs:
       package-version:
         description: Version from package.json
@@ -212,8 +216,9 @@ jobs:
       # TestFlight group. fastlane's distribute_only mode skips the upload and assigns the
       # already-submitted build to the group, polling until Apple finishes processing it.
       - name: 🧪 Assign build to TestFlight group
-        if: ${{ inputs.assignTestFlightGroup }}
+        if: ${{ inputs.testFlightGroup != 'none' }}
         env:
+          TESTFLIGHT_GROUP: ${{ inputs.testFlightGroup }}
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
           ASC_KEY_P8_BASE64: ${{ secrets.ASC_KEY_P8_BASE64 }}
@@ -241,7 +246,7 @@ jobs:
             app_identifier:"xyz.blueskyweb.app" \
             app_version:"$APP_VERSION" \
             build_number:"$BUILD_NUMBER" \
-            groups:"QA Team" \
+            groups:"$TESTFLIGHT_GROUP" \
             notify_external_testers:true
 
       - name: 🔔 Notify Slack of Production Build

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -77,7 +77,7 @@ jobs:
     uses: ./.github/workflows/build-submit-ios.yml
     with:
       profile: testflight
-      assignTestFlightGroup: true
+      testFlightGroup: "QA Team"
     secrets: inherit
 
   android:


### PR DESCRIPTION
## Summary

- Replaces the `assignTestFlightGroup` boolean input on `build-submit-ios.yml` with a `testFlightGroup` choice input. Options: `none`, `QA Team`, `Software Mansion`.
- The hardcoded `groups:"QA Team"` in the fastlane step becomes `groups:"$TESTFLIGHT_GROUP"`, populated from the new input.
- `nightly-build.yml` passes `testFlightGroup: "QA Team"` to preserve current nightly behavior.

This lets a workflow dispatcher pick which TestFlight group receives the build, without editing the workflow each time. The "none" sentinel skips the assignment step entirely.

## Notes

- The `workflow_call` variant takes a string (not enum) so reusable callers can pass any group name; the `workflow_dispatch` UI is the choice dropdown.
- Adding another group later is a one-line edit to the `options:` list.
- The selected group must exist in App Store Connect under the same name; fastlane errors otherwise.

## Test plan

- [ ] Dispatch `Build and Submit iOS` from main with `testFlightGroup: none` and confirm the assign step is skipped.
- [ ] Dispatch with `testFlightGroup: QA Team` and confirm the build lands in the QA Team group.
- [ ] Confirm the next scheduled nightly run still posts to the QA Team group.