### PR TITLE
Fix GrowthBook exposure did mis-attribution across account switches

### DIFF
--- a/src/analytics/index.tsx
+++ b/src/analytics/index.tsx
@@ -1,5 +1,6 @@
 import {createContext, useContext, useMemo} from 'react'
 import {Platform} from 'react-native'
+import {type Result} from '@growthbook/growthbook-react'
 
 import {Logger} from '#/logger'
 import {
@@ -170,6 +171,39 @@ export function AnalyticsContext({
 }
 
 /**
+ * GrowthBook attribute name for the did. Must match the key used in
+ * `setAttributes` (`#/analytics/features`) and the assignment unit configured
+ * in the GrowthBook dashboard.
+ */
+const DID_HASH_ATTRIBUTE = 'did'
+
+/**
+ * Builds the session metadata override for an exposure event so the event's
+ * `did` is sourced from the unit GrowthBook actually bucketed on
+ * (`result.hashValue`) rather than from ambient React session metadata. This
+ * keeps the `did` and the variation in sync, since both then come from the
+ * same evaluation. See APP-2461.
+ *
+ * Only did-bucketed experiments are overridden. Experiments bucketed on
+ * another attribute (e.g. `deviceId`) have a `hashValue` that is not a did, so
+ * we leave their session metadata untouched and let the ambient did stand.
+ */
+function sessionMetadataForResult(
+  parentContext: AnalyticsBaseContextType,
+  result: Result<unknown>,
+): MergeableMetadata | undefined {
+  if (result.hashAttribute !== DID_HASH_ATTRIBUTE) return undefined
+  const {session} = parentContext.metadata
+  if (!session) return undefined
+  return {
+    session: {
+      ...session,
+      did: result.hashValue,
+    },
+  }
+}
+
+/**
  * Feature gates provider. Decorates the parent analytics context with
  * feature gate capabilities. Should be mounted within `AnalyticsContext`,
  * and below the `<Fragment key={did} />` breaker in `App.<platform>.tsx`.
@@ -185,22 +219,46 @@ export function AnalyticsFeaturesContext({
    * Side-effects: we need to synchronously set these during the same render
    * cycle. These calls do not trigger re-renders, they just set properties on
    * the singleton GrowthBook instance.
+   *
+   * Order matters here. We register the tracking callbacks _before_ calling
+   * `setAttributes`, because `setAttributes` triggers a synchronous
+   * re-evaluation that can fire exposure events. Registering first guarantees
+   * those events run through this render's callback (with this render's
+   * metadata) rather than a stale callback left over from a previous render,
+   * e.g. after an account switch remounts this provider via the
+   * `<Fragment key={did} />` breaker in `App.<platform>.tsx`. See APP-2461.
+   *
+   * We deliberately keep these synchronous rather than moving them into a
+   * `useEffect`: `setAttributes` must run before children evaluate gates (or
+   * they bucket on the previous account's attributes), and the feature usage
+   * callback has no deferred-replay, so a feature evaluated before it is
+   * registered would lose its `feature:viewed` event entirely.
    */
-  setAttributes(parentContext.metadata)
   feats.setTrackingCallback((experiment, result) => {
-    parentContext.metric('experiment:viewed', {
-      experimentId: experiment.key,
-      variationId: result.key,
-    })
+    parentContext.metric(
+      'experiment:viewed',
+      {
+        experimentId: experiment.key,
+        variationId: result.key,
+      },
+      sessionMetadataForResult(parentContext, result),
+    )
   })
   feats.setFeatureUsageCallback((feature, result) => {
-    parentContext.metric('feature:viewed', {
-      featureId: feature,
-      featureResultValue: result.value,
-      experimentId: result.experiment?.key,
-      variationId: result.experimentResult?.key,
-    })
+    parentContext.metric(
+      'feature:viewed',
+      {
+        featureId: feature,
+        featureResultValue: result.value,
+        experimentId: result.experiment?.key,
+        variationId: result.experimentResult?.key,
+      },
+      result.experimentResult
+        ? sessionMetadataForResult(parentContext, result.experimentResult)
+        : undefined,
+    )
   })
+  setAttributes(parentContext.metadata)
 
   const childContext = useMemo<AnalyticsContextType>(() => {
     return {


### PR DESCRIPTION
## Summary

Fixes [APP-2461](https://linear.app/blueskyweb/issue/APP-2461/growthbook-exposures-mis-attributed-across-account-switches-multiple). Experiment exposure events (`experiment:viewed` / `feature:viewed`) could be logged with a `did` that did not match the unit GrowthBook actually bucketed on, surfacing as "Multiple Exposures" warnings on did-based experiments (e.g. `follow-buttons-notifications-page` flagged ~3.17% / 40,026 users in both arms). This affected every did-based experiment, and the affected population was multi-account switchers.

## Root cause

In `AnalyticsFeaturesContext` (`src/analytics/index.tsx`):

1. **`did` and variation were sourced independently.** The variation came from GrowthBook's `result.key`, but the `did` came from ambient React session metadata. After an account switch, the `<Fragment key={did}>` remount opened a window where an exposure computed for the *new* did was stamped with the *old* did.
2. **Callbacks were registered after `setAttributes`.** `setAttributes()` triggers a synchronous re-evaluation that can fire exposure events, but it ran *before* the new render's tracking callback was registered, so events went through a stale callback closing over the previous account's metadata (or GrowthBook's deferred-replay, with the same decoupling).

## Fix

- **Source `did` from `result.hashValue`** (the actual bucketing unit) via `sessionMetadataForResult`, so `did` and variation always come from the same evaluation. Only did-bucketed experiments (`hashAttribute === 'did'`) are overridden; experiments bucketed on `deviceId`/`sessionId` keep their ambient did. The override spreads the existing session so future `SessionMetadata` fields carry through automatically.
- **Register the tracking/feature callbacks before `setAttributes`**, so the synchronous re-eval runs through the current render's callback.

## Note on the ticket's prescription

The ticket suggested moving registration into a `useEffect` keyed on `did`. Reading GrowthBook's internals, that would introduce regressions: `setAttributes` must run synchronously before children read gates (or they bucket on the previous account's attributes), and `setFeatureUsageCallback` has no deferred-replay — a feature evaluated before an effect ran would mark itself "seen" and lose its `feature:viewed` event. Keeping registration synchronous but reordering it achieves the same goal without those downsides.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint` (changed file clean)
- [x] `pnpm test src/analytics`
- [ ] Per the ticket: restart affected experiments with a clean tracking key after merge, since existing data is already contaminated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)