### PR TITLE
Remove potentially intent violating chat settings restriction

### DIFF
--- a/src/ageAssurance/index.tsx
+++ b/src/ageAssurance/index.tsx
@@ -1,8 +1,6 @@
 import {createContext, useCallback, useContext, useMemo} from 'react'
 
 import {useGetAndRegisterPushToken} from '#/lib/notifications/notifications'
-import {restrictChatSettings} from '#/state/queries/messages/restrictChatSettings'
-import {useAgent} from '#/state/session'
 import {Provider as RedirectOverlayProvider} from '#/ageAssurance/components/RedirectOverlay'
 import {
   AgeAssuranceServerDataProvider,
@@ -80,7 +78,6 @@ export function Provider({children}: {children: React.ReactNode}) {
 }
 
 function InnerProvider({children}: {children: React.ReactNode}) {
-  const agent = useAgent()
   const state = useAgeAssuranceState()
   const {metadata, deviceSignals} = useAgeAssuranceServerDataContext()
   const regionConfig = useAgeAssuranceRegionConfigWithFallback()
@@ -99,15 +96,8 @@ function InnerProvider({children}: {children: React.ReactNode}) {
           isAgeRestricted: true,
         })
       }
-      if (flags.chatDisabled || flags.groupChatDisabled) {
-        void restrictChatSettings({
-          agent,
-          restrictIncoming: flags.chatDisabled,
-          restrictGroupInvites: flags.groupChatDisabled,
-        })
-      }
     },
-    [agent, getAndRegisterPushToken, regionConfig, metadata, deviceSignals],
+    [getAndRegisterPushToken, regionConfig, metadata, deviceSignals],
   )
   useOnAgeAssuranceAccessUpdate(handleAccessUpdate)
 


### PR DESCRIPTION
In the event of a flaky network, age assurance state may fail to load and could result in a momentary state computation that makes it appear as if a user is blocked from accessing chats, which current has a side effect of restricting their incoming chat settings. We've heard reports of this, and this almost certainly the cause.

This PR removes this side effect. Chat settings are still set to defaults when creating new accounts or when adjusting birthdate prefs.

An alternative we should consider is storing user-desired prefs on separate fields on the actor declaration record, so that we can restore those choices if chat access is restored via any means.