### PR TITLE
Add featured feed tab to profiles

### DIFF
--- a/src/screens/Profile/Header/EditProfileDialog.tsx
+++ b/src/screens/Profile/Header/EditProfileDialog.tsx
@@ -10,7 +10,12 @@ import {cleanError} from '#/lib/strings/errors'
 import {isOverMaxGraphemeCount} from '#/lib/strings/helpers'
 import {logger} from '#/logger'
 import {type ImageMeta} from '#/state/gallery'
+import {useFeedSourceInfoQuery} from '#/state/queries/feed'
 import {useProfileUpdateMutation} from '#/state/queries/profile'
+import {
+  useFeaturedFeedUri,
+  useProfileRecordQuery,
+} from '#/state/queries/profile-featured-feed'
 import {ErrorMessage} from '#/view/com/util/error/ErrorMessage'
 import {EditableUserAvatar} from '#/view/com/util/UserAvatar'
 import {UserBanner} from '#/view/com/util/UserBanner'
@@ -19,12 +24,14 @@ import {Admonition} from '#/components/Admonition'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import * as TextField from '#/components/forms/TextField'
+import {ChevronRight_Stroke2_Corner0_Rounded as ChevronRightIcon} from '#/components/icons/Chevron'
 import {InlineLinkText} from '#/components/Link'
 import {Loader} from '#/components/Loader'
 import * as Prompt from '#/components/Prompt'
 import * as Toast from '#/components/Toast'
 import {Text} from '#/components/Typography'
 import {useSimpleVerificationState} from '#/components/verification'
