### PR TITLE
Add missing l18n wrapper to ‘⚠Invalid Handle’ in handles.ts

### DIFF
--- a/src/lib/strings/handles.ts
+++ b/src/lib/strings/handles.ts
@@ -1,7 +1,9 @@
 // Regex from the go implementation
 // https://github.com/bluesky-social/indigo/blob/main/atproto/syntax/handle.go#L10
+import {i18n} from '@lingui/core'
+import {msg} from '@lingui/core/macro'
+
 import {forceLTR} from '#/lib/strings/bidi'
-import {Trans} from "@lingui/react/macro";
 
 const VALIDATE_REGEX =
   /^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/
@@ -33,7 +35,7 @@ export function sanitizeHandle(
 ): string {
   const lowercasedWithPrefix = `${prefix}${handle.toLocaleLowerCase()}`
   return isInvalidHandle(handle)
-    ? {_(msg`⚠Invalid Handle`)}
+    ? i18n._(msg({message: `⚠Invalid Handle`}))
     : forceLeftToRight
       ? forceLTR(lowercasedWithPrefix)
       : lowercasedWithPrefix

--- a/src/lib/strings/handles.ts
+++ b/src/lib/strings/handles.ts
@@ -1,6 +1,7 @@
 // Regex from the go implementation
 // https://github.com/bluesky-social/indigo/blob/main/atproto/syntax/handle.go#L10
 import {forceLTR} from '#/lib/strings/bidi'
+import {Trans} from "@lingui/react/macro";
 
 const VALIDATE_REGEX =
   /^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/
@@ -32,7 +33,7 @@ export function sanitizeHandle(
 ): string {
   const lowercasedWithPrefix = `${prefix}${handle.toLocaleLowerCase()}`
   return isInvalidHandle(handle)
-    ? '⚠Invalid Handle'
+    ? {_(msg`⚠Invalid Handle`)}
     : forceLeftToRight
       ? forceLTR(lowercasedWithPrefix)
       : lowercasedWithPrefix


### PR DESCRIPTION
This fixes a minor translation issue where one usage of ‘⚠Invalid Handle’ wasn't wrapped in a l18n function. This string is already present in the localisation files from a different instance, so merging this PR will require no additional translator involvement – it works right away.

| Before | After |
| ----- | ----- |
| <img width="367" height="58" alt="Képernyőkép_20260706_112618" src="https://github.com/user-attachments/assets/bfad1a22-4b37-44e6-98b3-ea0dcf9c86e5" /> | <img width="400" height="54" alt="Képernyőkép_20260706_114303" src="https://github.com/user-attachments/assets/e77f882c-1d1d-47a1-82a6-f2827f2dc395" /> |