### PR TITLE
Lazy-load emoji-mart picker on web

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -227,11 +227,6 @@
       "count": 2
     }
   },
-  "src/components/EmojiPicker/preload.web.ts": {
-    "@typescript-eslint/no-floating-promises": {
-      "count": 2
-    }
-  },
   "src/components/FeedCard.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1

--- a/src/components/EmojiPicker/index.web.tsx
+++ b/src/components/EmojiPicker/index.web.tsx
@@ -1,5 +1,13 @@
-import {createContext, useContext, useEffect, useMemo, useRef} from 'react'
-import EmojiPicker from '@emoji-mart/react'
+import {
+  createContext,
+  lazy,
+  Suspense,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react'
+import {View} from 'react-native'
 import {DropdownMenu} from 'radix-ui'
 
 import {useA11y} from '#/state/a11y'
@@ -15,6 +23,24 @@ import {
 } from './types'
 
 export * from './types'
+
+/**
+ * The emoji-mart picker is code-split into its own chunk (`emoji-mart`) so its
+ * weight stays out of the main bundle and is only fetched when the picker
+ * actually mounts (i.e. when the dropdown opens). {@link useWebPreloadEmoji}
+ * warms the same chunk ahead of time.
+ */
+const EmojiPickerLazy = lazy(
+  () => import(/* webpackChunkName: "emoji-mart" */ '@emoji-mart/react'),
+)
+
+/**
+ * Fixed-size placeholder shown while the emoji-mart chunk loads, sized to match
+ * emoji-mart's default picker so the dropdown doesn't visually jump when the
+ * real picker mounts.
+ */
+const PICKER_WIDTH = 352
+const PICKER_HEIGHT = 435
 
 const EmojiPickerContext = createContext<{
   onEmojiSelect: (emoji: Emoji) => void
@@ -124,16 +150,21 @@ export function Picker({keepOpenWhenShiftHeld = true}: PickerProps) {
         <div
           onWheel={evt => evt.stopPropagation()}
           style={flatten([!reduceMotionEnabled && a.zoom_fade_in])}>
-          <EmojiPicker
-            autoFocus
-            onEmojiSelect={(emoji: Emoji) => {
-              onEmojiSelect(emoji)
+          <Suspense
+            fallback={
+              <View style={{width: PICKER_WIDTH, height: PICKER_HEIGHT}} />
+            }>
+            <EmojiPickerLazy
+              autoFocus
+              onEmojiSelect={(emoji: Emoji) => {
+                onEmojiSelect(emoji)
 
-              if (!keepOpenWhenShiftHeld || !isShiftDown.current) {
-                control.close()
-              }
-            }}
-          />
+                if (!keepOpenWhenShiftHeld || !isShiftDown.current) {
+                  control.close()
+                }
+              }}
+            />
+          </Suspense>
         </div>
       </DropdownMenu.Content>
     </DropdownMenu.Portal>

--- a/src/components/EmojiPicker/preload.web.ts
+++ b/src/components/EmojiPicker/preload.web.ts
@@ -24,9 +24,9 @@ export function useWebPreloadEmoji({immediate}: {immediate?: boolean} = {}) {
         import(/* webpackChunkName: "emoji-mart" */ 'emoji-mart'),
         import(/* webpackChunkName: "emoji-mart-data" */ '@emoji-mart/data'),
       ])
-      init({data})
+      await init({data})
     } catch (e) {}
   }, [])
-  if (immediate) preload()
+  if (immediate) void preload()
   return preload
 }

--- a/src/components/EmojiPicker/preload.web.ts
+++ b/src/components/EmojiPicker/preload.web.ts
@@ -1,5 +1,4 @@
 import {useCallback} from 'react'
-import {init} from 'emoji-mart'
 
 /**
  * Only load the emoji picker data once per page load.
@@ -21,7 +20,10 @@ export function useWebPreloadEmoji({immediate}: {immediate?: boolean} = {}) {
     if (loadRequested) return
     loadRequested = true
     try {
-      const data = (await import('@emoji-mart/data')).default
+      const [{init}, {default: data}] = await Promise.all([
+        import(/* webpackChunkName: "emoji-mart" */ 'emoji-mart'),
+        import(/* webpackChunkName: "emoji-mart-data" */ '@emoji-mart/data'),
+      ])
       init({data})
     } catch (e) {}
   }, [])


### PR DESCRIPTION
## Why

The emoji picker data (`@emoji-mart/data`) was already lazily imported, but the picker *code* wasn't: `preload.web.ts` had a static `import {init} from 'emoji-mart'`, and since the `emoji-mart` entry exports both `init` and `Picker`, the whole library (~163KB ESM) was pulled into the main bundle anyway — plus the static `@emoji-mart/react` import in `index.web.tsx`.

## What

- `preload.web.ts`: the `init` import is now dynamic, loaded via `Promise.all` alongside the data inside the existing once-per-page-load preload callback. Both carry `webpackChunkName` magic comments (`emoji-mart` / `emoji-mart-data`).
- `index.web.tsx`: `@emoji-mart/react` is now `React.lazy`, sharing the same `emoji-mart` chunk name. The picker renders inside a Radix `DropdownMenu.Portal`/`Content` without `forceMount`, so it only mounts when the dropdown opens — which is exactly when the lazy import fires. The `Suspense` fallback is a fixed-size placeholder matching emoji-mart's default dimensions (352×435) so the dropdown doesn't jump when the real picker pops in.
- In practice the chunk is usually warm before the user ever opens the picker: `useWebPreloadEmoji` fires on `Root` mount and imports `emoji-mart`, which shares the chunk with the `@emoji-mart/react` wrapper.

All three call sites (post composer, DM composer, DM reaction picker) go through the same `Picker`, so no call-site changes. Native is untouched (it uses stubs / `expo-emoji-picker`).

## Test plan

- `pnpm typecheck`, `pnpm lint` pass; `pnpm test` passes scoped to the main tree (34 suites, 0 failures).
- Manual: open the composer on web, click the emoji button — picker loads and inserts emoji normally; DevTools Network shows the `emoji-mart` chunk loading on composer mount (preload) rather than page load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)