### PR TITLE
fix(search): Update advanced search label text (#11049)

### DIFF
--- a/src/screens/Search/components/AdvancedSearchDialog/index.tsx
+++ b/src/screens/Search/components/AdvancedSearchDialog/index.tsx
@@ -456,7 +456,7 @@ function DialogInner({
             </Admonition>
           )}
           <Button
-            label={l`Add an additional search filter`}
+            label={l`Add another search filter`}
             size="small"
             color="secondary"
             disabled={filters.length >= MAX_FILTERS}


### PR DESCRIPTION
This PR changes the label text in the Advanced Search Dialog from "Add an additional search filter" to "Add another search filter", as requested in the issue.

Fixes #11049