### PR TITLE
Fix Android crash in chat keyboard scroll (part 2)

### DIFF
--- a/patches/react-native-keyboard-controller@1.21.8.patch
+++ b/patches/react-native-keyboard-controller@1.21.8.patch
@@ -1,3 +1,26 @@
+diff --git a/src/components/KeyboardChatScrollView/useChatKeyboard/index.ts b/src/components/KeyboardChatScrollView/useChatKeyboard/index.ts
+index 48178d9246ab94d701983ac20473983eb746d1a6..451d38e6e20646c32795db3be28fbea57de1d12f 100644
+--- a/src/components/KeyboardChatScrollView/useChatKeyboard/index.ts
++++ b/src/components/KeyboardChatScrollView/useChatKeyboard/index.ts
+@@ -172,6 +172,18 @@ function useChatKeyboard(
+ 
+         currentHeight.value = e.height;
+ 
++        if (scrollViewRef() == null) {
++          // The scroll view can be detached or not yet attached while a
++          // keyboard animation is running (e.g. the chat list re-creating its
++          // scroll component mid-animation). Every branch below eventually
++          // calls scrollTo (directly or via clampScrollIfNeeded); on Paper
++          // reanimated's scrollTo would hand the null ref to the native
++          // _scrollToPaper HostFunction, which throws "Value is null, expected
++          // a number" and crashes in release builds. currentHeight is kept up
++          // to date above so the animated style keeps committing.
++          return;
++        }
++
+         if (inverted) {
+           // Skip post-interactive snap-back (duration === -1)
+           if (e.duration === -1) {
 diff --git a/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts b/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts
 index 0f6d7c67a307885310ab184fdf9e7a5c7b296825..1a01093e7909973cef5268f999158df389e77634 100644
 --- a/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,7 +228,7 @@ patchedDependencies:
   react-native-compressor@1.13.0: 58379dfaace6ced8590cb341c77f2ca8099dfa8f7df6297032ec51de767a9925
   react-native-date-picker@5.0.13: f2a6697da7a7ca79b4f39efda142eee1b82db6de3aa5010ad4bd59df41fe2ce1
   react-native-drawer-layout@4.2.3: 74f2c043cc22ab87054f219e7c7373a509b779b18bfa79d27e7d051d73355130
-  react-native-keyboard-controller@1.21.8: 2f6791837622fb391c3e41fc044b91ddedbe503da14da86165ee0a73924b05f1
+  react-native-keyboard-controller@1.21.8: ac52bf7502ff3ad34a8594b5e1a916b96bf87a2523b6abc87c31f03607d52271
   react-native-pager-view@6.8.0: 0979d6fe1e2fa43b2784cc0b5e0ff0117d53b53423e85ee5855eefdc41a00108
   react-native-reanimated@3.19.1: 97a1967f37a4213fbab59e1fd59a1bf859b5efc79af5e1b528a47fe488e6c5d6
   react-native-svg@15.12.1: 31401fa6ff01498773afb51a7b066821c471eb3e71b0764a10017938beed49e9
@@ -639,7 +639,7 @@ importers:
         version: 2.28.0(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-keyboard-controller:
         specifier: ^1.21.8
-        version: 1.21.8(patch_hash=2f6791837622fb391c3e41fc044b91ddedbe503da14da86165ee0a73924b05f1)(react-native-reanimated@3.19.1(patch_hash=97a1967f37a4213fbab59e1fd59a1bf859b5efc79af5e1b528a47fe488e6c5d6)(@babel/core@7.29.0)(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        version: 1.21.8(patch_hash=ac52bf7502ff3ad34a8594b5e1a916b96bf87a2523b6abc87c31f03607d52271)(react-native-reanimated@3.19.1(patch_hash=97a1967f37a4213fbab59e1fd59a1bf859b5efc79af5e1b528a47fe488e6c5d6)(@babel/core@7.29.0)(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-pager-view:
         specifier: 6.8.0
         version: 6.8.0(patch_hash=0979d6fe1e2fa43b2784cc0b5e0ff0117d53b53423e85ee5855eefdc41a00108)(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -17878,7 +17878,7 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
-  react-native-keyboard-controller@1.21.8(patch_hash=2f6791837622fb391c3e41fc044b91ddedbe503da14da86165ee0a73924b05f1)(react-native-reanimated@3.19.1(patch_hash=97a1967f37a4213fbab59e1fd59a1bf859b5efc79af5e1b528a47fe488e6c5d6)(@babel/core@7.29.0)(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+  react-native-keyboard-controller@1.21.8(patch_hash=ac52bf7502ff3ad34a8594b5e1a916b96bf87a2523b6abc87c31f03607d52271)(react-native-reanimated@3.19.1(patch_hash=97a1967f37a4213fbab59e1fd59a1bf859b5efc79af5e1b528a47fe488e6c5d6)(@babel/core@7.29.0)(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
       react-native: 0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)


### PR DESCRIPTION
## The crash

The dominant `com.facebook.jni.CppException` on Android ([APP-SDPY](https://blueskyweb.sentry.io/issues/APP-SDPY), ~3.9k events / 2.5k users) is still occurring on every release since the fix in #10673:

```
Exception in HostFunction: Value is null, expected a number
    at _scrollToPaper (native)
    at scrollToPaper_reactNativeReanimated_scrollToTs2 (:1:156)
    at reactNativeKeyboardController_indexTs3 (:1:2958)
    at call (native)
    at reactNativeKeyboardController_indexTs1 (:1:465)
    at handleAndFlushAnimationFrame_reactNativeReanimated_coreTs1 (:1:178)
```

## Why #10673 didn't fully fix it

#10673 guarded the **deferred** (`requestAnimationFrame`) `scrollTo` path in `KeyboardChatScrollView/useExtraContentPadding/index.ts`. But the surviving stack is the **synchronous** path: `handleAndFlushAnimationFrame` here is reanimated's wrapper around every registered event handler (not a rAF callback), so this is the `useKeyboardHandler` `onMove` worklet in the sibling file `KeyboardChatScrollView/useChatKeyboard/index.ts`, which calls `scrollTo` in five places (plus via `clampScrollIfNeeded`) with no null guard. Both files are `index.ts`, so the minified worklet names look nearly identical.

When the chat ScrollView detaches mid-keyboard-animation (navigating away, or the list re-creating its scroll component), the animated ref resolves to null, and on Paper reanimated hands that null straight to the native `_scrollToPaper` HostFunction, which throws. Worklets are only call-guarded in debug builds, so in release the JS error escapes as a fatal `CppException`.

## The fix

Extends the existing `react-native-keyboard-controller` patch with a single early-return null-ref guard at the top of the `onMove` worklet (after the `currentHeight` bookkeeping that the commit-forcing animated style depends on, before every branch that leads to a `scrollTo`). This covers all five direct call sites plus `clampScrollIfNeeded`, which is only ever invoked from `onMove`. Same style as the guard from #10673.

Worth upstreaming both guards to kirillzyusko/react-native-keyboard-controller as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)