### PR TITLE
Lazy load @ipld/dag-cbor in computeCid

### DIFF
--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -16,7 +16,6 @@ import {
   RichText,
 } from '@atproto/api'
 import {TID} from '@atproto/common-web'
-import * as dcbor from '@ipld/dag-cbor'
 import {t} from '@lingui/core/macro'
 import {type QueryClient} from '@tanstack/react-query'
 import {sha256} from 'js-sha256'
@@ -505,6 +504,12 @@ const mf_sha256 = Hasher.from({
 })
 
 async function computeCid(record: AppBskyFeedPost.Record): Promise<string> {
+  /*
+   * Lazily loaded since it's only needed when posting a thread, and its
+   * `cborg` dependency is ~190KB that would otherwise be in the initial
+   * web bundle.
+   */
+  const dcbor = await import('@ipld/dag-cbor')
   // IMPORTANT: `prepareObject` prepares the record to be hashed by removing
   // fields with undefined value, and converting BlobRef instances to the
   // right IPLD representation.


### PR DESCRIPTION
## Why

`@ipld/dag-cbor` and its `cborg` dependency (~190KB stat size combined) were in the initial web bundle, but they have exactly one consumer in the whole module graph: `computeCid()` in `src/lib/api/index.ts`, which is only called when posting a thread (to compute the CID of the just-created post so the next post can reference it as its reply parent).

## How

Switched the static import to a dynamic `await import('@ipld/dag-cbor')` inside `computeCid`. The function is already async and its only call site already awaits it, so there's no behavior change – the chunk downloads once, during a network-bound flow.

## Verification

Built with `EXPO_PUBLIC_GENERATE_STATS=1` and confirmed via `stats.json`: `@ipld/dag-cbor` and all `cborg` modules moved from the initial chunk to an async chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)