### PR TITLE
Raise composer character limit

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -61,9 +61,9 @@ export function FEEDBACK_FORM_URL({
 export const MAX_DISPLAY_NAME = 64
 export const MAX_DESCRIPTION = 256
 
-export const MAX_GRAPHEME_LENGTH = 300
+export const MAX_GRAPHEME_LENGTH = 2000
 
-export const MAX_DRAFT_GRAPHEME_LENGTH = 1000
+export const MAX_DRAFT_GRAPHEME_LENGTH = 2000
 
 export const MAX_DM_GRAPHEME_LENGTH = 1000
 

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1375,7 +1375,14 @@ export const ComposePost = ({
                     </Trans>
                   )
                 ) : (
-                  <Trans>You can only save drafts up to 1000 characters.</Trans>
+                  <Trans>
+                    You can only save drafts up to{' '}
+                    {plural(MAX_DRAFT_GRAPHEME_LENGTH, {
+                      one: '# character',
+                      other: '# characters',
+                    })}
+                    .
+                  </Trans>
                 )}
               </Prompt.DescriptionText>
             </Prompt.Content>

--- a/src/view/com/composer/drafts/DraftsButton.tsx
+++ b/src/view/com/composer/drafts/DraftsButton.tsx
@@ -1,4 +1,4 @@
-import {msg} from '@lingui/core/macro'
+import {msg, plural} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
 
@@ -6,6 +6,7 @@ import {atoms as a} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import * as Prompt from '#/components/Prompt'
+import {MAX_DRAFT_GRAPHEME_LENGTH} from '#/lib/constants'
 import {useAnalytics} from '#/analytics'
 import {DraftsListDialog} from './DraftsListDialog'
 import {useSaveDraftMutation} from './state/queries'
@@ -114,8 +115,12 @@ export function DraftsButton({
             )
           ) : (
             <Trans>
-              You can only save drafts up to 1000 characters. Would you like to
-              discard this post before viewing your drafts?
+              You can only save drafts up to{' '}
+              {plural(MAX_DRAFT_GRAPHEME_LENGTH, {
+                one: '# character',
+                other: '# characters',
+              })}
+              . Would you like to discard this post before viewing your drafts?
             </Trans>
           )}
         </Prompt.DescriptionText>


### PR DESCRIPTION
## Summary

- raise the composer post grapheme limit from 300 to 2000
- raise the draft-save grapheme limit to match, so longer posts can still be saved as drafts
- update draft-limit prompts to render from the shared draft limit constant

## Research / caveat

This is the social-app side of the change. The current `app.bsky.feed.post` lexicon in `bluesky-social/atproto` still declares `text.maxGraphemes: 300` and `text.maxLength: 3000`, so this client patch depends on a protocol/server validation change before it can be merge-ready.

Relevant issue threads:

- Closes #10960
- Refs #5913
- Refs #4952

## Test plan

- `git diff --check`
- Not run locally: `pnpm lint` and `pnpm typecheck` both require installed dependencies, and this checkout has no `node_modules`. The local runtime also reports Node `v20.19.4`, while the repo requires `>=24.15.0`.
