### PR TITLE
Collapse label appeal flow into ModerationDetailsDialog

### DIFF
--- a/src/components/Pills.tsx
+++ b/src/components/Pills.tsx
@@ -151,6 +151,83 @@ export function Label({
   )
 }
 
+export type LabelBaseProps = {
+  label: string
+  onPress: () => void
+  noBg?: boolean
+} & CommonProps
+
+export function LabelBase({label, onPress, size = 'sm', noBg}: LabelBaseProps) {
+  const t = useTheme()
+
+  const {outer, text} = useMemo(() => {
+    switch (size) {
+      case 'lg': {
+        return {
+          outer: [
+            t.atoms.bg_contrast_25,
+            {
+              gap: 5,
+              paddingHorizontal: 5,
+              paddingVertical: 5,
+            },
+          ],
+          text: [a.text_sm],
+        }
+      }
+      case 'sm':
+      default: {
+        return {
+          outer: [
+            !noBg && t.atoms.bg_contrast_25,
+            {
+              gap: 3,
+              paddingHorizontal: 3,
+              paddingVertical: 3,
+            },
+          ],
+          text: [a.text_xs],
+        }
+      }
+    }
+  }, [t, size, noBg])
+
+  return (
+    <>
+      <Button
+        label={label}
+        onPress={e => {
+          e.preventDefault()
+          e.stopPropagation()
+          onPress()
+        }}>
+        {({hovered, pressed}) => (
+          <View
+            style={[
+              a.flex_row,
+              a.align_center,
+              a.rounded_full,
+              outer,
+              (hovered || pressed) && t.atoms.bg_contrast_50,
+            ]}>
+            <Text
+              emoji
+              style={[
+                text,
+                a.font_semi_bold,
+                a.leading_tight,
+                t.atoms.text_contrast_medium,
+                {paddingRight: 3},
+              ]}>
+              {label}
+            </Text>
+          </View>
+        )}
+      </Button>
+    </>
+  )
+}
+
 export function FollowsYou({size = 'sm'}: CommonProps) {
   const t = useTheme()
 

--- a/src/components/Pills.tsx
+++ b/src/components/Pills.tsx
@@ -93,7 +93,15 @@ export function Label({
 }
 
 export type LabelBaseProps = {
+  /**
+   * The accessibility label for the pill.
+   */
   label: string
+  /**
+   * The visible pill text. Defaults to `label`. Use this when the visible
+   * text is too terse to serve as the accessibility label, e.g. "+2".
+   */
+  cta?: string
   onPress: () => void
   disabled?: boolean
   noBg?: boolean
@@ -102,6 +110,7 @@ export type LabelBaseProps = {
 
 export function LabelBase({
   label,
+  cta = label,
   onPress,
   disabled,
   size = 'sm',
@@ -171,7 +180,7 @@ export function LabelBase({
               t.atoms.text_contrast_medium,
               {paddingRight: 3},
             ]}>
-            {label}
+            {cta}
           </Text>
         </View>
       )}

--- a/src/components/Pills.tsx
+++ b/src/components/Pills.tsx
@@ -66,83 +66,24 @@ export function Label({
   const isLabeler = Boolean(desc.sourceType && desc.sourceDid)
   const isBlueskyLabel =
     desc.sourceType === 'labeler' && desc.sourceDid === BSKY_LABELER_DID
-
-  const {outer, avi, text} = useMemo(() => {
-    switch (size) {
-      case 'lg': {
-        return {
-          outer: [
-            t.atoms.bg_contrast_25,
-            {
-              gap: 5,
-              paddingHorizontal: 5,
-              paddingVertical: 5,
-            },
-          ],
-          avi: 16,
-          text: [a.text_sm],
-        }
-      }
-      case 'sm':
-      default: {
-        return {
-          outer: [
-            !noBg && t.atoms.bg_contrast_25,
-            {
-              gap: 3,
-              paddingHorizontal: 3,
-              paddingVertical: 3,
-            },
-          ],
-          avi: 12,
-          text: [a.text_xs],
-        }
-      }
-    }
-  }, [t, size, noBg])
+  const avi = size === 'lg' ? 16 : 12
 
   return (
     <>
-      <Button
-        disabled={disableDetailsDialog}
+      <LabelBase
         label={desc.name}
-        onPress={e => {
-          e.preventDefault()
-          e.stopPropagation()
-          control.open()
-        }}>
-        {({hovered, pressed}) => (
-          <View
-            style={[
-              a.flex_row,
-              a.align_center,
-              a.rounded_full,
-              outer,
-              (hovered || pressed) && t.atoms.bg_contrast_50,
-            ]}>
-            {isBlueskyLabel || !isLabeler ? (
-              <desc.icon
-                width={avi}
-                fill={t.atoms.text_contrast_medium.color}
-              />
-            ) : (
-              <UserAvatar avatar={desc.sourceAvi} type="user" size={avi} />
-            )}
-
-            <Text
-              emoji
-              style={[
-                text,
-                a.font_semi_bold,
-                a.leading_tight,
-                t.atoms.text_contrast_medium,
-                {paddingRight: 3},
-              ]}>
-              {desc.name}
-            </Text>
-          </View>
-        )}
-      </Button>
+        size={size}
+        noBg={noBg}
+        disabled={disableDetailsDialog}
+        onPress={() => control.open()}
+        icon={
+          isBlueskyLabel || !isLabeler ? (
+            <desc.icon width={avi} fill={t.atoms.text_contrast_medium.color} />
+          ) : (
+            <UserAvatar avatar={desc.sourceAvi} type="user" size={avi} />
+          )
+        }
+      />
 
       {!disableDetailsDialog && (
         <ModerationDetailsDialog control={control} modcause={cause} />
@@ -154,10 +95,19 @@ export function Label({
 export type LabelBaseProps = {
   label: string
   onPress: () => void
+  disabled?: boolean
   noBg?: boolean
+  icon?: React.ReactNode
 } & CommonProps
 
-export function LabelBase({label, onPress, size = 'sm', noBg}: LabelBaseProps) {
+export function LabelBase({
+  label,
+  onPress,
+  disabled,
+  size = 'sm',
+  noBg,
+  icon,
+}: LabelBaseProps) {
   const t = useTheme()
 
   const {outer, text} = useMemo(() => {
@@ -193,38 +143,39 @@ export function LabelBase({label, onPress, size = 'sm', noBg}: LabelBaseProps) {
   }, [t, size, noBg])
 
   return (
-    <>
-      <Button
-        label={label}
-        onPress={e => {
-          e.preventDefault()
-          e.stopPropagation()
-          onPress()
-        }}>
-        {({hovered, pressed}) => (
-          <View
+    <Button
+      disabled={disabled}
+      label={label}
+      onPress={e => {
+        e.preventDefault()
+        e.stopPropagation()
+        onPress()
+      }}>
+      {({hovered, pressed}) => (
+        <View
+          style={[
+            a.flex_row,
+            a.align_center,
+            a.rounded_full,
+            outer,
+            (hovered || pressed) && t.atoms.bg_contrast_50,
+          ]}>
+          {icon}
+
+          <Text
+            emoji
             style={[
-              a.flex_row,
-              a.align_center,
-              a.rounded_full,
-              outer,
-              (hovered || pressed) && t.atoms.bg_contrast_50,
+              text,
+              a.font_semi_bold,
+              a.leading_tight,
+              t.atoms.text_contrast_medium,
+              {paddingRight: 3},
             ]}>
-            <Text
-              emoji
-              style={[
-                text,
-                a.font_semi_bold,
-                a.leading_tight,
-                t.atoms.text_contrast_medium,
-                {paddingRight: 3},
-              ]}>
-              {label}
-            </Text>
-          </View>
-        )}
-      </Button>
-    </>
+            {label}
+          </Text>
+        </View>
+      )}
+    </Button>
   )
 }
 

--- a/src/components/Post/Embed/index.tsx
+++ b/src/components/Post/Embed/index.tsx
@@ -321,7 +321,11 @@ export function QuoteEmbed({
         linkDisabled
       />
       {moderation ? (
-        <PostAlerts modui={moderation.ui('contentView')} style={[a.py_xs]} />
+        <PostAlerts
+          post={quote}
+          modui={moderation.ui('contentView')}
+          style={[a.py_xs]}
+        />
       ) : null}
       {richText ? (
         <RichText

--- a/src/components/moderation/AppealForm.tsx
+++ b/src/components/moderation/AppealForm.tsx
@@ -1,0 +1,162 @@
+import {useState} from 'react'
+import {View} from 'react-native'
+import {type ComAtprotoLabelDefs, ToolsOzoneReportDefs} from '@atproto/api'
+import {XRPCError} from '@atproto/api'
+import {msg} from '@lingui/core/macro'
+import {useLingui} from '@lingui/react'
+import {Trans} from '@lingui/react/macro'
+import {useMutation} from '@tanstack/react-query'
+
+import {useLabelSubject} from '#/lib/moderation'
+import {useLabelInfo} from '#/lib/moderation/useLabelInfo'
+import {makeProfileLink} from '#/lib/routes/links'
+import {sanitizeHandle} from '#/lib/strings/handles'
+import {logger} from '#/logger'
+import {useAgent} from '#/state/session'
+import {atoms as a, useBreakpoints} from '#/alf'
+import {Admonition} from '#/components/Admonition'
+import {Button, ButtonIcon, ButtonText} from '#/components/Button'
+import * as Dialog from '#/components/Dialog'
+import {InlineLinkText} from '#/components/Link'
+import {Loader} from '#/components/Loader'
+import * as Toast from '#/components/Toast'
+import {Text} from '#/components/Typography'
+import {IS_ANDROID} from '#/env'
+
+export function AppealForm({
+  label,
+  control,
+  onPressBack,
+}: {
+  label: ComAtprotoLabelDefs.Label
+  control: Dialog.DialogOuterProps['control']
+  onPressBack: () => void
+}) {
+  const {_} = useLingui()
+  const {labeler, strings} = useLabelInfo(label)
+  const {gtMobile} = useBreakpoints()
+  const [details, setDetails] = useState('')
+  const {subject} = useLabelSubject({label})
+  const isAccountReport = 'did' in subject
+  const agent = useAgent()
+  const sourceName = labeler
+    ? sanitizeHandle(labeler.creator.handle, '@')
+    : label.src
+  const [error, setError] = useState<string | null>(null)
+
+  const {mutate, isPending} = useMutation({
+    mutationFn: async () => {
+      const $type = !isAccountReport
+        ? 'com.atproto.repo.strongRef'
+        : 'com.atproto.admin.defs#repoRef'
+      await agent.createModerationReport(
+        {
+          reasonType: ToolsOzoneReportDefs.REASONAPPEAL,
+          subject: {
+            $type,
+            ...subject,
+          },
+          reason: details,
+        },
+        {
+          encoding: 'application/json',
+          headers: {
+            'atproto-proxy': `${label.src}#atproto_labeler`,
+          },
+        },
+      )
+    },
+    onError: err => {
+      if (err instanceof XRPCError && err.error === 'AlreadyAppealed') {
+        setError(
+          _(
+            msg`You've already appealed this label and it's being reviewed by our moderation team.`,
+          ),
+        )
+      } else {
+        setError(_(msg`Failed to submit appeal, please try again.`))
+      }
+      logger.error('Failed to submit label appeal', {message: err})
+    },
+    onSuccess: () => {
+      control.close()
+      Toast.show(_(msg({message: 'Appeal submitted', context: 'toast'})))
+    },
+  })
+
+  const onSubmit = () => mutate()
+
+  return (
+    <>
+      <View>
+        <Text style={[a.text_2xl, a.font_semi_bold, a.pb_xs, a.leading_tight]}>
+          <Trans>Appeal "{strings.name}" label</Trans>
+        </Text>
+        <Text style={[a.text_md, a.leading_snug]}>
+          <Trans>
+            This appeal will be sent to{' '}
+            <InlineLinkText
+              label={sourceName}
+              to={makeProfileLink(
+                labeler ? labeler.creator : {did: label.src, handle: ''},
+              )}
+              onPress={() => control.close()}
+              style={[a.text_md, a.leading_snug]}>
+              {sourceName}
+            </InlineLinkText>
+            .
+          </Trans>
+        </Text>
+      </View>
+      {error && (
+        <Admonition type="error" style={[a.mt_sm]}>
+          {error}
+        </Admonition>
+      )}
+      <View style={[a.my_md]}>
+        <Dialog.Input
+          label={_(msg`Text input field`)}
+          placeholder={_(
+            msg`Please explain why you think this label was incorrectly applied by ${
+              labeler ? sanitizeHandle(labeler.creator.handle, '@') : label.src
+            }`,
+          )}
+          value={details}
+          onChangeText={setDetails}
+          autoFocus={true}
+          numberOfLines={3}
+          multiline
+          maxLength={300}
+        />
+      </View>
+
+      <View
+        style={
+          gtMobile
+            ? [a.flex_row, a.justify_between]
+            : [{flexDirection: 'column-reverse'}, a.gap_sm]
+        }>
+        <Button
+          testID="backBtn"
+          variant="solid"
+          color="secondary"
+          size="large"
+          onPress={onPressBack}
+          label={_(msg`Back`)}>
+          <ButtonText>{_(msg`Back`)}</ButtonText>
+        </Button>
+        <Button
+          testID="submitBtn"
+          variant="solid"
+          color="primary"
+          size="large"
+          onPress={onSubmit}
+          label={_(msg`Submit`)}>
+          <ButtonText>{_(msg`Submit`)}</ButtonText>
+          {isPending && <ButtonIcon icon={Loader} />}
+        </Button>
+      </View>
+      {IS_ANDROID && <View style={{height: 300}} />}
+    </>
+  )
+}

--- a/src/components/moderation/LabelsOnMe.tsx
+++ b/src/components/moderation/LabelsOnMe.tsx
@@ -1,5 +1,5 @@
 import {type StyleProp, View, type ViewStyle} from 'react-native'
-import {type AppBskyFeedDefs, type ComAtprotoLabelDefs} from '@atproto/api'
+import {type ComAtprotoLabelDefs} from '@atproto/api'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Plural} from '@lingui/react/macro'
@@ -19,12 +19,10 @@ import {
 } from '#/components/moderation/LabelsOnMeDialog'
 
 export function LabelsOnMe({
-  type,
   labels,
   size,
   style,
 }: {
-  type: 'account' | 'content'
   labels: ComAtprotoLabelDefs.Label[] | undefined
   size?: ButtonSize
   style?: StyleProp<ViewStyle>
@@ -47,7 +45,7 @@ export function LabelsOnMe({
 
   return (
     <View style={[a.flex_row, style]}>
-      <LabelsOnMeDialog control={control} labels={labels} type={type} />
+      <LabelsOnMeDialog control={control} labels={labels} type="account" />
 
       <Button
         variant="solid"
@@ -59,37 +57,13 @@ export function LabelsOnMe({
         }}>
         <ButtonIcon position="left" icon={CircleInfo} />
         <ButtonText style={[a.leading_snug]}>
-          {type === 'account' ? (
-            <Plural
-              value={labels.length}
-              one="# account label"
-              other="# account labels"
-            />
-          ) : (
-            <Plural
-              value={labels.length}
-              one="# content label"
-              other="# content labels"
-            />
-          )}
+          <Plural
+            value={labels.length}
+            one="# account label"
+            other="# account labels"
+          />
         </ButtonText>
       </Button>
     </View>
-  )
-}
-
-export function LabelsOnMyPost({
-  post,
-  style,
-}: {
-  post: AppBskyFeedDefs.PostView
-  style?: StyleProp<ViewStyle>
-}) {
-  const {currentAccount} = useSession()
-  if (post.author.did !== currentAccount?.did) {
-    return null
-  }
-  return (
-    <LabelsOnMe type="content" labels={post.labels} size="tiny" style={style} />
   )
 }

--- a/src/components/moderation/LabelsOnMe.tsx
+++ b/src/components/moderation/LabelsOnMe.tsx
@@ -4,6 +4,7 @@ import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Plural} from '@lingui/react/macro'
 
+import {filterUserFacingLabels} from '#/lib/moderation'
 import {useSession} from '#/state/session'
 import {atoms as a} from '#/alf'
 import {
@@ -34,11 +35,7 @@ export function LabelsOnMe({
   if (!labels || !currentAccount) {
     return null
   }
-  labels = labels.filter(
-    l =>
-      !l.val.startsWith('!') &&
-      !(l.val === 'bot' && l.src === currentAccount.did),
-  )
+  labels = filterUserFacingLabels(labels, currentAccount.did)
   if (!labels.length) {
     return null
   }

--- a/src/components/moderation/LabelsOnMeDialog.tsx
+++ b/src/components/moderation/LabelsOnMeDialog.tsx
@@ -1,29 +1,22 @@
-import {useCallback, useMemo, useState} from 'react'
+import {useMemo, useState} from 'react'
 import {View} from 'react-native'
-import {type ComAtprotoLabelDefs, ToolsOzoneReportDefs} from '@atproto/api'
-import {XRPCError} from '@atproto/api'
+import {type ComAtprotoLabelDefs} from '@atproto/api'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
-import {useMutation} from '@tanstack/react-query'
 
 import {useGetTimeAgo} from '#/lib/hooks/useTimeAgo'
-import {useLabelSubject} from '#/lib/moderation'
 import {useLabelInfo} from '#/lib/moderation/useLabelInfo'
 import {makeProfileLink} from '#/lib/routes/links'
 import {sanitizeHandle} from '#/lib/strings/handles'
-import {logger} from '#/logger'
-import {useAgent, useSession} from '#/state/session'
-import {atoms as a, useBreakpoints, useTheme} from '#/alf'
-import {Button, ButtonIcon, ButtonText} from '#/components/Button'
+import {useSession} from '#/state/session'
+import {atoms as a, useTheme} from '#/alf'
+import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import {InlineLinkText} from '#/components/Link'
-import * as Toast from '#/components/Toast'
+import {AppealForm} from '#/components/moderation/AppealForm'
 import {Text} from '#/components/Typography'
-import {IS_ANDROID} from '#/env'
-import {Admonition} from '../Admonition'
 import {Divider} from '../Divider'
-import {Loader} from '../Loader'
 
 export {useDialogControl as useLabelsOnMeDialogControl} from '#/components/Dialog'
 
@@ -209,143 +202,5 @@ function Label({
         )}
       </View>
     </View>
-  )
-}
-
-function AppealForm({
-  label,
-  control,
-  onPressBack,
-}: {
-  label: ComAtprotoLabelDefs.Label
-  control: Dialog.DialogOuterProps['control']
-  onPressBack: () => void
-}) {
-  const {_} = useLingui()
-  const {labeler, strings} = useLabelInfo(label)
-  const {gtMobile} = useBreakpoints()
-  const [details, setDetails] = useState('')
-  const {subject} = useLabelSubject({label})
-  const isAccountReport = 'did' in subject
-  const agent = useAgent()
-  const sourceName = labeler
-    ? sanitizeHandle(labeler.creator.handle, '@')
-    : label.src
-  const [error, setError] = useState<string | null>(null)
-
-  const {mutate, isPending} = useMutation({
-    mutationFn: async () => {
-      const $type = !isAccountReport
-        ? 'com.atproto.repo.strongRef'
-        : 'com.atproto.admin.defs#repoRef'
-      await agent.createModerationReport(
-        {
-          reasonType: ToolsOzoneReportDefs.REASONAPPEAL,
-          subject: {
-            $type,
-            ...subject,
-          },
-          reason: details,
-        },
-        {
-          encoding: 'application/json',
-          headers: {
-            'atproto-proxy': `${label.src}#atproto_labeler`,
-          },
-        },
-      )
-    },
-    onError: err => {
-      if (err instanceof XRPCError && err.error === 'AlreadyAppealed') {
-        setError(
-          _(
-            msg`You've already appealed this label and it's being reviewed by our moderation team.`,
-          ),
-        )
-      } else {
-        setError(_(msg`Failed to submit appeal, please try again.`))
-      }
-      logger.error('Failed to submit label appeal', {message: err})
-    },
-    onSuccess: () => {
-      control.close()
-      Toast.show(_(msg({message: 'Appeal submitted', context: 'toast'})))
-    },
-  })
-
-  const onSubmit = useCallback(() => mutate(), [mutate])
-
-  return (
-    <>
-      <View>
-        <Text style={[a.text_2xl, a.font_semi_bold, a.pb_xs, a.leading_tight]}>
-          <Trans>Appeal "{strings.name}" label</Trans>
-        </Text>
-        <Text style={[a.text_md, a.leading_snug]}>
-          <Trans>
-            This appeal will be sent to{' '}
-            <InlineLinkText
-              label={sourceName}
-              to={makeProfileLink(
-                labeler ? labeler.creator : {did: label.src, handle: ''},
-              )}
-              onPress={() => control.close()}
-              style={[a.text_md, a.leading_snug]}>
-              {sourceName}
-            </InlineLinkText>
-            .
-          </Trans>
-        </Text>
-      </View>
-      {error && (
-        <Admonition type="error" style={[a.mt_sm]}>
-          {error}
-        </Admonition>
-      )}
-      <View style={[a.my_md]}>
-        <Dialog.Input
-          label={_(msg`Text input field`)}
-          placeholder={_(
-            msg`Please explain why you think this label was incorrectly applied by ${
-              labeler ? sanitizeHandle(labeler.creator.handle, '@') : label.src
-            }`,
-          )}
-          value={details}
-          onChangeText={setDetails}
-          autoFocus={true}
-          numberOfLines={3}
-          multiline
-          maxLength={300}
-        />
-      </View>
-
-      <View
-        style={
-          gtMobile
-            ? [a.flex_row, a.justify_between]
-            : [{flexDirection: 'column-reverse'}, a.gap_sm]
-        }>
-        <Button
-          testID="backBtn"
-          variant="solid"
-          color="secondary"
-          size="large"
-          onPress={onPressBack}
-          label={_(msg`Back`)}>
-          <ButtonText>{_(msg`Back`)}</ButtonText>
-        </Button>
-        <Button
-          testID="submitBtn"
-          variant="solid"
-          color="primary"
-          size="large"
-          onPress={onSubmit}
-          label={_(msg`Submit`)}>
-          <ButtonText>{_(msg`Submit`)}</ButtonText>
-          {isPending && <ButtonIcon icon={Loader} />}
-        </Button>
-      </View>
-      {IS_ANDROID && <View style={{height: 300}} />}
-    </>
   )
 }

--- a/src/components/moderation/LabelsOnMeDialog.tsx
+++ b/src/components/moderation/LabelsOnMeDialog.tsx
@@ -152,7 +152,7 @@ function Label({
             {strings.description}
           </Text>
           {showAccountCallout && (
-            <Admonition type="info" style={[a.mt_xs]}>
+            <Admonition type="info" style={[a.mt_sm]}>
               <Trans>
                 This label was applied to the entire user account and will
                 appear on all posts.

--- a/src/components/moderation/LabelsOnMeDialog.tsx
+++ b/src/components/moderation/LabelsOnMeDialog.tsx
@@ -11,6 +11,7 @@ import {makeProfileLink} from '#/lib/routes/links'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {useSession} from '#/state/session'
 import {atoms as a, useTheme} from '#/alf'
+import {Admonition} from '#/components/Admonition'
 import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import {InlineLinkText} from '#/components/Link'
@@ -23,6 +24,11 @@ export {useDialogControl as useLabelsOnMeDialogControl} from '#/components/Dialo
 export interface LabelsOnMeDialogProps {
   control: Dialog.DialogOuterProps['control']
   labels: ComAtprotoLabelDefs.Label[]
+  /**
+   * Whether the labels are being shown on the user's account or on a post.
+   * With `content`, the list may include account-level labels, which get a
+   * per-label callout.
+   */
   type: 'account' | 'content'
 }
 
@@ -55,7 +61,7 @@ function LabelsOnMeDialogInner(props: LabelsOnMeDialogProps) {
       label={
         isAccount
           ? _(msg`The following labels were applied to your account.`)
-          : _(msg`The following labels were applied to your content.`)
+          : _(msg`The following labels were applied to this post.`)
       }>
       {appealingLabel ? (
         <AppealForm
@@ -69,7 +75,7 @@ function LabelsOnMeDialogInner(props: LabelsOnMeDialogProps) {
             {isAccount ? (
               <Trans>Labels on your account</Trans>
             ) : (
-              <Trans>Labels on your content</Trans>
+              <Trans>Labels applied to this post</Trans>
             )}
           </Text>
           <Text style={[a.text_md, a.leading_snug]}>
@@ -89,9 +95,10 @@ function LabelsOnMeDialogInner(props: LabelsOnMeDialogProps) {
           <View style={[a.py_lg, a.gap_md]}>
             {labels.map(label => (
               <Label
-                key={`${label.val}-${label.src}`}
+                key={`${label.val}-${label.src}-${label.uri}`}
                 label={label}
                 isSelfLabel={label.src === currentAccount?.did}
+                showAccountCallout={!isAccount && label.uri.startsWith('did:')}
                 control={props.control}
                 onPressAppeal={setAppealingLabel}
               />
@@ -107,11 +114,17 @@ function LabelsOnMeDialogInner(props: LabelsOnMeDialogProps) {
 function Label({
   label,
   isSelfLabel,
+  showAccountCallout,
   control,
   onPressAppeal,
 }: {
   label: ComAtprotoLabelDefs.Label
   isSelfLabel: boolean
+  /**
+   * Call out that the label applies to the whole account, for contexts that
+   * mix account and content labels.
+   */
+  showAccountCallout?: boolean
   control: Dialog.DialogOuterProps['control']
   onPressAppeal: (label: ComAtprotoLabelDefs.Label) => void
 }) {
@@ -138,6 +151,14 @@ function Label({
           <Text emoji style={[t.atoms.text_contrast_medium, a.leading_snug]}>
             {strings.description}
           </Text>
+          {showAccountCallout && (
+            <Admonition type="info" style={[a.mt_xs]}>
+              <Trans>
+                This label was applied to the entire user account and will
+                appear on all posts.
+              </Trans>
+            </Admonition>
+          )}
         </View>
         {!isSelfLabel && (
           <View>

--- a/src/components/moderation/LabelsOnMeDialog.tsx
+++ b/src/components/moderation/LabelsOnMeDialog.tsx
@@ -164,7 +164,7 @@ function Label({
           <View>
             <Button
               variant="solid"
-              color="secondary"
+              color="primary_subtle"
               size="small"
               label={_(msg`Appeal`)}
               onPress={() => onPressAppeal(label)}>

--- a/src/components/moderation/ModerationDetailsDialog.tsx
+++ b/src/components/moderation/ModerationDetailsDialog.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react'
 import {View} from 'react-native'
 import {type ModerationCause} from '@atproto/api'
 import {msg} from '@lingui/core/macro'
@@ -11,8 +12,10 @@ import {listUriToHref} from '#/lib/strings/url-helpers'
 import {useSession} from '#/state/session'
 import {atoms as a, useGutters, useTheme, web} from '#/alf'
 import {Admonition} from '#/components/Admonition'
+import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import {InlineLinkText} from '#/components/Link'
+import {AppealForm} from '#/components/moderation/AppealForm'
 import {type AppModerationCause} from '#/components/Pills'
 import {Text} from '#/components/Typography'
 import {IS_NATIVE} from '#/env'
@@ -47,6 +50,18 @@ function ModerationDetailsDialogInner({
   const desc = useModerationCauseDescription(modcause)
   const {currentAccount} = useSession()
   const timeDiff = useGetTimeAgo({future: true})
+  const [isAppealing, setIsAppealing] = useState(false)
+
+  /*
+   * Appeal eligibility: only for label causes on content belonging to the
+   * current user, where the label was not self-applied.
+   */
+  const canAppeal =
+    modcause?.type === 'label' &&
+    !!currentAccount &&
+    modcause.label.src !== currentAccount.did &&
+    (modcause.label.uri === currentAccount.did ||
+      modcause.label.uri.startsWith(`at://${currentAccount.did}/`))
 
   let name
   let description
@@ -136,6 +151,23 @@ function ModerationDetailsDialogInner({
 
   const sourceName =
     desc.source || desc.sourceDisplayName || _(msg`an unknown labeler`)
+
+  if (isAppealing && modcause?.type === 'label') {
+    return (
+      <Dialog.ScrollableInner
+        label={_(msg`Appeal label`)}
+        style={web({
+          maxWidth: 460,
+        })}>
+        <AppealForm
+          label={modcause.label}
+          control={control}
+          onPressBack={() => setIsAppealing(false)}
+        />
+        <Dialog.Close />
+      </Dialog.ScrollableInner>
+    )
+  }
 
   return (
     <Dialog.ScrollableInner
@@ -228,6 +260,20 @@ function ModerationDetailsDialogInner({
                   </View>
                 )}
               </View>
+              {canAppeal && (
+                <View style={[a.flex_row, a.justify_end, a.mt_sm]}>
+                  <Button
+                    variant="solid"
+                    color="secondary"
+                    size="small"
+                    label={_(msg`Appeal this label`)}
+                    onPress={() => setIsAppealing(true)}>
+                    <ButtonText>
+                      <Trans>Appeal</Trans>
+                    </ButtonText>
+                  </Button>
+                </View>
+              )}
             </>
           )}
         </View>

--- a/src/components/moderation/ModerationDetailsDialog.tsx
+++ b/src/components/moderation/ModerationDetailsDialog.tsx
@@ -10,7 +10,7 @@ import {useModerationCauseDescription} from '#/lib/moderation/useModerationCause
 import {makeProfileLink} from '#/lib/routes/links'
 import {listUriToHref} from '#/lib/strings/url-helpers'
 import {useSession} from '#/state/session'
-import {atoms as a, useGutters, useTheme, web} from '#/alf'
+import {atoms as a, useBreakpoints, useGutters, useTheme, web} from '#/alf'
 import {Admonition} from '#/components/Admonition'
 import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
@@ -51,6 +51,7 @@ function ModerationDetailsDialogInner({
   const {currentAccount} = useSession()
   const timeDiff = useGetTimeAgo({future: true})
   const [isAppealing, setIsAppealing] = useState(false)
+  const {gtPhone} = useBreakpoints()
 
   /*
    * Appeal eligibility: only for label causes on content belonging to the
@@ -192,14 +193,20 @@ function ModerationDetailsDialogInner({
           <View
             style={[
               a.flex_row,
-              a.justify_start,
+              a.flex_wrap,
+              a.gap_sm,
               a.pt_md,
               a.pb_xs,
               a.mt_md,
               a.border_t,
               t.atoms.border_contrast_low,
             ]}>
-            <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+            <Text
+              style={[
+                a.text_sm,
+                t.atoms.text_contrast_medium,
+                gtPhone ? a.flex_1 : a.w_full,
+              ]}>
               <Trans>
                 You may appeal these labels if you feel they were placed in
                 error.
@@ -210,6 +217,7 @@ function ModerationDetailsDialogInner({
               color="primary_subtle"
               size="small"
               label={_(msg`Appeal this label`)}
+              style={[gtPhone ? undefined : a.w_full]}
               onPress={() => setIsAppealing(true)}>
               <ButtonText>
                 <Trans>Appeal</Trans>

--- a/src/components/moderation/ModerationDetailsDialog.tsx
+++ b/src/components/moderation/ModerationDetailsDialog.tsx
@@ -191,8 +191,8 @@ function ModerationDetailsDialogInner({
         {desc.isSubjectAccount && (
           <Admonition type="info" style={[a.mt_md]}>
             <Trans>
-              This moderation was applied to the entire user account and will
-              appear on all posts.
+              This label was applied to the entire user account and will appear
+              on all posts.
             </Trans>
           </Admonition>
         )}

--- a/src/components/moderation/ModerationDetailsDialog.tsx
+++ b/src/components/moderation/ModerationDetailsDialog.tsx
@@ -188,6 +188,36 @@ function ModerationDetailsDialogInner({
           {description}
         </Text>
 
+        {canAppeal && (
+          <View
+            style={[
+              a.flex_row,
+              a.justify_start,
+              a.pt_md,
+              a.pb_xs,
+              a.mt_md,
+              a.border_t,
+              t.atoms.border_contrast_low,
+            ]}>
+            <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+              <Trans>
+                You may appeal these labels if you feel they were placed in
+                error.
+              </Trans>
+            </Text>
+            <Button
+              variant="solid"
+              color="primary_subtle"
+              size="small"
+              label={_(msg`Appeal this label`)}
+              onPress={() => setIsAppealing(true)}>
+              <ButtonText>
+                <Trans>Appeal</Trans>
+              </ButtonText>
+            </Button>
+          </View>
+        )}
+
         {desc.isSubjectAccount && (
           <Admonition type="info" style={[a.mt_md]}>
             <Trans>
@@ -260,20 +290,6 @@ function ModerationDetailsDialogInner({
                   </View>
                 )}
               </View>
-              {canAppeal && (
-                <View style={[a.flex_row, a.justify_end, a.mt_sm]}>
-                  <Button
-                    variant="solid"
-                    color="secondary"
-                    size="small"
-                    label={_(msg`Appeal this label`)}
-                    onPress={() => setIsAppealing(true)}>
-                    <ButtonText>
-                      <Trans>Appeal</Trans>
-                    </ButtonText>
-                  </Button>
-                </View>
-              )}
             </>
           )}
         </View>

--- a/src/components/moderation/PostAlerts.tsx
+++ b/src/components/moderation/PostAlerts.tsx
@@ -33,15 +33,13 @@ export function PostAlerts({
 }) {
   const {currentAccount} = useSession()
 
-  if (!modui.alert && !modui.inform && !additionalCauses?.length) {
-    return null
-  }
-
   const alerts = modui.alerts.filter(unique)
   const informs = modui.informs.filter(unique)
   /*
    * The "+n" pill surfaces labels for the author to review and appeal, so it
-   * only applies when the viewer is the author.
+   * only applies when the viewer is the author. It renders even when no other
+   * moderation is visible, since it may be the author's only entry point to
+   * appeal labels on their content.
    */
   const isOwnPost = !!post && post.author.did === currentAccount?.did
   const allLabels: ComAtprotoLabelDefs.Label[] = isOwnPost
@@ -66,6 +64,15 @@ export function PostAlerts({
           cause.label.uri !== label.uri,
       ),
   )
+
+  if (
+    !modui.alert &&
+    !modui.inform &&
+    !additionalCauses?.length &&
+    !additionalLabels.length
+  ) {
+    return null
+  }
 
   return (
     <Pills.Row size={size} style={[size === 'sm' && {marginLeft: -3}, style]}>
@@ -94,7 +101,15 @@ export function PostAlerts({
         />
       ))}
       {additionalLabels.length ? (
-        <AdditionalLabels labels={additionalLabels} size={size} />
+        <AdditionalLabels
+          labels={additionalLabels}
+          size={size}
+          hasPrecedingPills={
+            alerts.length > 0 ||
+            informs.length > 0 ||
+            (additionalCauses?.length ?? 0) > 0
+          }
+        />
       ) : null}
     </Pills.Row>
   )
@@ -103,9 +118,15 @@ export function PostAlerts({
 function AdditionalLabels({
   labels,
   size,
+  hasPrecedingPills,
 }: {
   labels: ComAtprotoLabelDefs.Label[]
   size?: Pills.CommonProps['size']
+  /**
+   * The compact "+n" syntax only makes sense as a continuation of other
+   * pills. When this pill stands alone, spell it out.
+   */
+  hasPrecedingPills: boolean
 }) {
   const {t: l} = useLingui()
   const control = useLabelsOnMeDialogControl()
@@ -115,7 +136,14 @@ function AdditionalLabels({
       <LabelsOnMeDialog control={control} labels={labels} type="content" />
 
       <Pills.LabelBase
-        label={l`+${plural(labels.length, {one: '#', other: '#'})}`}
+        label={
+          hasPrecedingPills
+            ? l`+${labels.length}`
+            : l`${plural(labels.length, {
+                one: '# label applied',
+                other: '# labels applied',
+              })}`
+        }
         size={size}
         noBg={size === 'sm'}
         onPress={() => {

--- a/src/components/moderation/PostAlerts.tsx
+++ b/src/components/moderation/PostAlerts.tsx
@@ -24,31 +24,38 @@ import * as Pills from '#/components/Pills'
 export function PostAlerts({
   post,
   modui,
-  size = 'sm',
+  view = 'compact',
   style,
   additionalCauses,
 }: {
   post?: AppBskyFeedDefs.PostView
   modui: ModerationUI
-  size?: Pills.CommonProps['size']
+  /**
+   * Expanded views (e.g. the thread anchor post) render larger pills and
+   * surface the "+n" additional labels pill. Compact views (feeds, replies)
+   * keep the alerts minimal.
+   */
+  view?: 'expanded' | 'compact'
   includeMute?: boolean
   style?: StyleProp<ViewStyle>
   additionalCauses?: ModerationCause[] | Pills.AppModerationCause[]
 }) {
   const {currentAccount} = useSession()
+  const size: Pills.CommonProps['size'] = view === 'expanded' ? 'lg' : 'sm'
 
   const alerts = modui.alerts.filter(unique)
   const informs = modui.informs.filter(unique)
   /*
    * The "+n" pill surfaces labels for the author to review and appeal, so it
-   * only applies when the viewer is the author. It renders even when no other
-   * moderation is visible, since it may be the author's only entry point to
-   * appeal labels on their content.
+   * only applies when the viewer is the author, and only in expanded views.
+   * It renders even when no other moderation is visible, since it may be the
+   * author's only entry point to appeal labels on their content.
    */
   const isOwnPost = !!post && post.author.did === currentAccount?.did
-  const allLabels: ComAtprotoLabelDefs.Label[] = isOwnPost
-    ? [...(post.labels ?? []), ...(post.author.labels ?? [])]
-    : []
+  const allLabels: ComAtprotoLabelDefs.Label[] =
+    isOwnPost && view === 'expanded'
+      ? [...(post.labels ?? []), ...(post.author.labels ?? [])]
+      : []
   /*
    * Labels that the moderation system already surfaces in this context -
    * whether as an alert, an inform, or a blur handled by ContentHider - should

--- a/src/components/moderation/PostAlerts.tsx
+++ b/src/components/moderation/PostAlerts.tsx
@@ -31,13 +31,41 @@ export function PostAlerts({
   style?: StyleProp<ViewStyle>
   additionalCauses?: ModerationCause[] | Pills.AppModerationCause[]
 }) {
+  const {currentAccount} = useSession()
+
   if (!modui.alert && !modui.inform && !additionalCauses?.length) {
     return null
   }
 
+  const alerts = modui.alerts.filter(unique)
+  const informs = modui.informs.filter(unique)
+  /*
+   * The "+n" pill surfaces labels for the author to review and appeal, so it
+   * only applies when the viewer is the author.
+   */
+  const isOwnPost = !!post && post.author.did === currentAccount?.did
+  const allLabels: ComAtprotoLabelDefs.Label[] = isOwnPost
+    ? [...(post.labels ?? []), ...(post.author.labels ?? [])]
+    : []
+  /*
+   * Labels that the moderation system already surfaces in this context -
+   * whether as an alert, an inform, or a blur handled by ContentHider - should
+   * not be repeated in the "+n" pill.
+   */
+  const shownCauses = [...alerts, ...informs, ...modui.blurs]
+  const additionalLabels = allLabels.filter(label =>
+    shownCauses.every(
+      cause =>
+        cause.type !== 'label' ||
+        cause.label.val !== label.val ||
+        cause.label.src !== label.src ||
+        cause.label.uri !== label.uri,
+    ),
+  )
+
   return (
     <Pills.Row size={size} style={[size === 'sm' && {marginLeft: -3}, style]}>
-      {modui.alerts.filter(unique).map(cause => (
+      {alerts.map(cause => (
         <Pills.Label
           key={getModerationCauseKey(cause)}
           cause={cause}
@@ -45,7 +73,7 @@ export function PostAlerts({
           noBg={size === 'sm'}
         />
       ))}
-      {modui.informs.filter(unique).map(cause => (
+      {informs.map(cause => (
         <Pills.Label
           key={getModerationCauseKey(cause)}
           cause={cause}
@@ -61,8 +89,8 @@ export function PostAlerts({
           noBg={size === 'sm'}
         />
       ))}
-      {post?.labels?.length ? (
-        <AdditionalLabels labels={post.labels} size={size} />
+      {additionalLabels.length ? (
+        <AdditionalLabels labels={additionalLabels} size={size} />
       ) : null}
     </Pills.Row>
   )
@@ -96,7 +124,7 @@ function AdditionalLabels({
       <LabelsOnMeDialog control={control} labels={labels} type="content" />
 
       <Pills.LabelBase
-        label={l`+${plural(labels.length, {one: '# label', other: '# labels'})}`}
+        label={l`+${plural(labels.length, {one: '#', other: '#'})}`}
         size={size}
         noBg={size === 'sm'}
         onPress={() => {

--- a/src/components/moderation/PostAlerts.tsx
+++ b/src/components/moderation/PostAlerts.tsx
@@ -8,7 +8,11 @@ import {
 import {plural} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react/macro'
 
-import {getModerationCauseKey, unique} from '#/lib/moderation'
+import {
+  filterUserFacingLabels,
+  getModerationCauseKey,
+  unique,
+} from '#/lib/moderation'
 import {useSession} from '#/state/session'
 import {atoms as a} from '#/alf'
 import {
@@ -48,21 +52,20 @@ export function PostAlerts({
   /*
    * Labels that the moderation system already surfaces in this context -
    * whether as an alert, an inform, or a blur handled by ContentHider - should
-   * not be repeated in the "+n" pill. System labels and the author's own
-   * "bot" self-label are excluded the same way LabelsOnMe excludes them.
+   * not be repeated in the "+n" pill.
    */
   const shownCauses = [...alerts, ...informs, ...modui.blurs]
-  const additionalLabels = allLabels.filter(
-    label =>
-      !label.val.startsWith('!') &&
-      !(label.val === 'bot' && label.src === currentAccount?.did) &&
-      shownCauses.every(
-        cause =>
-          cause.type !== 'label' ||
-          cause.label.val !== label.val ||
-          cause.label.src !== label.src ||
-          cause.label.uri !== label.uri,
-      ),
+  const additionalLabels = filterUserFacingLabels(
+    allLabels,
+    currentAccount?.did,
+  ).filter(label =>
+    shownCauses.every(
+      cause =>
+        cause.type !== 'label' ||
+        cause.label.val !== label.val ||
+        cause.label.src !== label.src ||
+        cause.label.uri !== label.uri,
+    ),
   )
 
   if (

--- a/src/components/moderation/PostAlerts.tsx
+++ b/src/components/moderation/PostAlerts.tsx
@@ -1,15 +1,30 @@
-import {type StyleProp, type ViewStyle} from 'react-native'
-import {type ModerationCause, type ModerationUI} from '@atproto/api'
+import {type StyleProp, View, type ViewStyle} from 'react-native'
+import {
+  type AppBskyFeedDefs,
+  type ComAtprotoLabelDefs,
+  type ModerationCause,
+  type ModerationUI,
+} from '@atproto/api'
+import {plural} from '@lingui/core/macro'
+import {useLingui} from '@lingui/react/macro'
 
 import {getModerationCauseKey, unique} from '#/lib/moderation'
+import {useSession} from '#/state/session'
+import {atoms as a} from '#/alf'
+import {
+  LabelsOnMeDialog,
+  useLabelsOnMeDialogControl,
+} from '#/components/moderation/LabelsOnMeDialog'
 import * as Pills from '#/components/Pills'
 
 export function PostAlerts({
+  post,
   modui,
   size = 'sm',
   style,
   additionalCauses,
 }: {
+  post?: AppBskyFeedDefs.PostView
   modui: ModerationUI
   size?: Pills.CommonProps['size']
   includeMute?: boolean
@@ -46,6 +61,48 @@ export function PostAlerts({
           noBg={size === 'sm'}
         />
       ))}
+      {post?.labels?.length ? (
+        <AdditionalLabels labels={post.labels} size={size} />
+      ) : null}
     </Pills.Row>
+  )
+}
+
+function AdditionalLabels({
+  labels,
+  size,
+}: {
+  labels: ComAtprotoLabelDefs.Label[] | undefined
+  size?: Pills.CommonProps['size']
+}) {
+  const {t: l} = useLingui()
+  const {currentAccount} = useSession()
+  const control = useLabelsOnMeDialogControl()
+
+  if (!labels || !currentAccount) {
+    return null
+  }
+  labels = labels.filter(
+    l =>
+      !l.val.startsWith('!') &&
+      !(l.val === 'bot' && l.src === currentAccount.did),
+  )
+  if (!labels.length) {
+    return null
+  }
+
+  return (
+    <View style={[a.flex_row]}>
+      <LabelsOnMeDialog control={control} labels={labels} type="content" />
+
+      <Pills.LabelBase
+        label={l`+${plural(labels.length, {one: '# label', other: '# labels'})}`}
+        size={size}
+        noBg={size === 'sm'}
+        onPress={() => {
+          control.open()
+        }}
+      />
+    </View>
   )
 }

--- a/src/components/moderation/PostAlerts.tsx
+++ b/src/components/moderation/PostAlerts.tsx
@@ -50,17 +50,21 @@ export function PostAlerts({
   /*
    * Labels that the moderation system already surfaces in this context -
    * whether as an alert, an inform, or a blur handled by ContentHider - should
-   * not be repeated in the "+n" pill.
+   * not be repeated in the "+n" pill. System labels and the author's own
+   * "bot" self-label are excluded the same way LabelsOnMe excludes them.
    */
   const shownCauses = [...alerts, ...informs, ...modui.blurs]
-  const additionalLabels = allLabels.filter(label =>
-    shownCauses.every(
-      cause =>
-        cause.type !== 'label' ||
-        cause.label.val !== label.val ||
-        cause.label.src !== label.src ||
-        cause.label.uri !== label.uri,
-    ),
+  const additionalLabels = allLabels.filter(
+    label =>
+      !label.val.startsWith('!') &&
+      !(label.val === 'bot' && label.src === currentAccount?.did) &&
+      shownCauses.every(
+        cause =>
+          cause.type !== 'label' ||
+          cause.label.val !== label.val ||
+          cause.label.src !== label.src ||
+          cause.label.uri !== label.uri,
+      ),
   )
 
   return (
@@ -100,24 +104,11 @@ function AdditionalLabels({
   labels,
   size,
 }: {
-  labels: ComAtprotoLabelDefs.Label[] | undefined
+  labels: ComAtprotoLabelDefs.Label[]
   size?: Pills.CommonProps['size']
 }) {
   const {t: l} = useLingui()
-  const {currentAccount} = useSession()
   const control = useLabelsOnMeDialogControl()
-
-  if (!labels || !currentAccount) {
-    return null
-  }
-  labels = labels.filter(
-    l =>
-      !l.val.startsWith('!') &&
-      !(l.val === 'bot' && l.src === currentAccount.did),
-  )
-  if (!labels.length) {
-    return null
-  }
 
   return (
     <View style={[a.flex_row]}>

--- a/src/components/moderation/PostAlerts.tsx
+++ b/src/components/moderation/PostAlerts.tsx
@@ -136,7 +136,11 @@ function AdditionalLabels({
       <LabelsOnMeDialog control={control} labels={labels} type="content" />
 
       <Pills.LabelBase
-        label={
+        label={l`${plural(labels.length, {
+          one: '# label applied to your post',
+          other: '# labels applied to your post',
+        })}`}
+        cta={
           hasPrecedingPills
             ? l`+${labels.length}`
             : l`${plural(labels.length, {

--- a/src/lib/moderation.ts
+++ b/src/lib/moderation.ts
@@ -58,6 +58,21 @@ export function labelIsHideableOffense(
   return ['!hide', '!takedown'].includes(label.val)
 }
 
+/**
+ * Filters out labels that are not user-facing: system labels (val prefixed
+ * with `!`) and the user's own "bot" self-label.
+ */
+export function filterUserFacingLabels(
+  labels: ComAtprotoLabelDefs.Label[],
+  currentAccountDid: string | undefined,
+): ComAtprotoLabelDefs.Label[] {
+  return labels.filter(
+    label =>
+      !label.val.startsWith('!') &&
+      !(label.val === 'bot' && label.src === currentAccountDid),
+  )
+}
+
 export function getLabelingServiceTitle({
   displayName,
   handle,

--- a/src/screens/Messages/components/ChatListItem.tsx
+++ b/src/screens/Messages/components/ChatListItem.tsx
@@ -164,7 +164,6 @@ function DirectChatItem({
         isWithinLeftPanel ? null : (
           <PostAlerts
             modui={moderation.ui('contentList')}
-            size="sm"
             style={[a.pb_2xs, a.max_w_full, a.overflow_hidden]}
           />
         )

--- a/src/screens/Messages/components/MessageInputEmbed.tsx
+++ b/src/screens/Messages/components/MessageInputEmbed.tsx
@@ -240,6 +240,7 @@ function MessageInputPostEmbed({
           </View>
           <ContentHider modui={moderation.ui('contentView')}>
             <PostAlerts
+              post={post}
               modui={moderation.ui('contentView')}
               style={a.py_xs}
               size="sm"

--- a/src/screens/Messages/components/MessageInputEmbed.tsx
+++ b/src/screens/Messages/components/MessageInputEmbed.tsx
@@ -243,7 +243,6 @@ function MessageInputPostEmbed({
               post={post}
               modui={moderation.ui('contentView')}
               style={a.py_xs}
-              size="sm"
             />
             {rt.text && (
               <RichText

--- a/src/screens/PostThread/components/ThreadItemAnchor.tsx
+++ b/src/screens/PostThread/components/ThreadItemAnchor.tsx
@@ -390,7 +390,7 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
               <PostAlerts
                 post={post}
                 modui={moderation.ui('contentView')}
-                size="lg"
+                view="expanded"
                 includeMute
                 style={[a.pb_sm]}
                 additionalCauses={additionalPostAlerts}

--- a/src/screens/PostThread/components/ThreadItemAnchor.tsx
+++ b/src/screens/PostThread/components/ThreadItemAnchor.tsx
@@ -388,6 +388,7 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
               ignoreMute
               childContainerStyle={[a.pt_sm]}>
               <PostAlerts
+                post={post}
                 modui={moderation.ui('contentView')}
                 size="lg"
                 includeMute

--- a/src/screens/PostThread/components/ThreadItemAnchor.tsx
+++ b/src/screens/PostThread/components/ThreadItemAnchor.tsx
@@ -42,7 +42,6 @@ import {Trash_Stroke2_Corner0_Rounded as TrashIcon} from '#/components/icons/Tra
 import {GalleryBleed} from '#/components/images/Gallery'
 import {Link} from '#/components/Link'
 import {ContentHider} from '#/components/moderation/ContentHider'
-import {LabelsOnMyPost} from '#/components/moderation/LabelsOnMe'
 import {PostAlerts} from '#/components/moderation/PostAlerts'
 import {type AppModerationCause} from '#/components/Pills'
 import {Embed, PostEmbedViewContext} from '#/components/Post/Embed'
@@ -384,7 +383,6 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
             </View>
           </View>
           <View style={[a.pb_sm]}>
-            <LabelsOnMyPost post={post} style={[a.pb_sm]} />
             <ContentHider
               modui={moderation.ui('contentView')}
               ignoreMute

--- a/src/screens/PostThread/components/ThreadItemPost.tsx
+++ b/src/screens/PostThread/components/ThreadItemPost.tsx
@@ -310,6 +310,7 @@ const ThreadItemPostInner = memo(function ThreadItemPostInner({
                 ]}
               />
               <PostAlerts
+                post={post}
                 modui={moderation.ui('contentList')}
                 style={[a.pb_2xs]}
                 additionalCauses={additionalPostAlerts}

--- a/src/screens/PostThread/components/ThreadItemPost.tsx
+++ b/src/screens/PostThread/components/ThreadItemPost.tsx
@@ -36,7 +36,6 @@ import {
   GalleryBleed,
   maybeApplyGalleryOffsetStyles,
 } from '#/components/images/Gallery'
-import {LabelsOnMyPost} from '#/components/moderation/LabelsOnMe'
 import {PostAlerts} from '#/components/moderation/PostAlerts'
 import {PostHider} from '#/components/moderation/PostHider'
 import {type AppModerationCause} from '#/components/Pills'
@@ -310,7 +309,6 @@ const ThreadItemPostInner = memo(function ThreadItemPostInner({
                   }),
                 ]}
               />
-              <LabelsOnMyPost post={post} style={[a.pb_xs]} />
               <PostAlerts
                 modui={moderation.ui('contentList')}
                 style={[a.pb_2xs]}

--- a/src/screens/PostThread/components/ThreadItemTreePost.tsx
+++ b/src/screens/PostThread/components/ThreadItemTreePost.tsx
@@ -340,6 +340,7 @@ const ThreadItemTreePostInner = memo(function ThreadItemTreePostInner({
                 <ThreadItemTreeReplyChildReplyLine item={item} />
                 <View style={[a.flex_1, a.pl_2xs]}>
                   <PostAlerts
+                    post={post}
                     modui={moderation.ui('contentList')}
                     style={[a.pb_2xs]}
                     additionalCauses={additionalPostAlerts}

--- a/src/screens/PostThread/components/ThreadItemTreePost.tsx
+++ b/src/screens/PostThread/components/ThreadItemTreePost.tsx
@@ -33,7 +33,6 @@ import {DebugFieldDisplay} from '#/components/DebugFieldDisplay'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
 import {Trash_Stroke2_Corner0_Rounded as TrashIcon} from '#/components/icons/Trash'
 import {GalleryBleed} from '#/components/images/Gallery'
-import {LabelsOnMyPost} from '#/components/moderation/LabelsOnMe'
 import {PostAlerts} from '#/components/moderation/PostAlerts'
 import {PostHider} from '#/components/moderation/PostHider'
 import {type AppModerationCause} from '#/components/Pills'
@@ -340,7 +339,6 @@ const ThreadItemTreePostInner = memo(function ThreadItemTreePostInner({
               <View style={[a.flex_row]}>
                 <ThreadItemTreeReplyChildReplyLine item={item} />
                 <View style={[a.flex_1, a.pl_2xs]}>
-                  <LabelsOnMyPost post={post} style={[a.pb_2xs]} />
                   <PostAlerts
                     modui={moderation.ui('contentList')}
                     style={[a.pb_2xs]}

--- a/src/screens/Profile/Header/Shell.tsx
+++ b/src/screens/Profile/Header/Shell.tsx
@@ -228,7 +228,6 @@ let ProfileHeaderShell = ({
       {!isPlaceholderProfile &&
         (isMe ? (
           <LabelsOnMe
-            type="account"
             labels={profile.labels}
             style={[
               a.px_lg,

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -219,6 +219,7 @@ function PostInner({
               style={styles.contentHider}
               childContainerStyle={styles.contentHiderChild}>
               <PostAlerts
+                post={post}
                 modui={moderation.ui('contentView')}
                 style={[a.pb_xs]}
               />

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -30,7 +30,6 @@ import {
   maybeApplyGalleryOffsetStyles,
 } from '#/components/images/Gallery'
 import {ContentHider} from '#/components/moderation/ContentHider'
-import {LabelsOnMyPost} from '#/components/moderation/LabelsOnMe'
 import {PostAlerts} from '#/components/moderation/PostAlerts'
 import {Embed, PostEmbedViewContext} from '#/components/Post/Embed'
 import {PostRepliedTo} from '#/components/Post/PostRepliedTo'
@@ -215,7 +214,6 @@ function PostInner({
             {replyAuthorDid !== '' && (
               <PostRepliedTo parentAuthor={replyAuthorDid} />
             )}
-            <LabelsOnMyPost post={post} />
             <ContentHider
               modui={moderation.ui('contentView')}
               style={styles.contentHider}

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -493,6 +493,7 @@ let PostContent = ({
       ignoreMute
       childContainerStyle={styles.contentHiderChild}>
       <PostAlerts
+        post={post}
         modui={moderation.ui('contentList')}
         style={[a.pb_xs]}
         additionalCauses={additionalPostAlerts}

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -39,7 +39,6 @@ import {
   maybeApplyGalleryOffsetStyles,
 } from '#/components/images/Gallery'
 import {ContentHider} from '#/components/moderation/ContentHider'
-import {LabelsOnMyPost} from '#/components/moderation/LabelsOnMe'
 import {PostAlerts} from '#/components/moderation/PostAlerts'
 import {type AppModerationCause} from '#/components/Pills'
 import {Embed} from '#/components/Post/Embed'
@@ -420,7 +419,6 @@ let FeedItemInner = ({
                   isParentNotFound={isParentNotFound}
                 />
               )}
-            <LabelsOnMyPost post={post} />
             <PostContent
               moderation={moderation}
               richText={richText}


### PR DESCRIPTION
## Why

Labels on your own posts currently render twice: once as the normal label chips, and again as a "1 content label" pill whose only reason to exist is that its dialog carries the Appeal button. Clicking the label chip itself opens a read-only details popup with no appeal path, which is non-obvious ([slack thread](https://bluesky-builders.slack.com/archives/C063SSE1Z7H/p1783452555015729)). The extra pill also reads vaguely ominous for benign third-party labels.

## What

- `ModerationDetailsDialog` (opened by clicking any label chip) now shows an **Appeal** button in the source footer when the label targets the viewer's own account or content (`label.uri` is their DID or an `at://<did>/...` URI), was not self-applied, and there's a session. Pressing it swaps the dialog body to the appeal form; Back returns to details.
- Extracted `AppealForm` from `LabelsOnMeDialog.tsx` into `src/components/moderation/AppealForm.tsx` (behavior unchanged) so both dialogs share it.
- Removed the per-post `LabelsOnMyPost` pill from all 5 render sites (feed item, thread post/anchor/tree post, generic post). The appeal path is now the chip itself.
- `LabelsOnMe` is now account-only (its sole remaining caller is the profile header, which keeps the "N account labels" pill — account labels don't render as chips on your own profile, so that pill isn't redundant).

## Notes for review

- Eligibility keys off the label subject URI, so the Appeal button also appears when viewing an account-level label's details via regular chips — previously only reachable through the profile-header pill. Believed to be an improvement rather than a regression, but flagging as a deliberate behavior expansion.
- `LabelsOnMeDialog` keeps its `type: 'account' | 'content'` prop as-is; only the pill component was narrowed.
- Deliberate narrowing (flagged by review): the old pill read `post.labels` directly, so it surfaced an appeal path even for labels you've configured to “off” for a labeler you subscribe to. Those labels no longer render a chip, so they lose their per-post appeal entry point. (Labels from *unsubscribed* labelers are unaffected — they never arrive in `post.labels`, since the `atproto-accept-labelers` header is built from your subscribed labelers.) Accepting this: the user explicitly hid the label, and re-adding chrome for that case defeats the purpose of the PR. If it matters, the labeler settings surface is a better future home for it.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (34 suites / 623 tests) all green.
- No existing tests cover these components specifically.

### Before Screenshots
<img width="888" height="266" alt="before-content-label-pill" src="https://github.com/user-attachments/assets/aaa0e579-b2cc-4d73-bda2-da75ab34d1c1" />
<img width="906" height="366" alt="before-details-no-appeal" src="https://github.com/user-attachments/assets/e0bd442e-5d2a-44c6-a993-9a6523735a79" />
<img width="1256" height="506" alt="before-labels-on-me-dialog" src="https://github.com/user-attachments/assets/263ee4b1-c932-42be-a2dd-d80cd923e580" />

### After Screenshots

<img width="920" height="540" alt="after-appeal-form" src="https://github.com/user-attachments/assets/247cd2aa-81b0-4f83-9d2c-2df82decff7c" />
<img width="920" height="442" alt="after-details-appeal" src="https://github.com/user-attachments/assets/35d6463f-c3e7-447e-88ec-979462665733" />
<img width="1200" height="656" alt="after-post-no-pill" src="https://github.com/user-attachments/assets/acf7960f-72ac-44fb-95bc-1f62e9c812d1" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
