### PR TITLE
use source file for web video compression

### DIFF
--- a/src/analytics/metrics/types.ts
+++ b/src/analytics/metrics/types.ts
@@ -1404,6 +1404,8 @@ export type Events = {
     uploadId: string
     engine: string
     errorClass: string
+    /** Truncated to 256 chars */
+    errorMessage: string
     elapsedMs: number
   }
   'video:upload:uploadStarted': {

--- a/src/lib/media/video/compress.web.ts
+++ b/src/lib/media/video/compress.web.ts
@@ -44,8 +44,12 @@ export async function compressVideo(
     hasWebCodecs: hasWebCodecs(),
   })
 
-  const response = await fetch(asset.uri)
-  const blob = await response.blob()
+  /*
+   * Prefer the original File over re-fetching the blob URL. A fetch round
+   * trip copies the bytes and fails with a bare TypeError if the URL was
+   * revoked or the read fails - the top web compressFailed error class.
+   */
+  const blob = asset.file ?? (await (await fetch(asset.uri)).blob())
 
   const isGif = blob.type === 'image/gif'
   const hasCodecs = hasWebCodecs()

--- a/src/lib/media/video/telemetry.ts
+++ b/src/lib/media/video/telemetry.ts
@@ -26,6 +26,11 @@ function errorClass(e: unknown): string {
   return 'Unknown'
 }
 
+function errorMessage(e: unknown): string {
+  const message = e instanceof Error ? e.message : String(e)
+  return message.slice(0, 256)
+}
+
 export type VideoTelemetry = {
   readonly uploadId: string
   readonly engine: string
@@ -208,6 +213,7 @@ export function createVideoTelemetry({
         uploadId,
         engine,
         errorClass: errorClass(e),
+        errorMessage: errorMessage(e),
         elapsedMs: Date.now() - phaseStartedAt,
       })
       endTxn('error')

--- a/src/view/com/composer/videos/metadata.web.ts
+++ b/src/view/com/composer/videos/metadata.web.ts
@@ -72,6 +72,7 @@ async function getMetadataWithWebCodecs(
 
     return {
       uri: blobUrl,
+      file,
       mimeType: file.type,
       width: videoTrack.displayWidth,
       height: videoTrack.displayHeight,
@@ -92,6 +93,7 @@ async function getMetadataWithBrowserAPIs(
       img.onload = () => {
         resolve({
           uri: blobUrl,
+          file,
           mimeType: 'image/gif',
           width: img.width,
           height: img.height,
@@ -111,6 +113,7 @@ async function getMetadataWithBrowserAPIs(
       video.onloadedmetadata = () => {
         resolve({
           uri: blobUrl,
+          file,
           mimeType: file.type,
           width: video.videoWidth,
           height: video.videoHeight,


### PR DESCRIPTION
## Why

`video:upload:compressFailed` on web runs at ~500-800 events (~200 users) per day, almost all with `errorClass: TypeError` and no further detail. The throw site is the `fetch(blob URL)` round trip at the top of `compressVideo`: it re-reads bytes we already have as a `File`, copies them, and rejects with a bare TypeError if the object URL was revoked or the underlying read fails.

## What

- `getVideoMetadata` (web) now attaches the source `File` to the returned asset. All web entry points (picker, paste, draft restore) build assets through it.
- `compressVideo` (web) uses `asset.file` directly when present, keeping the fetch as a fallback. This removes the revoked-URL failure mode, skips a redundant full copy of the video, and lets remaining read failures surface as descriptive errors instead of bare TypeErrors.
- `compressFailed` now includes `errorMessage` (truncated to 256 chars) alongside `errorClass`, so failure causes are diagnosable from the funnel.