### PR TITLE
Always set `allTime` to `true` for search v2

### DIFF
--- a/src/state/queries/search-posts-v2.ts
+++ b/src/state/queries/search-posts-v2.ts
@@ -74,14 +74,6 @@ export function useSearchPostsV2Query({
        */
       const {q, ...embedded} = extractSearchPostsParams(query)
       const builtFilters = buildSearchPostsV2Filters(embedded, filters)
-      /*
-       * v2 defaults to a recent-post window; the Latest tab keeps that, while
-       * Top searches the full index. But an explicit since/until date filter
-       * must search the full index too, otherwise the recent window would
-       * silently override the user's date range and return nothing for older
-       * dates.
-       */
-      const hasDateFilter = !!(builtFilters.since || builtFilters.until)
       const res = await agent.app.bsky.feed.searchPostsV2({
         ...builtFilters,
         query: q,
@@ -92,7 +84,7 @@ export function useSearchPostsV2Query({
          * the v1 'latest' label.
          */
         sort: sort === 'latest' ? 'recent' : sort,
-        allTime: sort !== 'latest' || hasDateFilter,
+        allTime: true,
       })
       return res.data
     },


### PR DESCRIPTION
Bypassing the 30-day window for recent searches for now to see how it performs.