### PR TITLE
Fix CI - grant workflows permission for internal sync push

### DIFF
--- a/.github/workflows/sync-internal.yaml
+++ b/.github/workflows/sync-internal.yaml
@@ -28,8 +28,11 @@ jobs:
           private-key: ${{ secrets.SYNC_INTERNAL_PK }}
           repositories: social-app-internal
           # Scope the token down from the app's full installation permissions;
-          # pushing is the only thing this token is used for
+          # pushing is the only thing this token is used for. The workflows
+          # permission is required because the sync includes files under
+          # .github/workflows/, which GitHub refuses to push without it.
           permission-contents: write
+          permission-workflows: write
       - name: Push to internal repo
         env:
           TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Problem

The **Sync to internal repo** workflow is failing on push to `main`:

```
 ! [remote rejected]     main -> main (refusing to allow a GitHub App to create or update workflow `.github/workflows/build-and-push-bskyweb-aws.yaml` without `workflows` permission)
error: failed to push some refs
```

The scoped GitHub App token only requests `permission-contents: write`. Because the sync mirrors the entire repo — including files under `.github/workflows/` — GitHub refuses the push unless the token also has the `workflows` permission.

## Fix

Add `permission-workflows: write` to the `create-github-app-token` step so the app token is allowed to create/update workflow files in the internal repo.

> [!NOTE]
> The GitHub App installation must also grant the **Workflows** permission for this to take effect — the action can only scope *down* from the app's installed permissions, not add new ones. If the app doesn't have it, that needs granting in the app settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)