### PR TITLE
Fix 149/150 user limit for starter packs

### DIFF
--- a/src/components/StarterPack/Wizard/WizardListCard.tsx
+++ b/src/components/StarterPack/Wizard/WizardListCard.tsx
@@ -139,8 +139,7 @@ export function WizardProfileCard({
   const isTarget = profile.did === targetProfileDid
   const included = isTarget || state.profiles.some(p => p.did === profile.did)
   const disabled =
-    isTarget ||
-    (!included && state.profiles.length >= STARTER_PACK_MAX_SIZE - 1)
+    isTarget || (!included && state.profiles.length >= STARTER_PACK_MAX_SIZE)
   const moderationUi = moderateProfile(profile, moderationOpts).ui('avatar')
   const displayName = profile.displayName
     ? sanitizeDisplayName(profile.displayName)


### PR DESCRIPTION
Currently users can only have 149 people in a starter pack, this number includes the pack creator themselves

This looks to be a simple math issue where the disabled const is based on a ``STARTER_PACK_MAX_SIZE - 1`` comparison 🐙