### PR TITLE
fix: restore Android native stretchy overscroll on image carousel

### DIFF
--- a/src/components/images/Gallery/index.tsx
+++ b/src/components/images/Gallery/index.tsx
@@ -274,9 +274,12 @@ export function Gallery({
           aria-label={l`Image gallery, ${images.length} images`}
           horizontal
           pagingEnabled={false}
-          // Disable Android's stretch overscroll, which can leave the carousel
-          // settled just off the left edge instead of aligned to x = 0
-          overScrollMode={IS_ANDROID ? 'never' : 'auto'}
+          // We use snapToOffsets on Android to ensure that if the stretch overscroll
+          // leaves the carousel slightly off the left edge, it snaps back to 0.
+          // This fixes the offset bug without disabling the native stretch behavior.
+          overScrollMode="auto"
+          snapToOffsets={IS_ANDROID ? [0] : undefined}
+          snapToEnd={false}
           showsHorizontalScrollIndicator={false}
           directionalLockEnabled
           nestedScrollEnabled


### PR DESCRIPTION
Fixes #10864

### What changed?
Restores the native bouncy/stretchy overscroll mechanics to the image carousel on Android by letting `overScrollMode` default to `"auto"`.

### Why?
Previously in #10717, `overScrollMode` was set to `"never"` to circumvent a known bug in React Native Android where the stretch effect's momentum decay calculates the final position slightly off `x = 0`, causing the first image to settle with a slight gap on the left margin. 

However, completely disabling the overscroll made the carousel feel unresponsive and non-native at the edges (as reported in #10864). 

### How does this fix it?
By passing `snapToOffsets={[0]}` and `snapToEnd={false}` alongside the restored overscroll, the `FlatList` now explicitly snaps perfectly back to `0` whenever the user triggers a stretch rebound on the left edge. This allows us to keep the native stretchy physics fully intact while gracefully avoiding the offset bug!