### PR TITLE
Fix chat input positioning on mobile android

### DIFF
--- a/src/screens/Messages/components/MessageComposer.tsx
+++ b/src/screens/Messages/components/MessageComposer.tsx
@@ -376,7 +376,7 @@ function ComposerContainer({children}: {children: React.ReactNode}) {
             web: [
               a.pt_xs,
               a.pl_lg,
-              a.pb_lg,
+              {paddingBottom: tokens.space.lg + bottomInset},
               // prevent overlap with the scrollbar, which looks ugly
               a.pr_sm, // sm + sm = lg
               {width: `calc(100% - ${tokens.space.sm}px)` as '100%'},

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -683,7 +683,7 @@ export function MessagesList({
             <KeyboardStickyView
               style={[a.absolute, a.bottom_0, a.left_0, a.right_0]}
               onLayout={onInputLayout}
-              minimumOffset={bottomInset}
+              minimumOffset={IS_WEB ? 0 : bottomInset}
               offset={{
                 closed: platform({
                   ios: tokens.space.lg, // hide bottom padding when closed


### PR DESCRIPTION
Fixes https://bsky.app/profile/riziles.bsky.social/post/3mpczdinyf22k

Safe area issue, turns out web android behaves differently to web iOS. Moves inset from positioning prop to padding on the input itself so that the underlying list has the correct bottom padding

## Before

<img width="1080" height="592" alt="image" src="https://github.com/user-attachments/assets/1665db2a-855e-4c55-999e-715fc175c7c9" />

## After

### Resting state

<img width="1080" height="793" alt="image" src="https://github.com/user-attachments/assets/f8183929-eba4-4cea-8365-d3e8cf34e8cd" />

### When scrolled

<img width="1080" height="562" alt="image" src="https://github.com/user-attachments/assets/e5c161ae-ec48-4768-a425-fe524d6db682" />


## Test plan

- confirm no overlap etc on web Android
- confirm no regression on mobile web iOS + desktop