### PR TITLE
improve animations and responsiveness for Like button & post controls

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -112,6 +112,7 @@ export type ButtonProps = Pick<
     label: string
     style?: StyleProp<ViewStyle>
     hoverStyle?: StyleProp<ViewStyle>
+    pressStyle?: StyleProp<ViewStyle>
     children: NonTextElements | ((context: ButtonContext) => NonTextElements)
     PressableComponent?: React.ComponentType<PressableProps>
   }
@@ -144,6 +145,7 @@ export const Button = forwardRef<View, ButtonProps>(
       disabled = false,
       style,
       hoverStyle: hoverStyleProp,
+      pressStyle: pressStyleProp,
       PressableComponent = Pressable,
       onPressIn: onPressInOuter,
       onPressOut: onPressOutOuter,
@@ -595,6 +597,7 @@ export const Button = forwardRef<View, ButtonProps>(
           ...(state.hovered || state.pressed
             ? [hoverStyles, hoverStyleProp]
             : []),
+          ...(state.pressed ? [pressStyleProp] : []),
         ]}
         onPressIn={onPressIn}
         onPressOut={onPressOut}

--- a/src/components/PostControls/PostControlButton.tsx
+++ b/src/components/PostControls/PostControlButton.tsx
@@ -83,7 +83,6 @@ export function PostControlButton({
       style={style}
       hoverStyle={t.atoms.bg_contrast_25}
       shape="round"
-      variant="ghost"
       color="secondary"
       {...props}
       hitSlop={{

--- a/src/components/PostControls/PostControlButton.tsx
+++ b/src/components/PostControls/PostControlButton.tsx
@@ -82,6 +82,7 @@ export function PostControlButton({
       onLongPress={handleLongPress}
       style={style}
       hoverStyle={t.atoms.bg_contrast_25}
+      pressStyle={{transform: [{scale: 0.9}]}}
       shape="round"
       color="secondary"
       {...props}

--- a/src/components/PostControls/PostControlButton.tsx
+++ b/src/components/PostControls/PostControlButton.tsx
@@ -3,7 +3,7 @@ import {type GestureResponderEvent, type Insets, type View} from 'react-native'
 
 import {useHaptics} from '#/lib/haptics'
 import {atoms as a, useTheme} from '#/alf'
-import {Button, type ButtonProps} from '#/components/Button'
+import {Button, type ButtonProps, useButtonContext} from '#/components/Button'
 import {type Props as SVGIconProps} from '#/components/icons/common'
 import {Text, type TextProps} from '#/components/Typography'
 
@@ -82,7 +82,7 @@ export function PostControlButton({
       onLongPress={handleLongPress}
       style={style}
       hoverStyle={t.atoms.bg_contrast_25}
-      pressStyle={[{transform: [{scale: 0.9}]}, t.atoms.bg_contrast_50]}
+      pressStyle={t.atoms.bg_contrast_50}
       shape="round"
       color="secondary"
       {...props}
@@ -112,11 +112,17 @@ export function PostControlButtonIcon({
 }: SVGIconProps & {
   icon: React.ComponentType<SVGIconProps>
 }) {
+  const {pressed} = useButtonContext()
   const {big, color} = useContext(PostControlContext)
 
   return (
     <Comp
-      style={[color, a.pointer_events_none, style]}
+      style={[
+        color,
+        a.pointer_events_none,
+        pressed ? [{transform: [{scale: 0.9}]}] : [],
+        style,
+      ]}
       {...rest}
       width={big ? 22 : 18}
     />

--- a/src/components/PostControls/PostControlButton.tsx
+++ b/src/components/PostControls/PostControlButton.tsx
@@ -82,7 +82,7 @@ export function PostControlButton({
       onLongPress={handleLongPress}
       style={style}
       hoverStyle={t.atoms.bg_contrast_25}
-      pressStyle={{transform: [{scale: 0.9}]}}
+      pressStyle={[{transform: [{scale: 0.9}]}, t.atoms.bg_contrast_50]}
       shape="round"
       color="secondary"
       {...props}

--- a/src/lib/custom-animations/CountWheel.web.tsx
+++ b/src/lib/custom-animations/CountWheel.web.tsx
@@ -14,23 +14,23 @@ const FILTER_BLUR_MAX = 'blur(0.15em)'
 const FILTER_BLUR_NONE = 'blur(0)'
 
 const enteringUpKeyframe = [
-  {opacity: 0, transform: 'translateY(18px)', filter: FILTER_BLUR_MAX},
+  {opacity: 0, transform: 'translateY(10px)', filter: FILTER_BLUR_MAX},
   {opacity: 1, transform: 'translateY(0)', filter: FILTER_BLUR_NONE},
 ]
 
 const enteringDownKeyframe = [
-  {opacity: 0, transform: 'translateY(-18px)', filter: FILTER_BLUR_MAX},
+  {opacity: 0, transform: 'translateY(-10px)', filter: FILTER_BLUR_MAX},
   {opacity: 1, transform: 'translateY(0)', filter: FILTER_BLUR_NONE},
 ]
 
 const exitingUpKeyframe = [
   {opacity: 1, transform: 'translateY(0)', filter: FILTER_BLUR_NONE},
-  {opacity: 0, transform: 'translateY(-18px)', filter: FILTER_BLUR_MAX},
+  {opacity: 0, transform: 'translateY(-10px)', filter: FILTER_BLUR_MAX},
 ]
 
 const exitingDownKeyframe = [
   {opacity: 1, transform: 'translateY(0)', filter: FILTER_BLUR_NONE},
-  {opacity: 0, transform: 'translateY(18px)', filter: FILTER_BLUR_MAX},
+  {opacity: 0, transform: 'translateY(10px)', filter: FILTER_BLUR_MAX},
 ]
 
 export function CountWheel({

--- a/src/lib/custom-animations/CountWheel.web.tsx
+++ b/src/lib/custom-animations/CountWheel.web.tsx
@@ -5,7 +5,7 @@ import {useReducedMotion} from 'react-native-reanimated'
 import {decideShouldRoll} from '#/lib/custom-animations/util'
 
 const animationConfig = {
-  duration: 400,
+  duration: 250,
   easing: 'cubic-bezier(0.4, 0, 0.2, 1)',
   fill: 'forwards' as FillMode,
 }

--- a/src/lib/custom-animations/CountWheel.web.tsx
+++ b/src/lib/custom-animations/CountWheel.web.tsx
@@ -10,7 +10,7 @@ const animationConfig = {
   fill: 'forwards' as FillMode,
 }
 
-const FILTER_BLUR_MAX = 'blur(0.1em)'
+const FILTER_BLUR_MAX = 'blur(0.15em)'
 const FILTER_BLUR_NONE = 'blur(0)'
 
 const enteringUpKeyframe = [

--- a/src/lib/custom-animations/CountWheel.web.tsx
+++ b/src/lib/custom-animations/CountWheel.web.tsx
@@ -10,24 +10,27 @@ const animationConfig = {
   fill: 'forwards' as FillMode,
 }
 
+const FILTER_BLUR_MAX = 'blur(0.1em)'
+const FILTER_BLUR_NONE = 'blur(0)'
+
 const enteringUpKeyframe = [
-  {opacity: 0, transform: 'translateY(18px)'},
-  {opacity: 1, transform: 'translateY(0)'},
+  {opacity: 0, transform: 'translateY(18px)', filter: FILTER_BLUR_MAX},
+  {opacity: 1, transform: 'translateY(0)', filter: FILTER_BLUR_NONE},
 ]
 
 const enteringDownKeyframe = [
-  {opacity: 0, transform: 'translateY(-18px)'},
-  {opacity: 1, transform: 'translateY(0)'},
+  {opacity: 0, transform: 'translateY(-18px)', filter: FILTER_BLUR_MAX},
+  {opacity: 1, transform: 'translateY(0)', filter: FILTER_BLUR_NONE},
 ]
 
 const exitingUpKeyframe = [
-  {opacity: 1, transform: 'translateY(0)'},
-  {opacity: 0, transform: 'translateY(-18px)'},
+  {opacity: 1, transform: 'translateY(0)', filter: FILTER_BLUR_NONE},
+  {opacity: 0, transform: 'translateY(-18px)', filter: FILTER_BLUR_MAX},
 ]
 
 const exitingDownKeyframe = [
-  {opacity: 1, transform: 'translateY(0)'},
-  {opacity: 0, transform: 'translateY(18px)'},
+  {opacity: 1, transform: 'translateY(0)', filter: FILTER_BLUR_NONE},
+  {opacity: 0, transform: 'translateY(18px)', filter: FILTER_BLUR_MAX},
 ]
 
 export function CountWheel({

--- a/src/lib/custom-animations/LikeIcon.web.tsx
+++ b/src/lib/custom-animations/LikeIcon.web.tsx
@@ -8,16 +8,17 @@ import {
   Heart2_Stroke2_Corner0_Rounded as HeartIconOutline,
 } from '#/components/icons/Heart2'
 
+// slower animation for small buttons
+// I cannot explain why it feels better this way, 25ms makes a big difference
 const animationConfigSmall = {
-  duration: 450,
+  duration: 575,
   easing: 'cubic-bezier(0.25, 0.5, 0.25, 1)',
   fill: 'forwards' as FillMode,
 }
 
-// slower animation for big buttons to match the perceived "weight"
 const animationConfigBig = {
   ...animationConfigSmall,
-  duration: 600,
+  duration: 550,
 }
 
 const keyframe = [
@@ -60,6 +61,7 @@ export function AnimatedLikeIcon({
   const circle1Ref = useRef<HTMLDivElement>(null)
   const circle2Ref = useRef<HTMLDivElement>(null)
 
+  // TODO: consolidate if i do truly end up keeping them identical
   const animationConfig = big ? animationConfigBig : animationConfigSmall
 
   useEffect(() => {

--- a/src/lib/custom-animations/LikeIcon.web.tsx
+++ b/src/lib/custom-animations/LikeIcon.web.tsx
@@ -41,7 +41,7 @@ const circle2Keyframe = [
   {opacity: 0, transform: 'scale(0)'},
   {opacity: 1, transform: 'scale(1.0)'},
   {opacity: 1},
-  {opacity: 0, transform: 'scale(2.0)'},
+  {opacity: 0, transform: 'scale(1.8)'},
 ]
 
 export function AnimatedLikeIcon({

--- a/src/lib/custom-animations/LikeIcon.web.tsx
+++ b/src/lib/custom-animations/LikeIcon.web.tsx
@@ -41,7 +41,7 @@ const circle2Keyframe = [
   {opacity: 0, transform: 'scale(0)'},
   {opacity: 1, transform: 'scale(1.0)'},
   {opacity: 1},
-  {opacity: 0, transform: 'scale(1.8)'},
+  {opacity: 0, transform: 'scale(1.9)'},
 ]
 
 export function AnimatedLikeIcon({

--- a/src/lib/custom-animations/LikeIcon.web.tsx
+++ b/src/lib/custom-animations/LikeIcon.web.tsx
@@ -7,6 +7,7 @@ import {
   Heart2_Filled_Stroke2_Corner0_Rounded as HeartIconFilled,
   Heart2_Stroke2_Corner0_Rounded as HeartIconOutline,
 } from '#/components/icons/Heart2'
+import {PostControlButtonIcon} from '#/components/PostControls/PostControlButton'
 
 // slower animation for small buttons
 // I cannot explain why it feels better this way, 25ms makes a big difference
@@ -82,12 +83,19 @@ export function AnimatedLikeIcon({
       {isLiked ? (
         // @ts-expect-error is div
         <View ref={likeIconRef}>
-          <HeartIconFilled style={{color: t.palette.pink}} width={size} />
+          <PostControlButtonIcon
+            icon={HeartIconFilled}
+            style={{color: t.palette.pink}}
+          />
         </View>
       ) : (
-        <HeartIconOutline
-          style={[{color: t.palette.contrast_500}, {pointerEvents: 'none'}]}
-          width={size}
+        <PostControlButtonIcon
+          icon={HeartIconOutline}
+          style={[
+            {color: t.palette.contrast_500},
+            // TODO(iLynxcat): why is this here?
+            {pointerEvents: 'none'},
+          ]}
         />
       )}
       <View

--- a/src/lib/custom-animations/LikeIcon.web.tsx
+++ b/src/lib/custom-animations/LikeIcon.web.tsx
@@ -9,15 +9,14 @@ import {
 } from '#/components/icons/Heart2'
 
 const animationConfig = {
-  duration: 600,
-  easing: 'cubic-bezier(0.4, 0, 0.2, 1)',
+  duration: 450,
+  easing: 'cubic-bezier(0.25, 0.5, 0.25, 1)',
   fill: 'forwards' as FillMode,
 }
 
 const keyframe = [
   {transform: 'scale(1)'},
-  {transform: 'scale(0.7)'},
-  {transform: 'scale(1.2)'},
+  {transform: 'scale(1.5)'},
   {transform: 'scale(1)'},
 ]
 
@@ -25,8 +24,8 @@ const circle1Keyframe = [
   {opacity: 0, transform: 'scale(0)'},
   {opacity: 0.4},
   {transform: 'scale(1.5)'},
-  {opacity: 0.4},
-  {opacity: 0, transform: 'scale(1.5)'},
+  {opacity: 0.2},
+  {opacity: 0, transform: 'scale(2)'},
 ]
 
 const circle2Keyframe = [

--- a/src/lib/custom-animations/LikeIcon.web.tsx
+++ b/src/lib/custom-animations/LikeIcon.web.tsx
@@ -8,10 +8,16 @@ import {
   Heart2_Stroke2_Corner0_Rounded as HeartIconOutline,
 } from '#/components/icons/Heart2'
 
-const animationConfig = {
+const animationConfigSmall = {
   duration: 450,
   easing: 'cubic-bezier(0.25, 0.5, 0.25, 1)',
   fill: 'forwards' as FillMode,
+}
+
+// slower animation for big buttons to match the perceived "weight"
+const animationConfigBig = {
+  ...animationConfigSmall,
+  duration: 600,
 }
 
 const keyframe = [
@@ -54,6 +60,8 @@ export function AnimatedLikeIcon({
   const circle1Ref = useRef<HTMLDivElement>(null)
   const circle2Ref = useRef<HTMLDivElement>(null)
 
+  const animationConfig = big ? animationConfigBig : animationConfigSmall
+
   useEffect(() => {
     if (prevIsLiked.current === isLiked) {
       return
@@ -65,7 +73,7 @@ export function AnimatedLikeIcon({
       circle2Ref.current?.animate?.(circle2Keyframe, animationConfig)
     }
     prevIsLiked.current = isLiked
-  }, [shouldAnimate, isLiked])
+  }, [shouldAnimate, isLiked, animationConfig])
 
   return (
     <View>

--- a/src/lib/custom-animations/LikeIcon.web.tsx
+++ b/src/lib/custom-animations/LikeIcon.web.tsx
@@ -62,7 +62,6 @@ export function AnimatedLikeIcon({
   const circle1Ref = useRef<HTMLDivElement>(null)
   const circle2Ref = useRef<HTMLDivElement>(null)
 
-  // TODO: consolidate if i do truly end up keeping them identical
   const animationConfig = big ? animationConfigBig : animationConfigSmall
 
   useEffect(() => {

--- a/src/lib/custom-animations/LikeIcon.web.tsx
+++ b/src/lib/custom-animations/LikeIcon.web.tsx
@@ -31,15 +31,15 @@ const circle1Keyframe = [
   {opacity: 0.4},
   {transform: 'scale(1.5)'},
   {opacity: 0.2},
-  {opacity: 0, transform: 'scale(2)'},
+  {opacity: 0, transform: 'scale(2.0)'},
 ]
 
 const circle2Keyframe = [
   {opacity: 0, transform: 'scale(0)'},
+  {opacity: 0, transform: 'scale(0)'},
+  {opacity: 1, transform: 'scale(1.0)'},
   {opacity: 1},
-  {transform: 'scale(0)'},
-  {opacity: 1},
-  {opacity: 0, transform: 'scale(1.5)'},
+  {opacity: 0, transform: 'scale(2.0)'},
 ]
 
 export function AnimatedLikeIcon({


### PR DESCRIPTION
The current like animation performs no action while held down, then performs a shrink-grow-bounce animation once released. I think some tweaks could make this interaction feel more responsive.

This PR makes the following changes to animations seen in PostControls:

- CountWheel applies a slight blur as elements enter and exit
- PostControlButton
  - …shrinks the icon slightly (to 90%) while held down
  - …gets a slightly deeper contrast background while held down
- Like button animation is snappier:
  - Shrink keyframe removed from heart bounce (PostControlButtonIcon shrink now handles this)
  - "Halo" effect is now more pronounced - worth asking, does this part feel like a design regression?
  - Animation duration varies slightly based on size - hard to explain why it feels better imo, but it does

## To-do

- [ ] Animate press-down scale effect
- [ ] Validate changes do not hurt other unexpected contexts
- [ ] Validate changes on major browsers
  - [x] Safari
  - [ ] Chromium
    - Once in a while stutters for me - need to validate if I should optimize or something else is affecting it
  - [ ] Firefox
- [ ] Port animation changes to mobile
  - [ ] Validate on iOS
  - [ ] Validate on Android
- [ ] Resolve all TODO comments

PR should remain a draft until these are resolved

## Comparison

### Before this change

https://github.com/user-attachments/assets/af0f7636-7e90-4462-ad79-425feebd3afa

### After

https://github.com/user-attachments/assets/421ef384-4e15-45d3-8778-469f547fdb4d

https://github.com/user-attachments/assets/91788ce6-5d77-4c2b-984f-3d8940b35d3d
