### PR TITLE
Remove unused video extension extraction in Share extension

### DIFF
--- a/modules/Share-with-Bluesky/ShareViewController.swift
+++ b/modules/Share-with-Bluesky/ShareViewController.swift
@@ -121,7 +121,6 @@ class ShareViewController: UIViewController {
     let firstItem = items.first
 
     if let dataUrl = try? await firstItem?.loadItem(forTypeIdentifier: "public.movie") as? URL {
-      let ext = String(dataUrl.lastPathComponent.split(separator: ".").last ?? "mp4")
       if let videoUriInfo = saveVideoWithInfo(dataUrl),
          let url = URL(string: "\(self.appScheme)://intent/compose?videoUri=\(videoUriInfo)") {
         _ = self.openURL(url)


### PR DESCRIPTION
## Summary
Removed unused code that extracted the file extension from a video URL in the Share with Bluesky extension.

## Changes
- Removed the `ext` variable assignment that split the video file path to extract the file extension
- The extracted extension was never used in the subsequent code, making this line dead code

## Details
The line `let ext = String(dataUrl.lastPathComponent.split(separator: ".").last ?? "mp4")` was extracting the video file extension but the `ext` variable was not referenced anywhere in the function. This cleanup removes unnecessary string manipulation.

https://claude.ai/code/session_019sWVUz99gzx1Yn5ia9ge8M