### PR TITLE
Hide autocomplete suggestions when input loses focus

### DIFF
--- a/src/view/shell/desktop/Search.tsx
+++ b/src/view/shell/desktop/Search.tsx
@@ -27,6 +27,10 @@ export function DesktopSearch() {
     if (query.length) setActive(true)
   }
 
+  const onBlur = () => {
+    setActive(false)
+  }
+
   const onChangeText = (text: string) => {
     setQuery(text)
     if (!active) {
@@ -64,6 +68,7 @@ export function DesktopSearch() {
         hotkey
         value={query}
         onFocus={onFocus}
+        onBlur={onBlur}
         onChangeText={onChangeText}
         onClearText={onClearText}
         onSubmitEditing={onSubmit}


### PR DESCRIPTION
Fixes an issue where it would remain visible if you opened the composer after entering a search term.

https://github.com/user-attachments/assets/fc28051a-4857-41f5-b562-5ec079d5cc22

