### PR TITLE
Remove actions-up script in favor of Dependabot

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,7 @@
     "generate-webpack-stats-file": "EXPO_PUBLIC_GENERATE_STATS=1 pnpm build-web",
     "open-analyzer": "EXPO_PUBLIC_OPEN_ANALYZER=1 pnpm build-web",
     "icons:optimize": "svgo -f ./assets/icons",
-    "prettier": "prettier --check .",
-    "update-actions": "pnpm dlx actions-up --min-age 7"
+    "prettier": "prettier --check ."
   },
   "dependencies": {
     "@atproto/api": "0.20.22",


### PR DESCRIPTION
With https://github.com/bluesky-social/social-app/pull/10475, we get nice PRs like https://github.com/bluesky-social/social-app/pull/11021. To compare with the latter, I ran this `update-actions` script and it incorrectly updated the `claude-code-action` to a version only 43 min old at the time. So let's ditch this and just use Dependabot.