### PR TITLE
fix web video preview error aborting upload

### DIFF
--- a/src/view/com/composer/videos/VideoPreview.web.tsx
+++ b/src/view/com/composer/videos/VideoPreview.web.tsx
@@ -1,14 +1,15 @@
+import {useState} from 'react'
 import {View} from 'react-native'
 import {type ImagePickerAsset} from 'expo-image-picker'
-import {msg} from '@lingui/core/macro'
-import {useLingui} from '@lingui/react'
+import {Trans} from '@lingui/react/macro'
 
 import {type CompressedVideo} from '#/lib/media/video/types'
+import {logger} from '#/logger'
 import {useAutoplayDisabled} from '#/state/preferences'
 import {ExternalEmbedRemoveBtn} from '#/view/com/composer/ExternalEmbedRemoveBtn'
 import {atoms as a} from '#/alf'
 import {ConstrainedImage} from '#/components/images/AutoSizedImage'
-import * as Toast from '#/components/Toast'
+import {Text} from '#/components/Typography'
 import {PlayButtonIcon} from '#/components/video/PlayButtonIcon'
 
 export function VideoPreview({
@@ -21,10 +22,10 @@ export function VideoPreview({
   isActivePost: boolean
   clear: () => void
 }) {
-  const {_} = useLingui()
   // TODO: figure out how to pause a GIF for reduced motion
   // it's not possible using an img tag -sfn
   const autoplayDisabled = useAutoplayDisabled()
+  const [previewFailed, setPreviewFailed] = useState(false)
 
   let aspectRatio: number | undefined
   if (asset.width && asset.height) {
@@ -52,6 +53,21 @@ export function VideoPreview({
               style={{width: '100%', height: '100%', objectFit: 'contain'}}
               alt="GIF"
             />
+          ) : previewFailed ? (
+            <View style={[a.flex_1, a.justify_center, a.align_center, a.px_lg]}>
+              <Text
+                style={[
+                  a.text_sm,
+                  a.leading_snug,
+                  a.text_center,
+                  {color: 'white'},
+                ]}>
+                <Trans>
+                  This video can’t be previewed in your browser. It will still
+                  be uploaded.
+                </Trans>
+              </Text>
+            </View>
           ) : (
             <>
               <video
@@ -61,12 +77,19 @@ export function VideoPreview({
                 loop
                 muted
                 playsInline
-                onError={err => {
-                  console.error('Error loading video', err)
-                  Toast.show(_(msg`Could not process your video`), {
-                    type: 'error',
+                onError={e => {
+                  /*
+                   * A preview render failure must not remove the video. The
+                   * upload is already in flight, and clearing here aborts it
+                   * even though the compressed file may be perfectly valid.
+                   */
+                  const mediaError = e.currentTarget.error
+                  logger.error('Video preview failed to render', {
+                    safeMessage: mediaError
+                      ? `code ${mediaError.code}: ${mediaError.message}`
+                      : 'unknown media error',
                   })
-                  clear()
+                  setPreviewFailed(true)
                 }}
               />
               {autoplayDisabled && (


### PR DESCRIPTION
## Problem

On web, when the composer's video preview `<video>` element fails to load the compressed file, its `onError` handler showed a "Could not process your video" toast and cleared the video embed. Clearing aborts the in-flight upload via the video AbortController, so a perfectly valid compressed video was thrown away over a preview-only render failure. The thrown `AbortError` is intentionally swallowed by the upload error handler, so no error state was set and telemetry recorded the session as user abandonment rather than a failure.

In practice this made every upload of certain videos (e.g. iPhone screen-recording `.mov` files whose compressed webm the browser won't play) appear to fail, even though compression and upload were succeeding.

## Fix

A preview render failure no longer clears the video or touches the upload. Instead:

- the preview area shows "This video can't be previewed in your browser. It will still be uploaded."
- the `MediaError` code/message is logged
- the remove button remains available if the user does want to discard the video

Native `VideoPreview` does not have this pattern; web-only change.

<img width="2076" height="2122" alt="CleanShot 2026-07-06 at 18 32 38@2x" src="https://github.com/user-attachments/assets/59dd3890-429b-4a84-8c29-8ebabfaddfd2" />


## Test plan

- typecheck, lint, prettier pass; web bundle compiles
- to reproduce the fallback: attach a video, and force the preview `<video>` to error (e.g. temporarily point `src` at an invalid URI). Previously the video embed vanished with an error toast and the upload aborted (`video:upload:abandoned` with ms-scale `elapsedInPhaseMs`); now the fallback message renders and upload/processing complete