### PR TITLE
Prevent reloads while the composer has unsaved content

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -859,34 +859,48 @@ export const ComposePost = ({
     [insets.top, insets.bottom],
   )
 
+  const hasUnsavedContent = useMemo(
+    () =>
+      thread.posts.some(
+        post =>
+          post.shortenedGraphemeLength > 0 ||
+          post.embed.media ||
+          post.embed.link,
+      ) &&
+      (!composerState.draftId || composerState.isDirty),
+    [thread.posts, composerState.draftId, composerState.isDirty],
+  )
+
+  // 'You might lose unsaved changes' warning
+  useEffect(() => {
+    if (IS_WEB && hasUnsavedContent) {
+      const abortController = new AbortController()
+      const {signal} = abortController
+      window.addEventListener('beforeunload', evt => evt.preventDefault(), {
+        signal,
+      })
+      return () => {
+        abortController.abort()
+      }
+    }
+  }, [hasUnsavedContent])
+
   const onPressCancel = useCallback(() => {
     if (textInputRef.current?.maybeClosePopup()) {
       return
     }
 
-    const hasContent = thread.posts.some(
-      post =>
-        post.shortenedGraphemeLength > 0 || post.embed.media || post.embed.link,
-    )
-
     // Show discard prompt if there's content AND either:
     // - No draft is loaded (new composition)
     // - Draft is loaded but has been modified
-    if (hasContent && (!composerState.draftId || composerState.isDirty)) {
+    if (hasUnsavedContent) {
       closeAllDialogs()
       Keyboard.dismiss()
       discardPromptControl.open()
     } else {
       onClose()
     }
-  }, [
-    thread,
-    composerState.draftId,
-    composerState.isDirty,
-    closeAllDialogs,
-    discardPromptControl,
-    onClose,
-  ])
+  }, [hasUnsavedContent, closeAllDialogs, discardPromptControl, onClose])
 
   useImperativeHandle(cancelRef, () => ({onPressCancel}))
 


### PR DESCRIPTION
Fixes #9319

This uses the same useEffect as ``CreateOrEditListDialog.tsx`` to show a warning

As this popup should match the checks used by the composers cancel button, it made a little more sense to make them their own constant and call that over redefining everything a second time 🐙

