### PR TITLE
Add setting for opting in to beta features

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -103,28 +103,12 @@
       "count": 1
     }
   },
-  "src/analytics/features/index.ts": {
-    "@typescript-eslint/no-floating-promises": {
-      "count": 1
-    },
-    "@typescript-eslint/no-misused-promises": {
-      "count": 1
-    },
-    "@typescript-eslint/require-await": {
-      "count": 1
-    }
-  },
   "src/analytics/identifiers/session.test.ts": {
     "@typescript-eslint/no-unsafe-call": {
       "count": 9
     },
     "@typescript-eslint/no-unsafe-member-access": {
       "count": 9
-    }
-  },
-  "src/analytics/metadata.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
     }
   },
   "src/analytics/metrics/client.test.ts": {

--- a/package.json
+++ b/package.json
@@ -93,9 +93,9 @@
     "prettier": "prettier --check ."
   },
   "dependencies": {
-    "@atproto/api": "0.20.26",
-    "@atproto/common-web": "0.5.3",
-    "@atproto/syntax": "0.7.0",
+    "@atproto/api": "0.20.27",
+    "@atproto/common-web": "0.5.5",
+    "@atproto/syntax": "0.7.1",
     "@bitdrift/react-native": "^0.6.8",
     "@braintree/sanitize-url": "^6.0.2",
     "@bsky.app/alf": "^0.1.14",

--- a/package.json
+++ b/package.json
@@ -93,9 +93,9 @@
     "prettier": "prettier --check ."
   },
   "dependencies": {
-    "@atproto/api": "0.20.25",
+    "@atproto/api": "0.20.26",
     "@atproto/common-web": "0.5.3",
-    "@atproto/syntax": "0.6.4",
+    "@atproto/syntax": "0.7.0",
     "@bitdrift/react-native": "^0.6.8",
     "@braintree/sanitize-url": "^6.0.2",
     "@bsky.app/alf": "^0.1.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,14 +242,14 @@ importers:
   .:
     dependencies:
       '@atproto/api':
-        specifier: 0.20.26
-        version: 0.20.26
+        specifier: 0.20.27
+        version: 0.20.27
       '@atproto/common-web':
-        specifier: 0.5.3
-        version: 0.5.3
+        specifier: 0.5.5
+        version: 0.5.5
       '@atproto/syntax':
-        specifier: 0.7.0
-        version: 0.7.0
+        specifier: 0.7.1
+        version: 0.7.1
       '@bitdrift/react-native':
         specifier: ^0.6.8
         version: 0.6.14(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -880,40 +880,32 @@ packages:
       graphql:
         optional: true
 
-  '@atproto/api@0.20.26':
-    resolution: {integrity: sha512-l51hlQQxBlV5XWYat8S1mltIyReI2dZvkWcSQGaQl9DY0oMuONHJw/m1DMeyZ27Y5pyiBH+kAl4SP8X0n+gz/Q==}
+  '@atproto/api@0.20.27':
+    resolution: {integrity: sha512-RQbsxcGrgsYELf3hyed9ICpjnK65l2S+cn7VUZ1J2S1S3Y9J5WUQD4bOVR+CvSbH+a2nwIk0z3fbmi9Gd+rlfw==}
     engines: {node: '>=22'}
 
-  '@atproto/common-web@0.5.3':
-    resolution: {integrity: sha512-FkMhOcNv1y7r5984+zXB+uMN4zJ4QFLEbZrYyQo6bNCf/Kfav/pEHXXENlaZEOweq2NYXf+tr2giMssBuM9u5A==}
+  '@atproto/common-web@0.5.5':
+    resolution: {integrity: sha512-Cd56SwEW4XQpW9Sz6O6LZAhv2hZ09ENl3rqPtzAidiCTSoeGRU5WjcVaSc8xPUQ3VsOqbKL0bVM6RkXQ6jXMSA==}
     engines: {node: '>=22'}
 
-  '@atproto/common-web@0.5.4':
-    resolution: {integrity: sha512-06DqJc5k8H9p2njfYVEfxMT0RWlHzVElX60wiwQSgsaVWwP5IIF6MgXXX/44VwK0bir5hKpQ/J75MpCD5v8RFQ==}
+  '@atproto/lex-data@0.1.5':
+    resolution: {integrity: sha512-TEM6GHuYpNm4O90LjNgbYq1Gmcr875S+BHrDxkg4PB5w/nlsz4HlbkGQG/WP/xbIV5O8TF5nNHDpCZ5ezTRrFA==}
     engines: {node: '>=22'}
 
-  '@atproto/lex-data@0.1.4':
-    resolution: {integrity: sha512-f9U95sk0zUtxHktvK59peU+Shd0cIUYV68p//GS7sfdkAxUIeaspvX6CY+Quv9Oa4aozmsXI52SjaNn1wuU8RQ==}
+  '@atproto/lex-json@0.1.4':
+    resolution: {integrity: sha512-ENR2cWkVrES+UL6TovbCRdX9BJOyHHJUS8jYx3Lxp3j4vEphjn/u+DW7bWloST2O8ID2OuVlt6+28ftNEEjmQQ==}
     engines: {node: '>=22'}
 
-  '@atproto/lex-json@0.1.3':
-    resolution: {integrity: sha512-Ch2w9bCLFOwWINFFxpZo6DBW7+ZxkehciU3P8N94gSyENLe3/5WWXHdHvkiH7EXZrpI7fKY8nVWn4GIL0ttqxw==}
+  '@atproto/lexicon@0.7.6':
+    resolution: {integrity: sha512-2q0hkXtzd9x5wE5n5enl/pjvPmktbKeLZOgdZBIHYSiuUWaacagbqdtUouSoddxSjehorfMNCNoBGMZoSp0ufA==}
     engines: {node: '>=22'}
 
-  '@atproto/lexicon@0.7.5':
-    resolution: {integrity: sha512-2xIeiCAfZYql0fZXw5f2Oo//T/q72crVV+cD+SnENH2/HQ0b+zdWp97aCetL0IOC3wDM1zbLWslBjoxAaJFNqQ==}
+  '@atproto/syntax@0.7.1':
+    resolution: {integrity: sha512-gK66efFZOFHymTc8GH9yOqHUSYzXIVWuQL20qpSQBX5py+QhlFfISHUHg6MO1mjREEdvXQj8Y7sEFVEcNUnp/g==}
     engines: {node: '>=22'}
 
-  '@atproto/syntax@0.6.4':
-    resolution: {integrity: sha512-ELgpShRGMF65cvLXcoMCZFL0HBzy67yz/Nlhox3yOtTh120B09KjjvZYXhMysVog3nUJqv2EW5rf1VRYCeM/hw==}
-    engines: {node: '>=22'}
-
-  '@atproto/syntax@0.7.0':
-    resolution: {integrity: sha512-bKilYbACYg87TgKa60NNoM1cysQxN9ikgIrgKQH4OpeXVN2TTb0qxqLDbxiU/rp+ugdrf4JYl6UyrQSM+IagHg==}
-    engines: {node: '>=22'}
-
-  '@atproto/xrpc@0.8.4':
-    resolution: {integrity: sha512-iAGfvZdJtG4tv1+aCG5GVX0UM3zPZizeU4lfmM8txZjCPdU4UV6/HC260PS3L8q958Jv4CSpeJRkMj9Z94Nn+Q==}
+  '@atproto/xrpc@0.8.5':
+    resolution: {integrity: sha512-f2+nor6ixxOHQaGmc27In+1BsaW7K+sS0nSPtZ9uAWquLglmfzJqGBLNbY1Asm6i7/VBlXFYWRlt7ZqERNIszQ==}
     engines: {node: '>=22'}
 
   '@babel/code-frame@7.10.4':
@@ -9012,9 +9004,6 @@ packages:
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
-  uint8arrays@5.1.1:
-    resolution: {integrity: sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==}
-
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
@@ -9485,63 +9474,50 @@ snapshots:
 
   '@0no-co/graphql.web@1.2.0': {}
 
-  '@atproto/api@0.20.26':
+  '@atproto/api@0.20.27':
     dependencies:
-      '@atproto/common-web': 0.5.4
-      '@atproto/lexicon': 0.7.5
-      '@atproto/syntax': 0.7.0
-      '@atproto/xrpc': 0.8.4
+      '@atproto/common-web': 0.5.5
+      '@atproto/lexicon': 0.7.6
+      '@atproto/syntax': 0.7.1
+      '@atproto/xrpc': 0.8.5
       await-lock: 3.0.0
       multiformats: 13.4.2
       tlds: 1.261.0
       zod: 3.25.76
 
-  '@atproto/common-web@0.5.3':
+  '@atproto/common-web@0.5.5':
     dependencies:
-      '@atproto/lex-data': 0.1.4
-      '@atproto/lex-json': 0.1.3
-      '@atproto/syntax': 0.6.4
+      '@atproto/lex-data': 0.1.5
+      '@atproto/lex-json': 0.1.4
+      '@atproto/syntax': 0.7.1
       zod: 3.25.76
 
-  '@atproto/common-web@0.5.4':
-    dependencies:
-      '@atproto/lex-data': 0.1.4
-      '@atproto/lex-json': 0.1.3
-      '@atproto/syntax': 0.7.0
-      zod: 3.25.76
-
-  '@atproto/lex-data@0.1.4':
+  '@atproto/lex-data@0.1.5':
     dependencies:
       multiformats: 13.4.2
       tslib: 2.8.1
-      uint8arrays: 5.1.1
       unicode-segmenter: 0.14.5
 
-  '@atproto/lex-json@0.1.3':
+  '@atproto/lex-json@0.1.4':
     dependencies:
-      '@atproto/lex-data': 0.1.4
+      '@atproto/lex-data': 0.1.5
       tslib: 2.8.1
 
-  '@atproto/lexicon@0.7.5':
+  '@atproto/lexicon@0.7.6':
     dependencies:
-      '@atproto/common-web': 0.5.4
-      '@atproto/syntax': 0.7.0
+      '@atproto/common-web': 0.5.5
+      '@atproto/syntax': 0.7.1
       multiformats: 13.4.2
       zod: 3.25.76
 
-  '@atproto/syntax@0.6.4':
+  '@atproto/syntax@0.7.1':
     dependencies:
       iso-datestring-validator: 2.2.2
       tslib: 2.8.1
 
-  '@atproto/syntax@0.7.0':
+  '@atproto/xrpc@0.8.5':
     dependencies:
-      iso-datestring-validator: 2.2.2
-      tslib: 2.8.1
-
-  '@atproto/xrpc@0.8.4':
-    dependencies:
-      '@atproto/lexicon': 0.7.5
+      '@atproto/lexicon': 0.7.6
       zod: 3.25.76
 
   '@babel/code-frame@7.10.4':
@@ -18979,10 +18955,6 @@ snapshots:
   ua-parser-js@1.0.41: {}
 
   uc.micro@2.1.0: {}
-
-  uint8arrays@5.1.1:
-    dependencies:
-      multiformats: 13.4.2
 
   unbox-primitive@1.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,14 +242,14 @@ importers:
   .:
     dependencies:
       '@atproto/api':
-        specifier: 0.20.25
-        version: 0.20.25
+        specifier: 0.20.26
+        version: 0.20.26
       '@atproto/common-web':
         specifier: 0.5.3
         version: 0.5.3
       '@atproto/syntax':
-        specifier: 0.6.4
-        version: 0.6.4
+        specifier: 0.7.0
+        version: 0.7.0
       '@bitdrift/react-native':
         specifier: ^0.6.8
         version: 0.6.14(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -880,12 +880,16 @@ packages:
       graphql:
         optional: true
 
-  '@atproto/api@0.20.25':
-    resolution: {integrity: sha512-PTwt6X0U45C9vikr8NRi0Qzcep9VqJet52HtfcxgG9R7ofRHxqLVPzfVuN/f2xOaYM6H5IG/Nk1E9kXZcI0mSQ==}
+  '@atproto/api@0.20.26':
+    resolution: {integrity: sha512-l51hlQQxBlV5XWYat8S1mltIyReI2dZvkWcSQGaQl9DY0oMuONHJw/m1DMeyZ27Y5pyiBH+kAl4SP8X0n+gz/Q==}
     engines: {node: '>=22'}
 
   '@atproto/common-web@0.5.3':
     resolution: {integrity: sha512-FkMhOcNv1y7r5984+zXB+uMN4zJ4QFLEbZrYyQo6bNCf/Kfav/pEHXXENlaZEOweq2NYXf+tr2giMssBuM9u5A==}
+    engines: {node: '>=22'}
+
+  '@atproto/common-web@0.5.4':
+    resolution: {integrity: sha512-06DqJc5k8H9p2njfYVEfxMT0RWlHzVElX60wiwQSgsaVWwP5IIF6MgXXX/44VwK0bir5hKpQ/J75MpCD5v8RFQ==}
     engines: {node: '>=22'}
 
   '@atproto/lex-data@0.1.4':
@@ -896,16 +900,20 @@ packages:
     resolution: {integrity: sha512-Ch2w9bCLFOwWINFFxpZo6DBW7+ZxkehciU3P8N94gSyENLe3/5WWXHdHvkiH7EXZrpI7fKY8nVWn4GIL0ttqxw==}
     engines: {node: '>=22'}
 
-  '@atproto/lexicon@0.7.4':
-    resolution: {integrity: sha512-ulk4RGwMBp4vbkTOZcIwZJeTEPlj3PImOnx9TqxSxMDnBdySxarpd0Aprg7+iAvGyKTsMcrYHpeoLukZaquk0A==}
+  '@atproto/lexicon@0.7.5':
+    resolution: {integrity: sha512-2xIeiCAfZYql0fZXw5f2Oo//T/q72crVV+cD+SnENH2/HQ0b+zdWp97aCetL0IOC3wDM1zbLWslBjoxAaJFNqQ==}
     engines: {node: '>=22'}
 
   '@atproto/syntax@0.6.4':
     resolution: {integrity: sha512-ELgpShRGMF65cvLXcoMCZFL0HBzy67yz/Nlhox3yOtTh120B09KjjvZYXhMysVog3nUJqv2EW5rf1VRYCeM/hw==}
     engines: {node: '>=22'}
 
-  '@atproto/xrpc@0.8.3':
-    resolution: {integrity: sha512-0gUGN71+bSqV3PI5U4cQ4fdnw4nI0eD6czHDQ6jB7hMYBwNcJpwAyfA9W+C1G1wayIvP0SIap/M0H/pSKDWFIQ==}
+  '@atproto/syntax@0.7.0':
+    resolution: {integrity: sha512-bKilYbACYg87TgKa60NNoM1cysQxN9ikgIrgKQH4OpeXVN2TTb0qxqLDbxiU/rp+ugdrf4JYl6UyrQSM+IagHg==}
+    engines: {node: '>=22'}
+
+  '@atproto/xrpc@0.8.4':
+    resolution: {integrity: sha512-iAGfvZdJtG4tv1+aCG5GVX0UM3zPZizeU4lfmM8txZjCPdU4UV6/HC260PS3L8q958Jv4CSpeJRkMj9Z94Nn+Q==}
     engines: {node: '>=22'}
 
   '@babel/code-frame@7.10.4':
@@ -9477,12 +9485,12 @@ snapshots:
 
   '@0no-co/graphql.web@1.2.0': {}
 
-  '@atproto/api@0.20.25':
+  '@atproto/api@0.20.26':
     dependencies:
-      '@atproto/common-web': 0.5.3
-      '@atproto/lexicon': 0.7.4
-      '@atproto/syntax': 0.6.4
-      '@atproto/xrpc': 0.8.3
+      '@atproto/common-web': 0.5.4
+      '@atproto/lexicon': 0.7.5
+      '@atproto/syntax': 0.7.0
+      '@atproto/xrpc': 0.8.4
       await-lock: 3.0.0
       multiformats: 13.4.2
       tlds: 1.261.0
@@ -9493,6 +9501,13 @@ snapshots:
       '@atproto/lex-data': 0.1.4
       '@atproto/lex-json': 0.1.3
       '@atproto/syntax': 0.6.4
+      zod: 3.25.76
+
+  '@atproto/common-web@0.5.4':
+    dependencies:
+      '@atproto/lex-data': 0.1.4
+      '@atproto/lex-json': 0.1.3
+      '@atproto/syntax': 0.7.0
       zod: 3.25.76
 
   '@atproto/lex-data@0.1.4':
@@ -9507,10 +9522,10 @@ snapshots:
       '@atproto/lex-data': 0.1.4
       tslib: 2.8.1
 
-  '@atproto/lexicon@0.7.4':
+  '@atproto/lexicon@0.7.5':
     dependencies:
-      '@atproto/common-web': 0.5.3
-      '@atproto/syntax': 0.6.4
+      '@atproto/common-web': 0.5.4
+      '@atproto/syntax': 0.7.0
       multiformats: 13.4.2
       zod: 3.25.76
 
@@ -9519,9 +9534,14 @@ snapshots:
       iso-datestring-validator: 2.2.2
       tslib: 2.8.1
 
-  '@atproto/xrpc@0.8.3':
+  '@atproto/syntax@0.7.0':
     dependencies:
-      '@atproto/lexicon': 0.7.4
+      iso-datestring-validator: 2.2.2
+      tslib: 2.8.1
+
+  '@atproto/xrpc@0.8.4':
+    dependencies:
+      '@atproto/lexicon': 0.7.5
       zod: 3.25.76
 
   '@babel/code-frame@7.10.4':

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import {Provider as HomeBadgeProvider} from '#/state/home-badge'
 import {MessagesProvider} from '#/state/messages'
 import {init as initPersistedState} from '#/state/persisted'
 import {Provider as PrefsStateProvider} from '#/state/preferences'
+import {BetaUserStorageSync} from '#/state/preferences/beta-user-sync'
 import {Provider as LabelDefsProvider} from '#/state/preferences/label-defs'
 import {Provider as ModerationOptsProvider} from '#/state/preferences/moderation-opts'
 import {Provider as UnreadNotifsProvider} from '#/state/queries/notifications/unread'
@@ -152,6 +153,7 @@ function InnerApp() {
                 key={currentAccount?.did}>
                 <AnalyticsFeaturesContext>
                   <QueryProvider currentDid={currentAccount?.did}>
+                    <BetaUserStorageSync />
                     <PolicyUpdateOverlayProvider>
                       <LiveEventsProvider>
                         <AgeAssuranceV2Provider>

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -26,6 +26,7 @@ import {Provider as HomeBadgeProvider} from '#/state/home-badge'
 import {MessagesProvider} from '#/state/messages'
 import {init as initPersistedState} from '#/state/persisted'
 import {Provider as PrefsStateProvider} from '#/state/preferences'
+import {BetaUserStorageSync} from '#/state/preferences/beta-user-sync'
 import {Provider as LabelDefsProvider} from '#/state/preferences/label-defs'
 import {Provider as ModerationOptsProvider} from '#/state/preferences/moderation-opts'
 import {Provider as UnreadNotifsProvider} from '#/state/queries/notifications/unread'
@@ -132,6 +133,7 @@ function InnerApp() {
                   key={currentAccount?.did}>
                   <AnalyticsFeaturesContext>
                     <QueryProvider currentDid={currentAccount?.did}>
+                      <BetaUserStorageSync />
                       <PolicyUpdateOverlayProvider>
                         <LiveEventsProvider>
                           <AgeAssuranceV2Provider>

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -108,6 +108,7 @@ import {AppearanceSettingsScreen} from '#/screens/Settings/AppearanceSettings'
 import {AppIconSettingsScreen} from '#/screens/Settings/AppIconSettings'
 import {AppPasswordsScreen} from '#/screens/Settings/AppPasswords'
 import {AutomationLabelSettingsScreen} from '#/screens/Settings/AutomationLabelSettings'
+import {BetaFeaturesSettingsScreen} from '#/screens/Settings/BetaFeaturesSettings'
 import {ContentAndMediaSettingsScreen} from '#/screens/Settings/ContentAndMediaSettings'
 import {ExternalMediaPreferencesScreen} from '#/screens/Settings/ExternalMediaPreferences'
 import {FindContactsSettingsScreen} from '#/screens/Settings/FindContactsSettings'
@@ -402,6 +403,14 @@ function commonScreens(Stack: typeof Flat, unreadCountLabel?: string) {
         getComponent={() => AccountSettingsScreen}
         options={{
           title: title(msg`Account`),
+          requireAuth: true,
+        }}
+      />
+      <Stack.Screen
+        name="BetaFeaturesSettings"
+        getComponent={() => BetaFeaturesSettingsScreen}
+        options={{
+          title: title(msg`Beta features`),
           requireAuth: true,
         }}
       />

--- a/src/analytics/features/index.ts
+++ b/src/analytics/features/index.ts
@@ -1,8 +1,11 @@
 import {MMKV} from '@bsky.app/react-native-mmkv'
 import {setPolyfills} from '@growthbook/growthbook'
 import {GrowthBook} from '@growthbook/growthbook-react'
+import {type I18n} from '@lingui/core'
+import {msg} from '@lingui/core/macro'
 
 import {Logger} from '#/logger'
+import {Features} from '#/analytics/features/types'
 import {getNavigationMetadata, type Metadata} from '#/analytics/metadata'
 import * as env from '#/env'
 
@@ -11,12 +14,14 @@ export {Features} from '#/analytics/features/types'
 const logger = Logger.create(Logger.Context.Growthbook)
 const CACHE = new MMKV({id: 'bsky_features_cache'})
 
+const BETA_USER_ATTRIBUTE = 'isBetaUser'
+
 setPolyfills({
   localStorage: {
     getItem: key => {
       return CACHE.getString(key) ?? null
     },
-    setItem: async (key, value) => {
+    setItem: (key, value) => {
       CACHE.set(key, value)
     },
   },
@@ -44,15 +49,13 @@ export const features = new GrowthBook({
  * that case, we may see a flash of uncustomized content until the
  * initialization completes.
  */
-export const init = new Promise<void>(async y => {
-  const res = await features.init({timeout: TIMEOUT_INIT})
+export const init = features.init({timeout: TIMEOUT_INIT}).then(res => {
   if (!res.success) {
     logger.warn('GrowthBook initialization failed or timed out', {
       source: res.source,
       safeMessage: res.error?.toString(),
     })
   }
-  y()
 })
 
 /**
@@ -68,6 +71,69 @@ export async function refresh({strategy}: {strategy: FeatureFetchStrategy}) {
   })
 }
 
+export function getFeatures() {
+  return features.getFeatures()
+}
+
+export function getFeatureDescription(feature: Features, i18n: I18n) {
+  switch (feature) {
+    case Features.AdvancedSearchV2Enable:
+      return {
+        key: feature,
+        name: i18n._(
+          msg({
+            message: 'Advanced search',
+            comment: 'Name for a feature flag',
+          }),
+        ),
+        description: i18n._(
+          msg({
+            message: 'Search with new filters for more precise results.',
+            comment: 'Description of a feature flag (Advanced search)',
+          }),
+        ),
+      }
+    default:
+      return null
+  }
+}
+
+export function getTargetedFeatures(i18n: I18n) {
+  const allFeatures = features.getFeatures()
+  const targetedFeatures: {key: Features; name: string; description: string}[] =
+    []
+  for (const [featureKey, feature] of Object.entries(allFeatures)) {
+    // Check if the feature contains any rules
+    if (!feature.rules) continue
+
+    // Determine if any rule targets the specified attribute
+    const hasTargeting = feature.rules.some(rule => {
+      // If the rule has targeting conditions, parse them
+      if (rule.condition) {
+        // Condition objects map attribute names (e.g., {"country": "US"})
+        const targetedAttributes = Object.keys(rule.condition)
+
+        // Handle standard attributes or MongoDB-style $operators
+        return targetedAttributes.some(
+          attr =>
+            attr === BETA_USER_ATTRIBUTE ||
+            attr.startsWith(`${BETA_USER_ATTRIBUTE} `),
+        )
+      }
+      return false
+    })
+
+    if (hasTargeting) {
+      const featureName = getFeatureDescription(featureKey as Features, i18n)
+      if (featureName) {
+        targetedFeatures.push(featureName)
+      }
+    }
+  }
+
+  return targetedFeatures
+}
+
 /**
  * Converts our metadata into GrowthBook attributes and sets them. GrowthBook
  * attributes are manually configured in the GrowthBook dashboard. So these
@@ -80,7 +146,7 @@ export function setAttributes({
   session,
   preferences,
 }: Metadata) {
-  features.setAttributes({
+  void features.setAttributes({
     deviceId: base.deviceId,
     sessionId: base.sessionId,
     platform: base.platform,
@@ -92,5 +158,6 @@ export function setAttributes({
     appLanguage: preferences?.appLanguage,
     contentLanguages: preferences?.contentLanguages,
     currentScreen: getNavigationMetadata()?.currentScreen,
+    isBetaUser: base.isBetaUser,
   })
 }

--- a/src/analytics/features/index.ts
+++ b/src/analytics/features/index.ts
@@ -98,6 +98,38 @@ export function getFeatureDescription(feature: Features, i18n: I18n) {
   }
 }
 
+/**
+ * Walks a GrowthBook condition tree to determine whether it targets the given
+ * attribute. Conditions can nest via the logical operators `$and`, `$or`,
+ * `$nor` (arrays of sub-conditions) and `$not` (a single sub-condition), so a
+ * flat scan of the top-level keys would miss e.g.
+ * `{$and: [{isBetaUser: true}, ...]}`. Dot-notation access (e.g.
+ * `isBetaUser.foo`) counts as targeting the attribute as well.
+ */
+function conditionTargetsAttribute(
+  condition: unknown,
+  attribute: string,
+): boolean {
+  if (!condition || typeof condition !== 'object') return false
+
+  for (const [key, value] of Object.entries(condition)) {
+    if (key === attribute || key.startsWith(`${attribute}.`)) return true
+
+    if (key === '$and' || key === '$or' || key === '$nor') {
+      if (
+        Array.isArray(value) &&
+        value.some(sub => conditionTargetsAttribute(sub, attribute))
+      ) {
+        return true
+      }
+    } else if (key === '$not') {
+      if (conditionTargetsAttribute(value, attribute)) return true
+    }
+  }
+
+  return false
+}
+
 export function getTargetedFeatures(i18n: I18n) {
   const allFeatures = features.getFeatures()
   const targetedFeatures: {key: Features; name: string; description: string}[] =
@@ -106,22 +138,10 @@ export function getTargetedFeatures(i18n: I18n) {
     // Check if the feature contains any rules
     if (!feature.rules) continue
 
-    // Determine if any rule targets the specified attribute
-    const hasTargeting = feature.rules.some(rule => {
-      // If the rule has targeting conditions, parse them
-      if (rule.condition) {
-        // Condition objects map attribute names (e.g., {"country": "US"})
-        const targetedAttributes = Object.keys(rule.condition)
-
-        // Handle standard attributes or MongoDB-style $operators
-        return targetedAttributes.some(
-          attr =>
-            attr === BETA_USER_ATTRIBUTE ||
-            attr.startsWith(`${BETA_USER_ATTRIBUTE} `),
-        )
-      }
-      return false
-    })
+    // Determine if any rule targets the beta user attribute
+    const hasTargeting = feature.rules.some(rule =>
+      conditionTargetsAttribute(rule.condition, BETA_USER_ATTRIBUTE),
+    )
 
     if (hasTargeting) {
       const featureName = getFeatureDescription(featureKey as Features, i18n)

--- a/src/analytics/features/types.ts
+++ b/src/analytics/features/types.ts
@@ -1,6 +1,6 @@
 /**
  * If a feature is in the beta program, be sure to add a localized description
- * for it via getFeatureName().
+ * for it via getFeatureDescription().
  */
 export enum Features {
   // core flags

--- a/src/analytics/features/types.ts
+++ b/src/analytics/features/types.ts
@@ -1,3 +1,7 @@
+/**
+ * If a feature is in the beta program, be sure to add a localized description
+ * for it via getFeatureName().
+ */
 export enum Features {
   // core flags
   IsBskyTeam = 'is_bsky_team',

--- a/src/analytics/index.tsx
+++ b/src/analytics/index.tsx
@@ -26,7 +26,7 @@ import {type Metrics, metrics} from '#/analytics/metrics'
 import * as refParams from '#/analytics/misc/refParams'
 import * as env from '#/env'
 import {useGeolocationServiceResponse} from '#/geolocation/service'
-import {device} from '#/storage'
+import {device, useStorage} from '#/storage'
 
 export * as utils from '#/analytics/utils'
 export const features = {init, refresh}
@@ -141,6 +141,7 @@ export function AnalyticsContext({
   const sessionId = useSessionId()
   const geolocation = useGeolocationServiceResponse()
   const parentContext = useContext(Context)
+  const [isBetaUser] = useStorage(device, ['isBetaUser'])
   const childContext = useMemo(() => {
     const combinedMetadata = {
       ...parentContext.metadata,
@@ -148,6 +149,7 @@ export function AnalyticsContext({
       base: {
         ...parentContext.metadata.base,
         sessionId,
+        isBetaUser,
       },
       geolocation,
     }
@@ -166,7 +168,7 @@ export function AnalyticsContext({
       },
     }
     return context
-  }, [sessionId, geolocation, parentContext, metadata])
+  }, [parentContext, metadata, sessionId, isBetaUser, geolocation])
   return <Context.Provider value={childContext}>{children}</Context.Provider>
 }
 

--- a/src/analytics/index.tsx
+++ b/src/analytics/index.tsx
@@ -26,7 +26,7 @@ import {type Metrics, metrics} from '#/analytics/metrics'
 import * as refParams from '#/analytics/misc/refParams'
 import * as env from '#/env'
 import {useGeolocationServiceResponse} from '#/geolocation/service'
-import {device, useStorage} from '#/storage'
+import {account, device, useStorage} from '#/storage'
 
 export * as utils from '#/analytics/utils'
 export const features = {init, refresh}
@@ -141,7 +141,17 @@ export function AnalyticsContext({
   const sessionId = useSessionId()
   const geolocation = useGeolocationServiceResponse()
   const parentContext = useContext(Context)
-  const [isBetaUser] = useStorage(device, ['isBetaUser'])
+  /*
+   * `isBetaUser` is account-specific, so it's cached per account. Read it
+   * scoped to the did for this render's session (from the `metadata` prop when
+   * set, otherwise inherited from the parent context). Without a did (e.g.
+   * logged out, or the top-level context above the session provider) there's
+   * no value, so beta-gated features are never evaluated for an ineligible or
+   * absent account. The empty-string fallback keeps the hook call
+   * unconditional and never resolves to a real account's cache entry.
+   */
+  const did = metadata?.session?.did ?? parentContext.metadata.session?.did
+  const [isBetaUser] = useStorage(account, [did ?? '', 'isBetaUser'])
   const childContext = useMemo(() => {
     const combinedMetadata = {
       ...parentContext.metadata,

--- a/src/analytics/index.tsx
+++ b/src/analytics/index.tsx
@@ -1,4 +1,10 @@
-import {createContext, useContext, useMemo} from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useSyncExternalStore,
+} from 'react'
 import {Platform} from 'react-native'
 import {type Result} from '@growthbook/growthbook-react'
 
@@ -26,7 +32,7 @@ import {type Metrics, metrics} from '#/analytics/metrics'
 import * as refParams from '#/analytics/misc/refParams'
 import * as env from '#/env'
 import {useGeolocationServiceResponse} from '#/geolocation/service'
-import {account, device, useStorage} from '#/storage'
+import {account, device} from '#/storage'
 
 export * as utils from '#/analytics/utils'
 export const features = {init, refresh}
@@ -121,6 +127,38 @@ Context.displayName = 'AnalyticsContext'
 export const setupDeviceId = getAndMigrateDeviceId()
 
 /**
+ * Reads the per-account cached `isBetaUser` flag for `did`, kept in sync with
+ * writes from `BetaUserStorageSync` and the beta settings toggle.
+ *
+ * This deliberately does not use `useStorage`, whose `useState` seeds once and
+ * only updates via the change listener. The consuming `AnalyticsContext` lives
+ * above the `<Fragment key={did}>` remount breaker, so on an account switch it
+ * re-renders (with a new did) rather than remounting. `useStorage` would keep
+ * serving the previous account's seeded value until a write happened to fire
+ * its listener, leaking a beta account's flag into a non-beta account. Reading
+ * via `useSyncExternalStore` re-evaluates `getSnapshot` every render, so the
+ * value is always correct for the current did.
+ */
+function useAccountIsBetaUser(did: string | undefined): boolean | undefined {
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      if (!did) return () => {}
+      const sub = account.addOnValueChangedListener(
+        [did, 'isBetaUser'],
+        onChange,
+      )
+      return () => sub.remove()
+    },
+    [did],
+  )
+  const getSnapshot = useCallback(() => {
+    if (!did) return undefined
+    return account.get([did, 'isBetaUser'])
+  }, [did])
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
+
+/**
  * Analytics context provider. Decorates the parent analytics context with
  * additional metadata. Nesting should be done carefully and sparingly.
  */
@@ -147,11 +185,10 @@ export function AnalyticsContext({
    * set, otherwise inherited from the parent context). Without a did (e.g.
    * logged out, or the top-level context above the session provider) there's
    * no value, so beta-gated features are never evaluated for an ineligible or
-   * absent account. The empty-string fallback keeps the hook call
-   * unconditional and never resolves to a real account's cache entry.
+   * absent account.
    */
   const did = metadata?.session?.did ?? parentContext.metadata.session?.did
-  const [isBetaUser] = useStorage(account, [did ?? '', 'isBetaUser'])
+  const isBetaUser = useAccountIsBetaUser(did)
   const childContext = useMemo(() => {
     const combinedMetadata = {
       ...parentContext.metadata,

--- a/src/analytics/metadata.ts
+++ b/src/analytics/metadata.ts
@@ -9,6 +9,7 @@ export type BaseMetadata = {
   bundleDate: number
   referrerSrc: string
   referrerUrl: string
+  isBetaUser?: boolean
 }
 
 export type GeolocationMetadata = Geolocation
@@ -66,7 +67,7 @@ export function getMetadataForLogger({
   base,
   geolocation,
   session,
-}: Metadata): Record<string, any> {
+}: Metadata): Record<string, unknown> {
   return {
     deviceId: base.deviceId,
     sessionId: base.sessionId,

--- a/src/lib/routes/types.ts
+++ b/src/lib/routes/types.ts
@@ -63,6 +63,7 @@ export type CommonNavigatorParams = {
   PreferencesExternalEmbeds: undefined
   AccessibilitySettings: undefined
   AppearanceSettings: undefined
+  BetaFeaturesSettings: undefined
   AccountSettings: undefined
   AutomationLabelSettings: undefined
   PrivacyAndSecuritySettings: undefined

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -50,6 +50,7 @@ export const router = new Router<AllNavigatableRoutes>({
   PreferencesExternalEmbeds: '/settings/external-embeds',
   AccessibilitySettings: '/settings/accessibility',
   AppearanceSettings: '/settings/appearance',
+  BetaFeaturesSettings: '/settings/beta-features',
   SavedFeeds: '/settings/saved-feeds',
   AccountSettings: '/settings/account',
   AutomationLabelSettings: '/settings/automation-label',

--- a/src/screens/Settings/AccountSettings.tsx
+++ b/src/screens/Settings/AccountSettings.tsx
@@ -1,6 +1,4 @@
-import {msg} from '@lingui/core/macro'
-import {useLingui} from '@lingui/react'
-import {Trans} from '@lingui/react/macro'
+import {Trans, useLingui} from '@lingui/react/macro'
 import {type NativeStackScreenProps} from '@react-navigation/native-stack'
 
 import {type CommonNavigatorParams} from '#/lib/routes/types'
@@ -36,7 +34,7 @@ import {ExportCarDialog} from './components/ExportCarDialog'
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'AccountSettings'>
 export function AccountSettingsScreen({}: Props) {
   const t = useTheme()
-  const {_} = useLingui()
+  const {t: l} = useLingui()
   const {currentAccount} = useSession()
   const {data: profile} = useProfileQuery({did: currentAccount?.did})
   const emailDialogControl = useEmailDialogControl()
@@ -83,7 +81,7 @@ export function AccountSettingsScreen({}: Props) {
           </SettingsList.Item>
           {currentAccount && !currentAccount.emailConfirmed && (
             <SettingsList.PressableItem
-              label={_(msg`Verify your email`)}
+              label={l`Verify your email`}
               onPress={() =>
                 emailDialogControl.open({
                   id: EmailDialogScreenID.Verify,
@@ -109,7 +107,7 @@ export function AccountSettingsScreen({}: Props) {
             </SettingsList.PressableItem>
           )}
           <SettingsList.PressableItem
-            label={_(msg`Update email`)}
+            label={l`Update email`}
             onPress={() =>
               emailDialogControl.open({
                 id: EmailDialogScreenID.Update,
@@ -123,7 +121,7 @@ export function AccountSettingsScreen({}: Props) {
           </SettingsList.PressableItem>
           <SettingsList.Divider />
           <SettingsList.PressableItem
-            label={_(msg`Password`)}
+            label={l`Password`}
             onPress={() => changePasswordControl.open()}>
             <SettingsList.ItemIcon icon={LockIcon} />
             <SettingsList.ItemText>
@@ -132,8 +130,8 @@ export function AccountSettingsScreen({}: Props) {
             <SettingsList.Chevron />
           </SettingsList.PressableItem>
           <SettingsList.PressableItem
-            label={_(msg`Handle`)}
-            accessibilityHint={_(msg`Opens change handle dialog`)}
+            label={l`Handle`}
+            accessibilityHint={l`Opens change handle dialog`}
             onPress={() => changeHandleControl.open()}>
             <SettingsList.ItemIcon icon={AtIcon} />
             <SettingsList.ItemText>
@@ -147,27 +145,27 @@ export function AccountSettingsScreen({}: Props) {
               <Trans>Birthday</Trans>
             </SettingsList.ItemText>
             <SettingsList.BadgeButton
-              label={_(msg`Edit`)}
+              label={l`Edit`}
               onPress={() => birthdayControl.open()}
             />
           </SettingsList.Item>
           <AgeAssuranceAccountCard style={[a.px_xl, a.pt_xs, a.pb_md]} />
           <SettingsList.LinkItem
             to="/settings/automation-label"
-            label={_(msg`Automation label`)}>
+            label={l`Automation label`}>
             <SettingsList.ItemIcon icon={RobotIcon} />
             <SettingsList.ItemText>
               <Trans>Automation label</Trans>
             </SettingsList.ItemText>
             {profile && (
               <SettingsList.BadgeText>
-                {isBotAccount(profile) ? _(msg`On`) : _(msg`Off`)}
+                {isBotAccount(profile) ? l`On` : l`Off`}
               </SettingsList.BadgeText>
             )}
           </SettingsList.LinkItem>
           <SettingsList.Divider />
           <SettingsList.PressableItem
-            label={_(msg`Export my data`)}
+            label={l`Export my data`}
             onPress={() => exportCarControl.open()}>
             <SettingsList.ItemIcon icon={CarIcon} />
             <SettingsList.ItemText>
@@ -176,7 +174,7 @@ export function AccountSettingsScreen({}: Props) {
             <SettingsList.Chevron />
           </SettingsList.PressableItem>
           <SettingsList.PressableItem
-            label={_(msg`Deactivate account`)}
+            label={l`Deactivate account`}
             onPress={() => deactivateAccountControl.open()}
             destructive>
             <SettingsList.ItemIcon icon={FreezeIcon} />
@@ -186,7 +184,7 @@ export function AccountSettingsScreen({}: Props) {
             <SettingsList.Chevron />
           </SettingsList.PressableItem>
           <SettingsList.PressableItem
-            label={_(msg`Delete account`)}
+            label={l`Delete account`}
             onPress={() => deleteAccountControl.open()}
             destructive>
             <SettingsList.ItemIcon icon={Trash_Stroke2_Corner2_Rounded} />
@@ -197,7 +195,6 @@ export function AccountSettingsScreen({}: Props) {
           </SettingsList.PressableItem>
         </SettingsList.Container>
       </Layout.Content>
-
       <BirthDateSettingsDialog control={birthdayControl} />
       <ChangeHandleDialog control={changeHandleControl} />
       <ChangePasswordDialog control={changePasswordControl} />

--- a/src/screens/Settings/BetaFeaturesSettings.tsx
+++ b/src/screens/Settings/BetaFeaturesSettings.tsx
@@ -154,7 +154,7 @@ export function BetaFeaturesSettingsScreen({}: Props) {
             </Button>
 
             {betaFeatures.length < 1 ? (
-              <View style={[a.align_center, a.gap_xs, a.py_4xl]}>
+              <View style={[a.align_center, a.gap_xs, a.py_5xl]}>
                 <BeakerIcon
                   size="4xl"
                   fill={t.palette.contrast_100}

--- a/src/screens/Settings/BetaFeaturesSettings.tsx
+++ b/src/screens/Settings/BetaFeaturesSettings.tsx
@@ -22,6 +22,7 @@ import * as Toast from '#/components/Toast'
 import {Text} from '#/components/Typography'
 import {features} from '#/analytics'
 import {getTargetedFeatures} from '#/analytics/features'
+import {IS_WEB} from '#/env'
 import {device} from '#/storage'
 
 type Props = NativeStackScreenProps<
@@ -135,10 +136,9 @@ export function BetaFeaturesSettingsScreen({}: Props) {
 
           <View style={[a.px_xl, a.gap_md]}>
             <Admonition type="info">
-              <Trans>
-                Beta features may be unstable. Some changes may require
-                restarting the app.
-              </Trans>
+              {IS_WEB
+                ? l`Beta features may be unstable. Some changes may require reloading the app.`
+                : l`Beta features may be unstable. Some changes may require restarting the app.`}
             </Admonition>
 
             <Button

--- a/src/screens/Settings/BetaFeaturesSettings.tsx
+++ b/src/screens/Settings/BetaFeaturesSettings.tsx
@@ -24,7 +24,7 @@ import {Text} from '#/components/Typography'
 import {features} from '#/analytics'
 import {getTargetedFeatures} from '#/analytics/features'
 import {IS_INTERNAL, IS_WEB} from '#/env'
-import {device} from '#/storage'
+import {account} from '#/storage'
 
 type Props = NativeStackScreenProps<
   CommonNavigatorParams,
@@ -66,9 +66,12 @@ export function BetaFeaturesSettingsScreen({}: Props) {
       /*
        * Cache the new value so analytics can set the `isBetaUser` GrowthBook
        * attribute synchronously on the next boot, before beta-gated features
-       * are evaluated.
+       * are evaluated. Scoped per account, since `isBetaUser` is
+       * account-specific.
        */
-      device.set(['isBetaUser'], next)
+      if (currentAccount) {
+        account.set([currentAccount.did, 'isBetaUser'], next)
+      }
     } catch (e) {
       logger.error('Failed to toggle beta features', {safeMessage: e})
       Toast.show(l`Something went wrong, please try again.`, {type: 'error'})

--- a/src/screens/Settings/BetaFeaturesSettings.tsx
+++ b/src/screens/Settings/BetaFeaturesSettings.tsx
@@ -1,0 +1,188 @@
+import {useState} from 'react'
+import {Linking, View} from 'react-native'
+import {Trans, useLingui} from '@lingui/react/macro'
+import {type NativeStackScreenProps} from '@react-navigation/native-stack'
+
+import {FEEDBACK_FORM_URL} from '#/lib/constants'
+import {type CommonNavigatorParams} from '#/lib/routes/types'
+import {logger} from '#/logger'
+import {
+  usePreferencesQuery,
+  useSetIsBetaUserMutation,
+} from '#/state/queries/preferences'
+import {useSession} from '#/state/session'
+import * as SettingsList from '#/screens/Settings/components/SettingsList'
+import {atoms as a, useTheme} from '#/alf'
+import {Admonition} from '#/components/Admonition'
+import {Button, ButtonText} from '#/components/Button'
+import * as Toggle from '#/components/forms/Toggle'
+import {Beaker_Stroke2_Corner2_Rounded as BeakerIcon} from '#/components/icons/Beaker'
+import * as Layout from '#/components/Layout'
+import * as Toast from '#/components/Toast'
+import {Text} from '#/components/Typography'
+import {features} from '#/analytics'
+import {getTargetedFeatures} from '#/analytics/features'
+import {device} from '#/storage'
+
+type Props = NativeStackScreenProps<
+  CommonNavigatorParams,
+  'BetaFeaturesSettings'
+>
+export function BetaFeaturesSettingsScreen({}: Props) {
+  const t = useTheme()
+  const {t: l, i18n} = useLingui()
+  const {currentAccount} = useSession()
+  const {data: preferences} = usePreferencesQuery()
+  const {mutateAsync: setIsBetaUser} = useSetIsBetaUserMutation()
+  const isBetaUser = preferences?.bskyAppState?.isBetaUser ?? false
+  const [isPending, setIsPending] = useState(false)
+
+  const betaFeatures = getTargetedFeatures(i18n)
+
+  const onChange = async (next: boolean) => {
+    try {
+      setIsPending(true)
+      await setIsBetaUser(next)
+      /*
+       * Cache the new value so analytics can set the `isBetaUser` GrowthBook
+       * attribute synchronously on the next boot, before beta-gated features
+       * are evaluated.
+       */
+      device.set(['isBetaUser'], next)
+      // re-evaluate feature gates against the new attribute in-session
+      void features.refresh({strategy: 'prefer-fresh-gates'})
+    } catch (e) {
+      logger.error('Failed to toggle beta features', {safeMessage: e})
+      Toast.show(l`Something went wrong, please try again.`, {type: 'error'})
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  const onPressShareFeedback = () => {
+    void Linking.openURL(
+      FEEDBACK_FORM_URL({
+        email: currentAccount?.email,
+        handle: currentAccount?.handle,
+      }),
+    )
+  }
+
+  return (
+    <Layout.Screen>
+      <Layout.Header.Outer>
+        <Layout.Header.BackButton />
+        <Layout.Header.Content>
+          <Layout.Header.TitleText>
+            <Trans>Beta features</Trans>
+          </Layout.Header.TitleText>
+        </Layout.Header.Content>
+        <Layout.Header.Slot />
+      </Layout.Header.Outer>
+      <Layout.Content>
+        <SettingsList.Container>
+          <Toggle.Item
+            name="enable_beta_features"
+            label={l`Enable beta features`}
+            value={isBetaUser}
+            disabled={isPending}
+            onChange={value => void onChange(value)}>
+            <SettingsList.Item>
+              <View style={[a.flex_1, a.gap_2xs]}>
+                <SettingsList.ItemText style={[a.font_semi_bold]}>
+                  <Trans>Enable beta features</Trans>
+                </SettingsList.ItemText>
+                <Text
+                  style={[
+                    a.text_sm,
+                    a.leading_snug,
+                    t.atoms.text_contrast_medium,
+                  ]}>
+                  <Trans>
+                    Get early access to experimental features we’re testing.
+                  </Trans>
+                </Text>
+              </View>
+              <Toggle.Platform />
+            </SettingsList.Item>
+          </Toggle.Item>
+
+          <View style={[a.px_xl, a.gap_md]}>
+            <Admonition type="info">
+              <Trans>
+                Beta features may be unstable. Some changes may require
+                restarting the app.
+              </Trans>
+            </Admonition>
+
+            <Button
+              disabled={!isBetaUser || betaFeatures.length < 1 || isPending}
+              label={l`Share feedback`}
+              size="medium"
+              color="primary_subtle"
+              onPress={onPressShareFeedback}
+              style={[a.self_start, a.mt_xs, a.mb_xl]}>
+              <ButtonText>
+                <Trans>Share feedback</Trans>
+              </ButtonText>
+            </Button>
+
+            {betaFeatures.length < 1 ? (
+              <View style={[a.align_center, a.gap_xs, a.py_4xl]}>
+                <BeakerIcon
+                  size="4xl"
+                  fill={t.palette.contrast_100}
+                  style={[a.mb_md]}
+                />
+                <Text style={[a.text_md, a.font_semi_bold, a.leading_snug]}>
+                  <Trans>No beta features at the moment.</Trans>
+                </Text>
+                <Text
+                  style={[a.text_sm, t.atoms.text_contrast_high]}
+                  emoji={false}>
+                  <Trans>Check back later!</Trans>
+                </Text>
+              </View>
+            ) : (
+              <>
+                <Text style={[a.text_md, a.font_semi_bold]}>
+                  <Trans>Current beta features</Trans>
+                </Text>
+                <View style={[a.gap_sm]}>
+                  {betaFeatures.map(feature => (
+                    <View
+                      key={feature.key}
+                      style={[
+                        a.p_md,
+                        a.rounded_md,
+                        a.border,
+                        t.atoms.border_contrast_low,
+                      ]}>
+                      <Text
+                        style={[
+                          a.text_md,
+                          a.font_medium,
+                          a.pb_2xs,
+                          t.atoms.text_contrast_high,
+                        ]}>
+                        {feature.name}
+                      </Text>
+                      <Text
+                        style={[
+                          a.text_sm,
+                          a.leading_snug,
+                          t.atoms.text_contrast_high,
+                        ]}>
+                        {feature.description}
+                      </Text>
+                    </View>
+                  ))}
+                </View>
+              </>
+            )}
+          </View>
+        </SettingsList.Container>
+      </Layout.Content>
+    </Layout.Screen>
+  )
+}

--- a/src/screens/Settings/BetaFeaturesSettings.tsx
+++ b/src/screens/Settings/BetaFeaturesSettings.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react'
+import {useEffect, useState} from 'react'
 import {Linking, View} from 'react-native'
 import {Trans, useLingui} from '@lingui/react/macro'
 import {type NativeStackScreenProps} from '@react-navigation/native-stack'
@@ -37,7 +37,25 @@ export function BetaFeaturesSettingsScreen({}: Props) {
   const isBetaUser = preferences?.bskyAppState?.isBetaUser ?? false
   const [isPending, setIsPending] = useState(false)
 
-  const betaFeatures = getTargetedFeatures(i18n)
+  /*
+   * `getTargetedFeatures` reads the GrowthBook singleton synchronously, but
+   * gates arrive asynchronously (from `init` on mount, or `refresh` after a
+   * toggle). Hold the result in state and re-read whenever fresh gates land so
+   * the list reflects the latest evaluation instead of a stale render.
+   */
+  const [betaFeatures, setBetaFeatures] = useState(() =>
+    getTargetedFeatures(i18n),
+  )
+
+  useEffect(() => {
+    let cancelled = false
+    void features.refresh({strategy: 'prefer-fresh-gates'}).then(() => {
+      if (!cancelled) setBetaFeatures(getTargetedFeatures(i18n))
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [i18n])
 
   const onChange = async (next: boolean) => {
     try {
@@ -49,14 +67,22 @@ export function BetaFeaturesSettingsScreen({}: Props) {
        * are evaluated.
        */
       device.set(['isBetaUser'], next)
-      // re-evaluate feature gates against the new attribute in-session
-      void features.refresh({strategy: 'prefer-fresh-gates'})
     } catch (e) {
       logger.error('Failed to toggle beta features', {safeMessage: e})
       Toast.show(l`Something went wrong, please try again.`, {type: 'error'})
+      return
     } finally {
       setIsPending(false)
     }
+    /*
+     * The toggle already succeeded; re-evaluate feature gates against the new
+     * attribute in-session as a best-effort follow-up. A failure here should
+     * not surface as a toggle error.
+     */
+    try {
+      await features.refresh({strategy: 'prefer-fresh-gates'})
+      setBetaFeatures(getTargetedFeatures(i18n))
+    } catch {}
   }
 
   const onPressShareFeedback = () => {

--- a/src/screens/Settings/BetaFeaturesSettings.tsx
+++ b/src/screens/Settings/BetaFeaturesSettings.tsx
@@ -14,9 +14,10 @@ import {useSession} from '#/state/session'
 import * as SettingsList from '#/screens/Settings/components/SettingsList'
 import {atoms as a, useTheme} from '#/alf'
 import {Admonition} from '#/components/Admonition'
-import {Button, ButtonText} from '#/components/Button'
+import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import * as Toggle from '#/components/forms/Toggle'
 import {Beaker_Stroke2_Corner2_Rounded as BeakerIcon} from '#/components/icons/Beaker'
+import {BubbleInfo_Stroke2_Corner2_Rounded as BubbleInfoIcon} from '#/components/icons/BubbleInfo'
 import * as Layout from '#/components/Layout'
 import * as Toast from '#/components/Toast'
 import {Text} from '#/components/Typography'
@@ -144,10 +145,11 @@ export function BetaFeaturesSettingsScreen({}: Props) {
             <Button
               disabled={!isBetaUser || betaFeatures.length < 1 || isPending}
               label={l`Share feedback`}
-              size="medium"
+              size="small"
               color="primary_subtle"
               onPress={onPressShareFeedback}
               style={[a.self_start, a.mt_xs, a.mb_xl]}>
+              <ButtonIcon icon={BubbleInfoIcon} />
               <ButtonText>
                 <Trans>Share feedback</Trans>
               </ButtonText>

--- a/src/screens/Settings/BetaFeaturesSettings.tsx
+++ b/src/screens/Settings/BetaFeaturesSettings.tsx
@@ -23,7 +23,7 @@ import * as Toast from '#/components/Toast'
 import {Text} from '#/components/Typography'
 import {features} from '#/analytics'
 import {getTargetedFeatures} from '#/analytics/features'
-import {IS_WEB} from '#/env'
+import {IS_INTERNAL, IS_WEB} from '#/env'
 import {device} from '#/storage'
 
 type Props = NativeStackScreenProps<
@@ -95,6 +95,8 @@ export function BetaFeaturesSettingsScreen({}: Props) {
       }),
     )
   }
+  const canSubmitFeedback =
+    !isPending && isBetaUser && (betaFeatures.length > 0 || IS_INTERNAL)
 
   return (
     <Layout.Screen>
@@ -138,12 +140,20 @@ export function BetaFeaturesSettingsScreen({}: Props) {
           <View style={[a.px_xl, a.gap_md]}>
             <Admonition type="info">
               {IS_WEB
-                ? l`Beta features may be unstable. Some changes may require reloading the app.`
-                : l`Beta features may be unstable. Some changes may require restarting the app.`}
+                ? l({
+                    message:
+                      'Beta features may be unstable. Some changes may require reloading the app.',
+                    context: 'web',
+                  })
+                : l({
+                    message:
+                      'Beta features may be unstable. Some changes may require restarting the app.',
+                    context: 'native',
+                  })}
             </Admonition>
 
             <Button
-              disabled={!isBetaUser || betaFeatures.length < 1 || isPending}
+              disabled={!canSubmitFeedback}
               label={l`Share feedback`}
               size="small"
               color="primary_subtle"

--- a/src/screens/Settings/Settings.tsx
+++ b/src/screens/Settings/Settings.tsx
@@ -36,6 +36,7 @@ import {useIsFindContactsFeatureEnabledBasedOnGeolocation} from '#/components/co
 import {useDialogControl} from '#/components/Dialog'
 import {SwitchAccountDialog} from '#/components/dialogs/SwitchAccount'
 import {Accessibility_Stroke2_Corner2_Rounded as AccessibilityIcon} from '#/components/icons/Accessibility'
+import {Beaker_Stroke2_Corner2_Rounded as BeakerIcon} from '#/components/icons/Beaker'
 import {Bell_Stroke2_Corner0_Rounded as NotificationIcon} from '#/components/icons/Bell'
 import {BubbleInfo_Stroke2_Corner2_Rounded as BubbleInfoIcon} from '#/components/icons/BubbleInfo'
 import {ChevronTop_Stroke2_Corner0_Rounded as ChevronUpIcon} from '#/components/icons/Chevron'
@@ -240,6 +241,14 @@ export function SettingsScreen({}: Props) {
             <SettingsList.ItemIcon icon={EarthIcon} />
             <SettingsList.ItemText>
               <Trans>Languages</Trans>
+            </SettingsList.ItemText>
+          </SettingsList.LinkItem>
+          <SettingsList.LinkItem
+            to="/settings/beta-features"
+            label={l`Beta features`}>
+            <SettingsList.ItemIcon icon={BeakerIcon} />
+            <SettingsList.ItemText>
+              <Trans>Beta features</Trans>
             </SettingsList.ItemText>
           </SettingsList.LinkItem>
           <SettingsList.PressableItem

--- a/src/state/preferences/beta-user-sync.tsx
+++ b/src/state/preferences/beta-user-sync.tsx
@@ -1,0 +1,30 @@
+import {useEffect} from 'react'
+
+import {usePreferencesQuery} from '#/state/queries/preferences'
+import {device} from '#/storage'
+
+/**
+ * Caches `bskyAppState.isBetaUser` from preferences into synchronous device
+ * storage so analytics can read it at init (before beta-gated features are
+ * evaluated). Must be mounted below `QueryProvider`, since the analytics
+ * providers that consume the cached value sit above it.
+ *
+ * Lives outside `#/analytics` so that module never imports the preferences
+ * query, which would create a circular import.
+ */
+export function BetaUserStorageSync() {
+  const {data: preferences} = usePreferencesQuery()
+  const isBetaUser = preferences?.bskyAppState?.isBetaUser
+
+  useEffect(() => {
+    if (isBetaUser === undefined) return
+    /*
+     * Guard against a redundant write on every warm boot. Writing triggers the
+     * storage change listener, which remounts the analytics subtree.
+     */
+    if (device.get(['isBetaUser']) === isBetaUser) return
+    device.set(['isBetaUser'], isBetaUser)
+  }, [isBetaUser])
+
+  return null
+}

--- a/src/state/preferences/beta-user-sync.tsx
+++ b/src/state/preferences/beta-user-sync.tsx
@@ -1,30 +1,37 @@
 import {useEffect} from 'react'
 
 import {usePreferencesQuery} from '#/state/queries/preferences'
-import {device} from '#/storage'
+import {useSession} from '#/state/session'
+import {account} from '#/storage'
 
 /**
  * Caches `bskyAppState.isBetaUser` from preferences into synchronous device
  * storage so analytics can read it at init (before beta-gated features are
- * evaluated). Must be mounted below `QueryProvider`, since the analytics
- * providers that consume the cached value sit above it.
+ * evaluated). Scoped per account, since `isBetaUser` is account-specific:
+ * a global cache would let one account's value leak into another after a
+ * switch, until the new account's preferences loaded. Must be mounted below
+ * `QueryProvider`, since the analytics providers that consume the cached value
+ * sit above it.
  *
  * Lives outside `#/analytics` so that module never imports the preferences
  * query, which would create a circular import.
  */
 export function BetaUserStorageSync() {
+  const {currentAccount} = useSession()
+  const did = currentAccount?.did
   const {data: preferences} = usePreferencesQuery()
   const isBetaUser = preferences?.bskyAppState?.isBetaUser
 
   useEffect(() => {
+    if (!did) return
     if (isBetaUser === undefined) return
     /*
      * Guard against a redundant write on every warm boot. Writing triggers the
      * storage change listener, which re-renders the analytics subtree.
      */
-    if (device.get(['isBetaUser']) === isBetaUser) return
-    device.set(['isBetaUser'], isBetaUser)
-  }, [isBetaUser])
+    if (account.get([did, 'isBetaUser']) === isBetaUser) return
+    account.set([did, 'isBetaUser'], isBetaUser)
+  }, [did, isBetaUser])
 
   return null
 }

--- a/src/state/preferences/beta-user-sync.tsx
+++ b/src/state/preferences/beta-user-sync.tsx
@@ -20,7 +20,7 @@ export function BetaUserStorageSync() {
     if (isBetaUser === undefined) return
     /*
      * Guard against a redundant write on every warm boot. Writing triggers the
-     * storage change listener, which remounts the analytics subtree.
+     * storage change listener, which re-renders the analytics subtree.
      */
     if (device.get(['isBetaUser']) === isBetaUser) return
     device.set(['isBetaUser'], isBetaUser)

--- a/src/state/queries/preferences/const.ts
+++ b/src/state/queries/preferences/const.ts
@@ -50,6 +50,7 @@ export const DEFAULT_LOGGED_OUT_PREFERENCES: UsePreferencesQueryResponse = {
     queuedNudges: [],
     activeProgressGuide: undefined,
     nuxs: [],
+    isBetaUser: undefined,
   },
   postInteractionSettings: {
     threadgateAllowRules: undefined,

--- a/src/state/queries/preferences/index.ts
+++ b/src/state/queries/preferences/index.ts
@@ -438,6 +438,21 @@ export function useSetActiveProgressGuideMutation() {
   })
 }
 
+export function useSetIsBetaUserMutation() {
+  const queryClient = useQueryClient()
+  const agent = useAgent()
+
+  return useMutation({
+    mutationFn: async (isBetaUser: boolean) => {
+      await agent.setIsBetaUser(isBetaUser)
+      // triggers a refetch
+      await queryClient.invalidateQueries({
+        queryKey: preferencesQueryKey,
+      })
+    },
+  })
+}
+
 export function useSetVerificationPrefsMutation() {
   const ax = useAnalytics()
   const queryClient = useQueryClient()

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -58,13 +58,6 @@ export type Device = {
   mergedGeolocation?: Geolocation
 
   trendingBetaEnabled: boolean
-  /**
-   * Cached from preferences (`bskyAppState.isBetaUser`) so the GrowthBook
-   * `isBetaUser` attribute can be set synchronously at analytics init, before
-   * beta-gated features (e.g. SearchV2Enable) are first evaluated. Written back
-   * when preferences load.
-   */
-  isBetaUser?: boolean
   devMode: boolean
   demoMode: boolean
   activitySubscriptionsNudged?: boolean
@@ -98,4 +91,16 @@ export type Account = {
    * Recently selected GIFs in the GIF picker. Most recent first, capped at 20.
    */
   recentGifs?: Gif[]
+
+  /**
+   * Cached from preferences (`bskyAppState.isBetaUser`) so the GrowthBook
+   * `isBetaUser` attribute can be set synchronously at analytics init, before
+   * beta-gated features (e.g. SearchV2Enable) are first evaluated. Written back
+   * when preferences load.
+   *
+   * Scoped per account, since `isBetaUser` is account-specific preference data.
+   * Reading it globally would let a beta account's value leak into a non-beta
+   * account after a switch, until that account's preferences loaded.
+   */
+  isBetaUser?: boolean
 }

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -58,6 +58,13 @@ export type Device = {
   mergedGeolocation?: Geolocation
 
   trendingBetaEnabled: boolean
+  /**
+   * Cached from preferences (`bskyAppState.isBetaUser`) so the GrowthBook
+   * `isBetaUser` attribute can be set synchronously at analytics init, before
+   * beta-gated features (e.g. SearchV2Enable) are first evaluated. Written back
+   * when preferences load.
+   */
+  isBetaUser?: boolean
   devMode: boolean
   demoMode: boolean
   activitySubscriptionsNudged?: boolean


### PR DESCRIPTION
Introduces a toggle for a new account-level preference for opting in to beta features.

> [!NOTE]
> At the moment there are no beta features available.

Example of a beta feature:

https://github.com/user-attachments/assets/6592b2ea-28d6-44ca-9b2f-36999eeca10a

With no features available:

https://github.com/user-attachments/assets/7ed039f5-4a57-442e-b2de-cb372c848a63