### PR TITLE
Stub out react-native-svg fetchData on web to drop buffer polyfill

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 const createExpoWebpackConfigAsync = require('@expo/webpack-config')
 const {withAlias} = require('@expo/webpack-config/addons')
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin')
@@ -46,11 +48,34 @@ module.exports = async function (env, argv) {
     dangerouslyAddModulePathsToTranspile: ['@bsky.app/expo', '@atproto/api'],
   }
   let config = await createExpoWebpackConfigAsync(env, argv)
+  /*
+   * Expo only registers its own internal config as a cache build dependency,
+   * so changes to this file (e.g. aliases) don't invalidate the persistent
+   * filesystem cache and stale module resolutions get reused. Register this
+   * file so edits here always bust the cache.
+   */
+  if (config.cache?.buildDependencies) {
+    config.cache.buildDependencies.config = [
+      ...(config.cache.buildDependencies.config || []),
+      __filename,
+    ]
+  }
   config = withAlias(config, {
     'react-native$': 'react-native-web',
     'react-native-webview': 'react-native-web-webview',
     'react-native-gesture-handler': false, // RNGH should not be used on web, so let's cause a build error if it sneaks in
     '@sentry-internal/replay': false, // not used, ~300kb of dead weight
+    /*
+     * react-native-svg's fetchData util imports the ~55KB `buffer` polyfill,
+     * but is only needed by SvgUri/SvgXml remote loading, which we don't use.
+     * Stubbing it out makes fetchText undefined, so it throws if ever called.
+     * The alias key must be an absolute path because the package imports it
+     * via a relative path internally.
+     */
+    [path.join(
+      __dirname,
+      'node_modules/react-native-svg/lib/module/utils/fetchData',
+    )]: false,
   })
 
   // react-native-uuid ships sourceMappingURL comments but no .map files.


### PR DESCRIPTION
## Why

The `buffer` polyfill (~55KB stat size, plus `base64-js` + `ieee754`) was landing in the **initial** web bundle. The only importer is `react-native-svg`'s `utils/fetchData.js`, which uses `Buffer.from(x, 'base64')` to decode base64 data URIs for `SvgUri`/`SvgXml` remote loading – a feature we don't use anywhere. The package has no `sideEffects` field, so webpack can't tree-shake it out of the barrel export. (It also doesn't declare `buffer` as a dependency – it only resolves via hoisting from unrelated packages.)

## How

- Alias the absolute path of `react-native-svg/lib/module/utils/fetchData` to `false` in `webpack.config.js`. The key must be an absolute path because the package imports it via a relative path internally. Webpack replaces the module with an empty stub, so `fetchText` becomes `undefined` – if `SvgUri`/`SvgXml` remote loading ever sneaks in, it throws immediately rather than silently bloating the bundle.
- Register our `webpack.config.js` in `cache.buildDependencies.config`. Expo only registers its own internal config, so edits to ours (like this alias) didn't invalidate the persistent filesystem cache and the alias was silently ignored on cached rebuilds.
- Add `webpack.config.js` to the ESLint ignore list (Node.js config file, was never linted before the flat-config migration and fails `no-nodejs-modules` + type-checked rules).

## Verification

Built with `EXPO_PUBLIC_GENERATE_STATS=1` and confirmed via `stats.json`: `buffer`, `base64-js`, and `ieee754` are gone; `fetchData` shows as a 15-byte `(ignored)` module. Also grepped the emitted chunks for the polyfill's signature strings – no matches.

<img width="1184" height="895" alt="Screenshot 2026-07-08 at 16 14 09" src="https://github.com/user-attachments/assets/d6e990ef-b472-4f5a-9606-ba2d9c3e34de" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)