### PR TITLE
Increase unread cap to 99+

### DIFF
--- a/src/screens/Messages/Inbox.tsx
+++ b/src/screens/Messages/Inbox.tsx
@@ -23,6 +23,7 @@ import {cleanError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
 import {MESSAGE_SCREEN_POLL_INTERVAL} from '#/state/messages/convo/const'
 import {useMessagesEventBus} from '#/state/messages/events'
+import {useUnreadCountsQuery} from '#/state/queries/messages/get-unread-counts'
 import {useListConvoRequests} from '#/state/queries/messages/list-conversation-requests'
 import {useUpdateAllRead} from '#/state/queries/messages/update-all-read'
 import {EmptyState} from '#/view/com/util/EmptyState'
@@ -84,16 +85,8 @@ export function MessagesInboxScreenInner({}: Props) {
     return items
   }, [data])
 
-  const hasUnreadConvos = useMemo(() => {
-    return conversations.some(
-      item =>
-        item.type === 'incoming' &&
-        item.view.members.every(
-          member => member.handle !== 'missing.invalid',
-        ) &&
-        item.view.unreadCount > 0,
-    )
-  }, [conversations])
+  const {data: unreadCounts} = useUnreadCountsQuery()
+  const hasUnreadConvos = (unreadCounts?.unreadRequestConvos ?? 0) > 0
 
   return (
     <Layout.Screen testID="messagesInboxScreen">

--- a/src/screens/Messages/components/InboxRequests.tsx
+++ b/src/screens/Messages/components/InboxRequests.tsx
@@ -1,11 +1,13 @@
 import {plural} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react/macro'
 
-import {UNREAD_REQUEST_CAP} from '#/state/queries/messages/get-unread-counts'
 import {atoms as a} from '#/alf'
 import {ButtonIcon, ButtonText} from '#/components/Button'
 import {Inbox_Stroke2_Corner2_Rounded as InboxIcon} from '#/components/icons/Inbox'
 import {Link} from '#/components/Link'
+
+// The server caps unreadRequestConvos at 11, where 11 means "any more than 10".
+const REQUEST_COUNT_CAP = 11
 
 export function InboxRequests({
   count,
@@ -19,7 +21,7 @@ export function InboxRequests({
   const {t: l} = useLingui()
 
   const unread = count > 0
-  const overflow = count >= UNREAD_REQUEST_CAP
+  const overflow = count >= REQUEST_COUNT_CAP
 
   const label = !unread
     ? l({
@@ -28,7 +30,7 @@ export function InboxRequests({
       })
     : overflow
       ? l({
-          message: `10+ requests`,
+          message: `${REQUEST_COUNT_CAP}+ requests`,
           comment: 'Displayed when the number of requests is greater than 10',
         })
       : plural(count, {

--- a/src/screens/Messages/components/InboxRequests.tsx
+++ b/src/screens/Messages/components/InboxRequests.tsx
@@ -55,7 +55,7 @@ export function InboxRequests({
                 ? l({
                     message: `${UNREAD_REQUEST_CAP - 1}+`,
                     comment:
-                      'Displayed when the number of requests exceeds the cap',
+                      'Displayed when the number of requests exceeds the cap – for example, 99+ requests',
                   })
                 : count}
             </ButtonText>

--- a/src/screens/Messages/components/InboxRequests.tsx
+++ b/src/screens/Messages/components/InboxRequests.tsx
@@ -1,13 +1,11 @@
 import {plural} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react/macro'
 
+import {UNREAD_REQUEST_CAP} from '#/state/queries/messages/get-unread-counts'
 import {atoms as a} from '#/alf'
 import {ButtonIcon, ButtonText} from '#/components/Button'
 import {Inbox_Stroke2_Corner2_Rounded as InboxIcon} from '#/components/icons/Inbox'
 import {Link} from '#/components/Link'
-
-// The server caps unreadRequestConvos at 11, where 11 means "any more than 10".
-const REQUEST_COUNT_CAP = 11
 
 export function InboxRequests({
   count,
@@ -21,7 +19,7 @@ export function InboxRequests({
   const {t: l} = useLingui()
 
   const unread = count > 0
-  const overflow = count >= REQUEST_COUNT_CAP
+  const overflow = count >= UNREAD_REQUEST_CAP
 
   const label = !unread
     ? l({

--- a/src/screens/Messages/components/InboxRequests.tsx
+++ b/src/screens/Messages/components/InboxRequests.tsx
@@ -1,13 +1,11 @@
 import {plural} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react/macro'
 
+import {UNREAD_REQUEST_CAP} from '#/state/queries/messages/get-unread-counts'
 import {atoms as a} from '#/alf'
 import {ButtonIcon, ButtonText} from '#/components/Button'
 import {Inbox_Stroke2_Corner2_Rounded as InboxIcon} from '#/components/icons/Inbox'
 import {Link} from '#/components/Link'
-
-// The server caps unreadRequestConvos at 11, where 11 means "any more than 10".
-const REQUEST_COUNT_CAP = 11
 
 export function InboxRequests({
   count,
@@ -21,7 +19,7 @@ export function InboxRequests({
   const {t: l} = useLingui()
 
   const unread = count > 0
-  const overflow = count >= REQUEST_COUNT_CAP
+  const overflow = count >= UNREAD_REQUEST_CAP
 
   const label = !unread
     ? l({
@@ -30,8 +28,8 @@ export function InboxRequests({
       })
     : overflow
       ? l({
-          message: `${REQUEST_COUNT_CAP - 1}+ requests`,
-          comment: 'Displayed when the number of requests is greater than 10',
+          message: `${UNREAD_REQUEST_CAP - 1}+ requests`,
+          comment: 'Displayed when the number of requests exceeds the cap',
         })
       : plural(count, {
           one: '# request',
@@ -55,9 +53,9 @@ export function InboxRequests({
             <ButtonText style={[a.text_md, a.font_bold]}>
               {overflow
                 ? l({
-                    message: `10+`,
+                    message: `${UNREAD_REQUEST_CAP - 1}+`,
                     comment:
-                      'Displayed when the number of requests is greater than 10',
+                      'Displayed when the number of requests exceeds the cap',
                   })
                 : count}
             </ButtonText>

--- a/src/screens/Messages/components/InboxRequests.tsx
+++ b/src/screens/Messages/components/InboxRequests.tsx
@@ -30,7 +30,7 @@ export function InboxRequests({
       })
     : overflow
       ? l({
-          message: `${REQUEST_COUNT_CAP}+ requests`,
+          message: `${REQUEST_COUNT_CAP - 1}+ requests`,
           comment: 'Displayed when the number of requests is greater than 10',
         })
       : plural(count, {

--- a/src/state/queries/messages/get-unread-counts.ts
+++ b/src/state/queries/messages/get-unread-counts.ts
@@ -10,13 +10,12 @@ export const RQKEY = (includeGroupChats: boolean) =>
   [RQKEY_ROOT, includeGroupChats] as const
 export const RQKEY_PARTIAL = [RQKEY_ROOT] as const
 
-// the server sentinel-caps the badge counts: unreadAcceptedConvos maxes at 100
-// (meaning "more than 99") and unreadRequestConvos at 11 (meaning "more than
-// 10"). at the cap the value is no longer an exact count, so consumers must not
-// treat it as one - both the optimistic decrement and the badge display ceiling
-// key off these.
+// the server sentinel-caps the badge counts: unreadAcceptedConvos and
+// unreadRequestConvos max out at 100 (meaning "more than 99"). at the cap the
+// value is no longer an exact count, so consumers must not treat it as one -
+// both the optimistic decrement and the badge display ceiling key off these.
 export const UNREAD_ACCEPTED_CAP = 100
-export const UNREAD_REQUEST_CAP = 11
+export const UNREAD_REQUEST_CAP = 100
 
 export function useUnreadCountsQuery() {
   const agent = useAgent()

--- a/src/state/queries/messages/get-unread-counts.ts
+++ b/src/state/queries/messages/get-unread-counts.ts
@@ -10,12 +10,12 @@ export const RQKEY = (includeGroupChats: boolean) =>
   [RQKEY_ROOT, includeGroupChats] as const
 export const RQKEY_PARTIAL = [RQKEY_ROOT] as const
 
-// the server sentinel-caps the badge counts: unreadAcceptedConvos maxes at 31
-// (meaning "more than 30") and unreadRequestConvos at 11 (meaning "more than
+// the server sentinel-caps the badge counts: unreadAcceptedConvos maxes at 100
+// (meaning "more than 99") and unreadRequestConvos at 11 (meaning "more than
 // 10"). at the cap the value is no longer an exact count, so consumers must not
 // treat it as one - both the optimistic decrement and the badge display ceiling
 // key off these.
-export const UNREAD_ACCEPTED_CAP = 31
+export const UNREAD_ACCEPTED_CAP = 100
 export const UNREAD_REQUEST_CAP = 11
 
 export function useUnreadCountsQuery() {

--- a/src/state/queries/messages/list-conversations.tsx
+++ b/src/state/queries/messages/list-conversations.tsx
@@ -860,9 +860,8 @@ export function useUnreadMessageCount(): {
       count: accepted,
       // accepted is sentinel-capped at UNREAD_ACCEPTED_CAP (meaning "more than
       // cap - 1"). show the "+" overflow label only when accepted is actually
-      // capped - the +1 request nudge must not trip it at exactly cap - 1
-      // accepted convos. otherwise clamp the number to cap - 1 so the nudge
-      // never surfaces the sentinel value (100) itself
+      // capped, otherwise clamp the number to cap - 1 so we never surface the
+      // sentinel value (100) itself
       numUnread:
         accepted >= UNREAD_ACCEPTED_CAP
           ? `${UNREAD_ACCEPTED_CAP - 1}+`

--- a/src/state/queries/messages/list-conversations.tsx
+++ b/src/state/queries/messages/list-conversations.tsx
@@ -856,18 +856,17 @@ export function useUnreadMessageCount(): {
   const request = data?.unreadRequestConvos ?? 0
 
   if (accepted > 0) {
-    const total = accepted + Math.min(request, 1)
     return {
-      count: total,
+      count: accepted,
       // accepted is sentinel-capped at UNREAD_ACCEPTED_CAP (meaning "more than
       // cap - 1"). show the "+" overflow label only when accepted is actually
       // capped - the +1 request nudge must not trip it at exactly cap - 1
       // accepted convos. otherwise clamp the number to cap - 1 so the nudge
-      // never surfaces the sentinel value (31) itself
+      // never surfaces the sentinel value (100) itself
       numUnread:
         accepted >= UNREAD_ACCEPTED_CAP
           ? `${UNREAD_ACCEPTED_CAP - 1}+`
-          : String(Math.min(total, UNREAD_ACCEPTED_CAP - 1)),
+          : String(Math.min(accepted, UNREAD_ACCEPTED_CAP - 1)),
       // only needed when numUnread is undefined
       hasNew: false,
     }

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -242,12 +242,17 @@ export function BottomBar({navigation}: BottomTabBarProps) {
               accessibilityLabel={l`Chat`}
               accessibilityHint={
                 !aa.flags.chatDisabled && numUnreadMessages.count > 0
-                  ? l({
-                      message: plural(numUnreadMessages.numUnread ?? 0, {
-                        one: '# unread item',
-                        other: '# unread items',
-                      }),
-                    })
+                  ? numUnreadMessages.numUnread?.includes('+')
+                    ? l({
+                        message: `${numUnreadMessages.numUnread} unread items`,
+                        comment: 'For example, 99+ unread items',
+                      })
+                    : l({
+                        message: plural(numUnreadMessages.numUnread ?? 0, {
+                          one: '# unread item',
+                          other: '# unread items',
+                        }),
+                      })
                   : ''
               }
             />

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -245,7 +245,8 @@ export function BottomBar({navigation}: BottomTabBarProps) {
                   ? numUnreadMessages.numUnread?.includes('+')
                     ? l({
                         message: `${numUnreadMessages.numUnread} unread items`,
-                        comment: 'For example, 99+ unread items',
+                        comment:
+                          'Accessibility hint for the bottom bar chat icon when the number of unread messages exceeds the cap, with the + symbol already included – for example, 99+ unread items',
                       })
                     : l({
                         message: plural(numUnreadMessages.numUnread ?? 0, {


### PR DESCRIPTION
The cap was increased here: https://github.com/bluesky-social/atproto/pull/5145

Also no longer artificially bumps the count by 1 if there are one or more incoming chat requests. The count simply and accurately reflects the number of unread messages.

Also fixes the `hasUnreadConvos` condition for the “Mark all as read” button for requests, which was using the first page of results instead of the new count query.