### PR TITLE
fix camera roll gif selection hanging on ios

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -389,9 +389,15 @@ export const ComposePost = ({
       /*
        * Share-extension deeplinks deliver a video URI without duration, so
        * probe before we decide whether to compress. The picker and web paste
-       * paths already populate duration upstream.
+       * paths already populate duration upstream. GIFs must skip the probe:
+       * they have no video track, so the iOS prober never resolves or rejects
+       * and the await below would hang forever.
        */
-      if (asset.duration == null && IS_NATIVE) {
+      if (
+        asset.duration == null &&
+        IS_NATIVE &&
+        asset.mimeType !== 'image/gif'
+      ) {
         try {
           const probed = await getVideoMetadata(asset.uri)
           asset = {


### PR DESCRIPTION
Selecting a saved GIF from the camera roll on iOS did nothing: no preview, no spinner, no error. Regressed in 1.126.0.

**Cause**

- #10999 made `selectVideo` await a duration probe before dispatching `embed_add_video` whenever the asset has no duration. Camera-roll GIFs always hit this: they are image assets with no duration, routed down the video path.
- The probe calls react-native-compressor's `getVideoMetaData`. Its iOS implementation only settles inside `if let track = asset.tracks(withMediaType: .video).first` and has no else branch. A GIF has no AVFoundation video track, so the promise never resolves or rejects and the await hangs before any composer state is dispatched.
- Android's implementation rejects instead (caught, flow continues), so this was iOS-only.

**Fix**

Skip the probe for `image/gif`, matching the existing guard in `compressVideo` (`compress.ts`). GIFs don't need the duration check: they upload as passthrough and the 3-minute gate is video-only.

**Testing**

- On unfixed main (iOS sim, dev client): picking an animated GIF from the camera roll silently does nothing.
- With this change: preview appears and the post flow works.
- Note when testing: a "GIF" saved from Google Images is often WebP, which takes the image path and won't reproduce the bug. Use a real animated GIF.