### PR TITLE
Disable selectable profile description on Android

### DIFF
--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -169,7 +169,7 @@ let ProfileHeaderStandard = ({
                     testID="profileHeaderDescription"
                     style={[a.text_md]}
                     numberOfLines={15}
-                    selectable
+                    selectable={platform({android: false, default: true})}
                     value={descriptionRT}
                     enableTags
                     authorHandle={profile.handle}


### PR DESCRIPTION
Should fix the profile header not being scrollable when swiping over the description. Unfortunately this is the better tradeoff