### PR TITLE
Change dialog label and header from 'Invite Friends' to 'Share Profile'

### DIFF
--- a/src/features/inviteFriends/InviteFriendsDialogInner.tsx
+++ b/src/features/inviteFriends/InviteFriendsDialogInner.tsx
@@ -138,7 +138,7 @@ export function InviteFriendsDialogInner({
 
   return (
     <Dialog.ScrollableInner
-      label={l`Invite friends`}
+      label={l`Share Profile`}
       contentContainerStyle={[a.pt_0, a.px_0]}
       header={
         <Dialog.Header
@@ -153,7 +153,7 @@ export function InviteFriendsDialogInner({
               <ButtonText style={[a.text_md]}>{l`Done`}</ButtonText>
             </Button>
           )}>
-          <Dialog.HeaderText>{l`Invite Friends`}</Dialog.HeaderText>
+          <Dialog.HeaderText>{l`Share Profile`}</Dialog.HeaderText>
         </Dialog.Header>
       }>
       <View style={[a.align_center, a.pt_xl, a.px_xl]}>


### PR DESCRIPTION
Related to #10966 

Here is how I went about changing it, but if this were to be a change that the team wants to do, should all references to the InviteFriends be changed to ShareProfile or something similar as OP mentioned or should only the on-screen text be changed?

(I am very new to contributing on GitHub and am trying to learn how to be better. Please do not hesitate to offer critique or close this Pull Request. Thank you!)