+import {FeaturedFeedPickerDialog} from './FeaturedFeedPickerDialog'
 
 export function EditProfileDialog({
   profile,
@@ -97,6 +104,7 @@ function DialogInner({
   const {_} = useLingui()
   const t = useTheme()
   const control = Dialog.useDialogContext()
+  const featuredFeedControl = Dialog.useDialogControl()
   const verification = useSimpleVerificationState({
     profile,
   })
@@ -124,11 +132,34 @@ function DialogInner({
     ImageMeta | undefined | null
   >()
 
+  /*
+   * The featured feed lives on the raw profile record, which loads
+   * asynchronously. Initialize local state once the record has been fetched so
+   * we do not clobber an existing value with `undefined` on save. We adjust
+   * state during render (rather than in an effect) so the initial value is in
+   * place before the first paint, matching the pattern used elsewhere in this
+   * file.
+   */
+  const recordQuery = useProfileRecordQuery({did: profile.did})
+  const initialFeaturedFeed = useFeaturedFeedUri({did: profile.did})
+  const [featuredFeed, setFeaturedFeed] = useState<string | undefined>()
+  const [featuredFeedReady, setFeaturedFeedReady] = useState(false)
+  if (!featuredFeedReady && recordQuery.isFetched) {
+    setFeaturedFeed(initialFeaturedFeed)
+    setFeaturedFeedReady(true)
+  }
+
+  const {data: featuredFeedInfo} = useFeedSourceInfoQuery({
+    uri: featuredFeed ?? '',
+    enabled: !!featuredFeed,
+  })
+
   const dirty =
     displayName !== initialDisplayName ||
     description !== initialDescription ||
     userAvatar !== profile.avatar ||
-    userBanner !== profile.banner
+    userBanner !== profile.banner ||
+    (featuredFeedReady && featuredFeed !== initialFeaturedFeed)
 
   useEffect(() => {
     setDirty(dirty)
@@ -175,10 +206,16 @@ function DialogInner({
     try {
       await updateProfileMutation({
         profile,
-        updates: {
-          displayName: displayName.trimEnd(),
-          description: description.trimEnd(),
-        },
+        updates: featuredFeedReady
+          ? {
+              displayName: displayName.trimEnd(),
+              description: description.trimEnd(),
+              featuredFeed,
+            }
+          : {
+              displayName: displayName.trimEnd(),
+              description: description.trimEnd(),
+            },
         newUserAvatar,
         newUserBanner,
       })
@@ -194,6 +231,8 @@ function DialogInner({
     control,
     displayName,
     description,
+    featuredFeed,
+    featuredFeedReady,
     newUserAvatar,
     newUserBanner,
     setImageError,
@@ -384,7 +423,44 @@ function DialogInner({
             </Text>
           )}
         </View>
+
+        <View>
+          <TextField.LabelText>
+            <Trans>Featured feed</Trans>
+          </TextField.LabelText>
+          <Button
+            label={_(msg`Choose a featured feed`)}
+            onPress={featuredFeedControl.open}
+            size="large"
+            color="secondary"
+            style={[a.justify_between]}
+            testID="editProfileFeaturedFeedBtn">
+            <ButtonText style={[a.flex_1, a.text_left]} numberOfLines={1}>
+              {featuredFeed ? (
+                (featuredFeedInfo?.displayName ?? _(msg`Selected feed`))
+              ) : (
+                <Trans>Latest posts</Trans>
+              )}
+            </ButtonText>
+            <ButtonIcon icon={ChevronRightIcon} />
+          </Button>
+          <Text
+            style={[a.text_sm, a.mt_xs, t.atoms.text_contrast_medium]}
+            emoji>
+            <Trans>
+              Show visitors a feed you have created when they open your profile,
+              instead of your latest posts.
+            </Trans>
+          </Text>
+        </View>
       </View>
+
+      <FeaturedFeedPickerDialog
+        control={featuredFeedControl}
+        did={profile.did}
+        selectedUri={featuredFeed}
+        onSelect={setFeaturedFeed}
+      />
     </Dialog.ScrollableInner>
   )
 }

--- a/src/screens/Profile/Header/FeaturedFeedPickerDialog.tsx
+++ b/src/screens/Profile/Header/FeaturedFeedPickerDialog.tsx
@@ -1,0 +1,167 @@
+import {Pressable, View} from 'react-native'
+import {type AppBskyFeedDefs} from '@atproto/api'
+import {Trans, useLingui} from '@lingui/react/macro'
+
+import {useProfileFeedgensQuery} from '#/state/queries/profile-feedgens'
+import {UserAvatar} from '#/view/com/util/UserAvatar'
+import {atoms as a, useTheme} from '#/alf'
+import * as Dialog from '#/components/Dialog'
+import {Check_Stroke2_Corner0_Rounded as CheckIcon} from '#/components/icons/Check'
+import {Loader} from '#/components/Loader'
+import {Text} from '#/components/Typography'
+
+export function FeaturedFeedPickerDialog({
+  control,
+  did,
+  selectedUri,
+  onSelect,
+}: {
+  control: Dialog.DialogControlProps
+  did: string
+  selectedUri?: string
+  onSelect: (uri: string | undefined) => void
+}) {
+  return (
+    <Dialog.Outer control={control}>
+      <Dialog.Handle />
+      <DialogInner did={did} selectedUri={selectedUri} onSelect={onSelect} />
+    </Dialog.Outer>
+  )
+}
+
+function DialogInner({
+  did,
+  selectedUri,
+  onSelect,
+}: {
+  did: string
+  selectedUri?: string
+  onSelect: (uri: string | undefined) => void
+}) {
+  const {t: l} = useLingui()
+  const control = Dialog.useDialogContext()
+  const {data, isLoading, isError} = useProfileFeedgensQuery(did)
+  const feeds = data?.pages.flatMap(page => page.feeds) ?? []
+
+  const select = (uri: string | undefined) => {
+    control.close(() => onSelect(uri))
+  }
+
+  return (
+    <Dialog.ScrollableInner label={l`Choose a featured feed`}>
+      <View style={[a.gap_sm, a.pb_lg]}>
+        <Text style={[a.text_xl, a.font_bold]}>
+          <Trans>Featured feed</Trans>
+        </Text>
+        <Text style={[a.text_sm, a.leading_snug]}>
+          <Trans>
+            Pick one of your feeds to greet visitors on your profile. They will
+            see this feed first instead of your latest posts.
+          </Trans>
+        </Text>
+      </View>
+
+      <View style={[a.gap_xs]}>
+        <FeedRow
+          label={l`Latest posts`}
+          description={l`Default reverse-chronological view`}
+          isSelected={!selectedUri}
+          onPress={() => select(undefined)}
+        />
+
+        {isLoading ? (
+          <View style={[a.py_lg, a.align_center]}>
+            <Loader size="lg" />
+          </View>
+        ) : isError ? (
+          <View style={[a.py_lg]}>
+            <Text style={[a.text_center]}>
+              <Trans>We could not load your feeds.</Trans>
+            </Text>
+          </View>
+        ) : feeds.length === 0 ? (
+          <View style={[a.py_lg]}>
+            <Text style={[a.text_center]}>
+              <Trans>
+                You have not published any feeds yet. Create a feed to feature
+                it on your profile.
+              </Trans>
+            </Text>
+          </View>
+        ) : (
+          feeds.map(feed => (
+            <FeedRow
+              key={feed.uri}
+              feed={feed}
+              label={feed.displayName}
+              isSelected={selectedUri === feed.uri}
+              onPress={() => select(feed.uri)}
+            />
+          ))
+        )}
+      </View>
+
+      <Dialog.Close />
+    </Dialog.ScrollableInner>
+  )
+}
+
+function FeedRow({
+  feed,
+  label,
+  description,
+  isSelected,
+  onPress,
+}: {
+  feed?: AppBskyFeedDefs.GeneratorView
+  label: string
+  description?: string
+  isSelected: boolean
+  onPress: () => void
+}) {
+  const t = useTheme()
+  const {t: l} = useLingui()
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityHint={l`Set as the featured feed for your profile`}
+      onPress={onPress}
+      style={[
+        a.flex_row,
+        a.align_center,
+        a.gap_md,
+        a.p_md,
+        a.rounded_md,
+        a.border,
+        isSelected ? t.atoms.border_contrast_high : t.atoms.border_contrast_low,
+        isSelected && t.atoms.bg_contrast_25,
+      ]}>
+      {feed ? (
+        <UserAvatar type="algo" size={36} avatar={feed.avatar} />
+      ) : (
+        <View
+          style={[
+            {width: 36, height: 36},
+            a.rounded_sm,
+            t.atoms.bg_contrast_50,
+          ]}
+        />
+      )}
+      <View style={[a.flex_1, a.gap_2xs]}>
+        <Text style={[a.font_bold]} emoji numberOfLines={1}>
+          {label}
+        </Text>
+        {description ? (
+          <Text
+            style={[a.text_sm, t.atoms.text_contrast_medium]}
+            numberOfLines={1}>
+            {description}
+          </Text>
+        ) : null}
+      </View>
+      {isSelected ? <CheckIcon size="sm" fill={t.palette.primary_500} /> : null}
+    </Pressable>
+  )
+}

--- a/src/state/queries/feed.ts
+++ b/src/state/queries/feed.ts
@@ -182,11 +182,18 @@ export function getAvatarTypeFromUri(uri: string) {
   return getFeedTypeFromUri(uri) === 'feed' ? 'algo' : 'list'
 }
 
-export function useFeedSourceInfoQuery({uri}: {uri: string}) {
+export function useFeedSourceInfoQuery({
+  uri,
+  enabled = true,
+}: {
+  uri: string
+  enabled?: boolean
+}) {
   const type = getFeedTypeFromUri(uri)
   const agent = useAgent()
 
   return useQuery({
+    enabled: enabled && !!uri,
     staleTime: STALE.INFINITY,
     queryKey: feedSourceInfoQueryKey({uri}),
     queryFn: async () => {

--- a/src/state/queries/profile-featured-feed.ts
+++ b/src/state/queries/profile-featured-feed.ts
@@ -1,0 +1,77 @@
+import {type AppBskyActorProfile} from '@atproto/api'
+import {useQuery} from '@tanstack/react-query'
+
+import {STALE} from '#/state/queries'
+import {useAgent} from '#/state/session'
+
+/**
+ * The `app.bsky.actor.profile` record, extended with the custom `featuredFeed`
+ * field. The field holds the at-uri of a feed generator that the account wants
+ * shown as the default tab when others visit their profile. It is not part of
+ * the official lexicon, so the AppView's getProfile does not surface it - we
+ * read it from the repo record directly.
+ */
+type ProfileRecordWithFeaturedFeed = AppBskyActorProfile.Record & {
+  featuredFeed?: string
+}
+
+const RQKEY_ROOT = 'profile-record'
+export const RQKEY = (did: string) => [RQKEY_ROOT, did]
+
+/**
+ * Reads the raw `app.bsky.actor.profile` record for an actor. Use this when you
+ * need fields that the AppView does not return, such as `featuredFeed`.
+ */
+export function useProfileRecordQuery({
+  did,
+  enabled = true,
+}: {
+  did?: string
+  enabled?: boolean
+}) {
+  const agent = useAgent()
+  return useQuery({
+    staleTime: STALE.MINUTES.FIVE,
+    queryKey: RQKEY(did ?? ''),
+    enabled: !!did && enabled,
+    queryFn: async () => {
+      try {
+        const res = await agent.com.atproto.repo.getRecord({
+          repo: did!,
+          collection: 'app.bsky.actor.profile',
+          rkey: 'self',
+        })
+        return res.data.value as ProfileRecordWithFeaturedFeed
+      } catch {
+        /*
+         * The record may not exist (e.g. the account never set up a profile),
+         * which getRecord surfaces as an error. Treat that as "no record".
+         */
+        return null
+      }
+    },
+  })
+}
+
+/**
+ * Returns the at-uri of the account's featured feed, or undefined if none is
+ * set. Only feed-generator uris are returned.
+ */
+export function useFeaturedFeedUri({
+  did,
+  enabled = true,
+}: {
+  did?: string
+  enabled?: boolean
+}): string | undefined {
+  const {data} = useProfileRecordQuery({did, enabled})
+  const uri = data?.featuredFeed
+  if (
+    typeof uri === 'string' &&
+    uri.startsWith('at://') &&
+    uri.includes('app.bsky.feed.generator')
+  ) {
+    return uri
+  }
+  return undefined
+}

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -27,6 +27,7 @@ import {type Shadow} from '#/state/cache/types'
 import {type ImageMeta} from '#/state/gallery'
 import {STALE} from '#/state/queries'
 import {resetProfilePostsQueries} from '#/state/queries/post-feed'
+import {RQKEY as PROFILE_RECORD_RQKEY} from '#/state/queries/profile-featured-feed'
 import {RQKEY as PROFILE_FOLLOWS_RQKEY} from '#/state/queries/profile-follows'
 import {
   unstableCacheProfileView,
@@ -129,10 +130,19 @@ export function usePrefetchProfileQuery() {
   return prefetchProfileQuery
 }
 
+/**
+ * The custom `featuredFeed` field is not part of the official lexicon, so it is
+ * not present on the generated record type. We allow setting it on the object
+ * form of profile updates.
+ */
+type ProfileRecordUpdate = Un$Typed<AppBskyActorProfile.Record> & {
+  featuredFeed?: string
+}
+
 interface ProfileUpdateParams {
   profile: AppBskyActorDefs.ProfileViewDetailed
   updates:
-    | Un$Typed<AppBskyActorProfile.Record>
+    | ProfileRecordUpdate
     | ((
         existing: Un$Typed<AppBskyActorProfile.Record>,
       ) => Un$Typed<AppBskyActorProfile.Record>)
@@ -181,6 +191,10 @@ export function useProfileUpdateMutation() {
           next.description = updates.description || undefined
           if ('pinnedPost' in updates) {
             next.pinnedPost = updates.pinnedPost
+          }
+          if ('featuredFeed' in updates) {
+            ;(next as ProfileRecordUpdate).featuredFeed =
+              updates.featuredFeed || undefined
           }
         }
         if (newUserAvatarPromise) {
@@ -237,6 +251,10 @@ export function useProfileUpdateMutation() {
       })
       void queryClient.invalidateQueries({
         queryKey: [profilesQueryKeyRoot, [variables.profile.did]],
+      })
+      // the raw profile record holds the custom `featuredFeed` field
+      void queryClient.invalidateQueries({
+        queryKey: PROFILE_RECORD_RQKEY(variables.profile.did),
       })
       await updateProfileVerificationCache({profile: variables.profile})
     },

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -28,9 +28,11 @@ import {colors} from '#/lib/styles'
 import {useProfileShadow} from '#/state/cache/profile-shadow'
 import {listenSoftReset} from '#/state/events'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
+import {useFeedSourceInfoQuery} from '#/state/queries/feed'
 import {useLabelerInfoQuery} from '#/state/queries/labeler'
 import {resetProfilePostsQueries} from '#/state/queries/post-feed'
 import {useProfileQuery} from '#/state/queries/profile'
+import {useFeaturedFeedUri} from '#/state/queries/profile-featured-feed'
 import {useResolveDidQuery} from '#/state/queries/resolve-uri'
 import {useAgent, useSession} from '#/state/session'
 import {ProfileFeedgens} from '#/view/com/feeds/ProfileFeedgens'
@@ -191,6 +193,7 @@ function ProfileScreenLoaded({
 
   const [scrollViewTag, setScrollViewTag] = useState<number | null>(null)
 
+  const featuredSectionRef = useRef<SectionRef>(null)
   const postsSectionRef = useRef<SectionRef>(null)
   const repliesSectionRef = useRef<SectionRef>(null)
   const mediaSectionRef = useRef<SectionRef>(null)
@@ -214,6 +217,21 @@ function ProfileScreenLoaded({
 
   const isMe = profile.did === currentAccount?.did
   const hasLabeler = !!profile.associated?.labeler
+  /*
+   * Accounts can designate a feed they created as their "featured" feed. When
+   * set, it becomes the first tab so visitors land on a curated feed instead of
+   * the reverse-chronological post list. Labelers do not have post tabs, so we
+   * skip it for them.
+   */
+  const featuredFeedUri = useFeaturedFeedUri({
+    did: profile.did,
+    enabled: !hasLabeler,
+  })
+  const {data: featuredFeedInfo} = useFeedSourceInfoQuery({
+    uri: featuredFeedUri ?? '',
+    enabled: !!featuredFeedUri,
+  })
+  const showFeaturedTab = !!featuredFeedUri
   const showFiltersTab = hasLabeler
   const showPostsTab = true
   const showRepliesTab = hasSession
@@ -229,6 +247,9 @@ function ProfileScreenLoaded({
   const showListsTab = hasSession && (isMe || listCount > 0)
 
   const sectionTitles = [
+    showFeaturedTab
+      ? featuredFeedInfo?.displayName || _(msg`Featured`)
+      : undefined,
     showFiltersTab ? _(msg`Labels`) : undefined,
     showListsTab && hasLabeler ? _(msg`Lists`) : undefined,
     showPostsTab ? _(msg`Posts`) : undefined,
@@ -242,6 +263,7 @@ function ProfileScreenLoaded({
   ].filter(Boolean) as string[]
 
   let nextIndex = 0
+  let featuredIndex: number | null = null
   let filtersIndex: number | null = null
   let postsIndex: number | null = null
   let repliesIndex: number | null = null
@@ -251,6 +273,9 @@ function ProfileScreenLoaded({
   let feedsIndex: number | null = null
   let starterPacksIndex: number | null = null
   let listsIndex: number | null = null
+  if (showFeaturedTab) {
+    featuredIndex = nextIndex++
+  }
   if (showFiltersTab) {
     filtersIndex = nextIndex++
   }
@@ -281,7 +306,9 @@ function ProfileScreenLoaded({
 
   const scrollSectionToTop = useCallback(
     (index: number) => {
-      if (index === filtersIndex) {
+      if (index === featuredIndex) {
+        featuredSectionRef.current?.scrollToTop()
+      } else if (index === filtersIndex) {
         labelsSectionRef.current?.scrollToTop()
       } else if (index === postsIndex) {
         postsSectionRef.current?.scrollToTop()
@@ -302,6 +329,7 @@ function ProfileScreenLoaded({
       }
     },
     [
+      featuredIndex,
       filtersIndex,
       postsIndex,
       repliesIndex,
@@ -390,6 +418,19 @@ function ProfileScreenLoaded({
         onCurrentPageSelected={onCurrentPageSelected}
         renderHeader={renderHeader}
         allowHeaderOverScroll>
+        {showFeaturedTab && featuredFeedUri
+          ? ({headerHeight, isFocused, scrollElRef}) => (
+              <ProfileFeedSection
+                ref={featuredSectionRef}
+                feed={`feedgen|${featuredFeedUri}`}
+                headerHeight={headerHeight}
+                isFocused={isFocused}
+                scrollElRef={scrollElRef as ListRef}
+                setScrollViewTag={setScrollViewTag}
+                emptyStateMessage={_(msg`This feed is empty.`)}
+              />
+            )
+          : null}
         {showFiltersTab
           ? ({headerHeight, isFocused, scrollElRef}) => (
               <ProfileLabelsSection


### PR DESCRIPTION
Let accounts designate one of their feeds as a "featured feed" that greets visitors on their profile. When set, the feed appears as the first tab (to the left of Posts), labeled with the feed's name, so visitors land on a curated feed instead of the reverse-chronological post list. Posts/Replies/Media remain one tap away, and the feature is fully opt-in.

The selection is stored as a custom `featuredFeed` field on the app.bsky.actor.profile record (alongside pinnedPost). Since the AppView does not surface custom fields, viewers read it from the repo record directly via com.atproto.repo.getRecord.

- profile-featured-feed.ts: query the raw profile record and derive the featured feed uri
- profile.ts: persist the featuredFeed field through the profile update mutation and invalidate the record query on success
- EditProfileDialog + FeaturedFeedPickerDialog: pick a featured feed from the feeds the account has created
- Profile.tsx: render the featured feed as the first profile tab
- feed.ts: allow useFeedSourceInfoQuery to be disabled


Claude-Session: https://claude.ai/code/session_01EF2br6faLvA5G6pScFiSzg