### PR TITLE
Focus composer input after replying to a message

### DIFF
--- a/src/components/ContextMenu/index.tsx
+++ b/src/components/ContextMenu/index.tsx
@@ -615,6 +615,8 @@ export function Outer({
   label?: string
   style?: StyleProp<ViewStyle>
   align?: 'left' | 'right'
+  /** Web only. Native restores focus differently. */
+  onCloseAutoFocus?: (event: Event) => void
 }) {
   const t = useTheme()
   const context = useContextMenuContext()

--- a/src/components/ContextMenu/index.web.tsx
+++ b/src/components/ContextMenu/index.web.tsx
@@ -34,14 +34,16 @@ export function Outer({
   children,
   label,
   style,
+  onCloseAutoFocus,
 }: {
   children: React.ReactNode
   label?: string
   style?: StyleProp<ViewStyle>
+  onCloseAutoFocus?: (event: Event) => void
 }) {
   const t = useTheme()
   return (
-    <Menu.Outer style={style}>
+    <Menu.Outer style={style} onCloseAutoFocus={onCloseAutoFocus}>
       {label ? (
         <Text
           numberOfLines={1}

--- a/src/components/dms/MessageContextMenu.tsx
+++ b/src/components/dms/MessageContextMenu.tsx
@@ -1,4 +1,4 @@
-import {memo, useCallback} from 'react'
+import {memo, useCallback, useRef} from 'react'
 import {Platform} from 'react-native'
 import {type GestureType} from 'react-native-gesture-handler'
 import * as Clipboard from 'expo-clipboard'
@@ -59,6 +59,21 @@ export let MessageContextMenu = ({
   const {setReply} = useMessageReplies()
   const langPrefs = useLanguagePrefs()
   const translate = useGoogleTranslate()
+
+  // On web, the menu is a Radix dropdown that restores focus to the trigger on
+  // close. When Reply is chosen we want focus to land in the composer instead
+  // (handled by the reply effect there), so we suppress the trigger refocus.
+  const didReply = useRef(false)
+  const onReply = useCallback(() => {
+    didReply.current = true
+    setReply(message)
+  }, [setReply, message])
+  const onCloseAutoFocus = useCallback((event: Event) => {
+    if (didReply.current) {
+      didReply.current = false
+      event.preventDefault()
+    }
+  }, [])
 
   const isFromSelf = message.sender?.did === currentAccount?.did
   const isGroupChatEnabled = !ax.features.enabled(ax.features.GroupChatsDisable)
@@ -161,11 +176,12 @@ export let MessageContextMenu = ({
         label={l`Sent at ${i18n.date(new Date(message.sentAt), {
           timeStyle: 'short',
         })}`}
-        style={[isFromSelf && isGroupChatEnabled ? null : a.ml_sm]}>
+        style={[isFromSelf && isGroupChatEnabled ? null : a.ml_sm]}
+        onCloseAutoFocus={onCloseAutoFocus}>
         <ContextMenu.Item
           testID="messageDropdownReplyBtn"
           label={l`Reply`}
-          onPress={() => setReply(message)}>
+          onPress={onReply}>
           <ContextMenu.ItemIcon icon={ReplyIcon} position="left" />
           <ContextMenu.ItemText>{l`Reply`}</ContextMenu.ItemText>
         </ContextMenu.Item>

--- a/src/components/dms/MessageContextMenu.tsx
+++ b/src/components/dms/MessageContextMenu.tsx
@@ -1,4 +1,4 @@
-import {memo, useCallback, useRef} from 'react'
+import {memo, useCallback} from 'react'
 import {Platform} from 'react-native'
 import {type GestureType} from 'react-native-gesture-handler'
 import * as Clipboard from 'expo-clipboard'
@@ -60,17 +60,16 @@ export let MessageContextMenu = ({
   const langPrefs = useLanguagePrefs()
   const translate = useGoogleTranslate()
 
-  // On web, the menu is a Radix dropdown that restores focus to the trigger on
-  // close. When Reply is chosen we want focus to land in the composer instead
-  // (handled by the reply effect there), so we suppress the trigger refocus.
-  const didReply = useRef(false)
   const onReply = useCallback(() => {
-    didReply.current = true
     setReply(message)
   }, [setReply, message])
+  // On web, the menu is a Radix dropdown that restores focus to the trigger on
+  // close. When Reply moves focus to the composer, don't let Radix steal it
+  // back. Checking activeElement (rather than tracking reply intent) also
+  // handles re-replying to the same message, where the composer's focus effect
+  // bails on an unchanged reply target and focus should stay on the trigger.
   const onCloseAutoFocus = useCallback((event: Event) => {
-    if (didReply.current) {
-      didReply.current = false
+    if (document.activeElement && document.activeElement !== document.body) {
       event.preventDefault()
     }
   }, [])


### PR DESCRIPTION
On web, the context menu re-focuses its trigger after it’s closed. This means after selecting “Reply” the composer’s text input would lose focus.

The emoji picker handles this via an `onCloseAutoFocus` [callback](https://github.com/bluesky-social/social-app/blob/main/src/components/dms/EmojiReactionPicker.web.tsx#L73-L83), which is the pattern used here.