### PR TITLE
Hide bottom tab bar on scroll in the home feed

### DIFF
--- a/src/lib/hooks/useMinimalShellTransform.ts
+++ b/src/lib/hooks/useMinimalShellTransform.ts
@@ -6,11 +6,13 @@ import {useShellLayout} from '#/state/shell/shell-layout'
 // Keep these separated so that we only pay for useAnimatedStyle that gets used.
 
 export function useMinimalShellFooterTransform() {
-  const {footerMode} = useMinimalShellMode()
+  const {footerMode, footerScrollMode} = useMinimalShellMode()
   const {footerHeight} = useShellLayout()
 
   const footerTransform = useAnimatedStyle(() => {
-    const footerModeValue = footerMode.get()
+    // Hide the footer when either a screen requests it (footerMode) or the user
+    // is scrolling a feed (footerScrollMode), whichever wants it more hidden.
+    const footerModeValue = Math.max(footerMode.get(), footerScrollMode.get())
     return {
       pointerEvents: footerModeValue === 0 ? 'auto' : 'none',
       opacity: Math.pow(1 - footerModeValue, 2),
@@ -30,13 +32,14 @@ export function useMinimalShellFooterTransform() {
 }
 
 export function useMinimalShellFabTransform() {
-  const {footerMode} = useMinimalShellMode()
+  const {footerMode, footerScrollMode} = useMinimalShellMode()
 
   const fabTransform = useAnimatedStyle(() => {
+    const footerModeValue = Math.max(footerMode.get(), footerScrollMode.get())
     return {
       transform: [
         {
-          translateY: interpolate(footerMode.get(), [0, 1], [-44, 0]),
+          translateY: interpolate(footerModeValue, [0, 1], [-44, 0]),
         },
       ],
     }

--- a/src/state/shell/minimal-mode.tsx
+++ b/src/state/shell/minimal-mode.tsx
@@ -14,7 +14,13 @@ import {
 import {useFocusEffect} from '@react-navigation/native'
 
 type StateContext = {
+  // Set to 1 to hide the footer entirely for a screen (e.g. video feed). Driven
+  // by the add/subtract counters below.
   footerMode: SharedValue<number>
+  // Set between 0 and 1 to hide the footer in response to scrolling, mirroring
+  // the home header. Driven by MainScrollProvider, and reset to 0 when the
+  // scrolling feed loses focus so other tabs never inherit a hidden bar.
+  footerScrollMode: SharedValue<number>
 }
 type SetContext = {
   add: () => void
@@ -28,6 +34,7 @@ setContext.displayName = 'MinimalModeSetContext'
 
 export function Provider({children}: React.PropsWithChildren<{}>) {
   const footerMode = useSharedValue(0)
+  const footerScrollMode = useSharedValue(0)
 
   const setModeWorklet = useCallback(
     (v: boolean) => {
@@ -68,8 +75,9 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   const value = useMemo(
     () => ({
       footerMode,
+      footerScrollMode,
     }),
-    [footerMode],
+    [footerMode, footerScrollMode],
   )
   return (
     <stateContext.Provider value={value}>

--- a/src/view/com/util/MainScrollProvider.tsx
+++ b/src/view/com/util/MainScrollProvider.tsx
@@ -9,9 +9,11 @@ import {
   withSpring,
 } from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
+import {useFocusEffect} from '@react-navigation/native'
 import {EventEmitter} from 'eventemitter3'
 
 import {ScrollProvider} from '#/lib/ScrollContext'
+import {useMinimalShellMode} from '#/state/shell/minimal-mode'
 import {useShellLayout} from '#/state/shell/shell-layout'
 import {IS_LIQUID_GLASS, IS_NATIVE, IS_WEB} from '#/env'
 
@@ -94,6 +96,10 @@ export function useHomeHeaderTransform() {
 export function MainScrollProvider({children}: {children: React.ReactNode}) {
   const {headerHeight} = useShellLayout()
   const headerMode = useHomeHeaderMode()
+  // The footer (bottom tab bar) follows the same scroll motion as the home
+  // header. It lives in the app-wide shell, outside this provider, so we drive
+  // it through the shared minimal-shell value rather than headerMode.
+  const {footerScrollMode} = useMinimalShellMode()
   const {top: topInset} = useSafeAreaInsets()
   const headerPinnedHeight = IS_LIQUID_GLASS ? topInset : 0
   const startDragOffset = useSharedValue<number | null>(null)
@@ -108,8 +114,27 @@ export function MainScrollProvider({children}: {children: React.ReactNode}) {
           overshootClamping: true,
         }),
       )
+      footerScrollMode.set(() =>
+        withSpring(v ? 1 : 0, {
+          overshootClamping: true,
+        }),
+      )
     },
-    [headerMode],
+    [headerMode, footerScrollMode],
+  )
+
+  // The footer is shared across all tabs, so make sure leaving this feed never
+  // leaves the bar hidden on another tab.
+  useFocusEffect(
+    useCallback(() => {
+      return () => {
+        footerScrollMode.set(() =>
+          withSpring(0, {
+            overshootClamping: true,
+          }),
+        )
+      }
+    }, [footerScrollMode]),
   )
 
   useEffect(() => {
@@ -214,6 +239,7 @@ export function MainScrollProvider({children}: {children: React.ReactNode}) {
         if (newValue !== headerMode.get()) {
           // Manually adjust the value. This won't be (and shouldn't be) animated.
           headerMode.set(newValue)
+          footerScrollMode.set(newValue)
         }
       } else {
         if (didJustRestoreScroll.get()) {
@@ -237,6 +263,7 @@ export function MainScrollProvider({children}: {children: React.ReactNode}) {
       headerHeight,
       headerPinnedHeight,
       headerMode,
+      footerScrollMode,
       setMode,
       startDragOffset,
       startMode,


### PR DESCRIPTION
## What

The home header already collapses as you scroll, but the bottom tab bar stayed fixed in place. This mirrors the header's scroll motion onto the footer, so the bottom tab bar slides away as you scroll down the home feed and returns as you scroll up.

## How

- Add a `footerScrollMode` shared value, kept separate from the existing focus-based `footerMode` (which fully hides the footer on certain screens like the video feed).
- `MainScrollProvider` drives `footerScrollMode` alongside `headerMode`, and resets it to `0` when the feed loses focus so other tabs never inherit a hidden bar.
- The footer and FAB transforms now hide based on `max(footerMode, footerScrollMode)`, so the two mechanisms compose without fighting each other.

## Scope / follow-up

This is currently wired through `MainScrollProvider`, so it applies to the home feed only. Extending it to the other tabs (likely by driving `footerScrollMode` from the shared `List` component when no `MainScrollProvider` is present, plus a central reset on tab change) is a natural follow-up - happy to do that in a separate PR if the approach looks good.

## Test plan

- iOS: scroll the home feed down -> bottom bar slides away; scroll up / return to top -> it comes back.
- Scroll down to hide the bar, then switch tabs -> the bar is visible on the other tab (reset on blur works).
- Screens that fully hide the footer (e.g. video feed) still behave as before.