### PR TITLE
Fix search typeahead performance with absolute overlay

### DIFF
--- a/src/screens/Search/Shell.tsx
+++ b/src/screens/Search/Shell.tsx
@@ -13,6 +13,11 @@ import {
   View,
   type ViewStyle,
 } from 'react-native'
+import Animated, {
+  Easing,
+  FadeInDown,
+  FadeOutDown,
+} from 'react-native-reanimated'
 import {setStringAsync} from 'expo-clipboard'
 import {Trans, useLingui} from '@lingui/react/macro'
 import {useFocusEffect, useNavigation, useRoute} from '@react-navigation/native'
@@ -41,7 +46,15 @@ import {
   withoutFilterParams,
 } from '#/screens/Search/searchParams'
 import {makeSearchQuery} from '#/screens/Search/utils'
-import {atoms as a, tokens, useBreakpoints, useTheme, web} from '#/alf'
+import {
+  atoms as a,
+  native,
+  platform,
+  tokens,
+  useBreakpoints,
+  useTheme,
+  web,
+} from '#/alf'
 import {useAutocomplete} from '#/components/Autocomplete'
 import {Button, ButtonIcon} from '#/components/Button'
 import {ArrowLeft_Stroke2_Corner0_Rounded as ArrowLeftIcon} from '#/components/icons/Arrow'
@@ -387,13 +400,14 @@ export function SearchScreenShell({
 
   const handleProfileClick = useCallback(
     (profile: bsky.profile.AnyProfileView) => {
+      updateSearchText('')
       unstableCacheProfileView(queryClient, profile)
       // Slight delay to avoid updating during push nav animation.
       setTimeout(() => {
         updateProfileHistory(profile)
       }, 400)
     },
-    [updateProfileHistory, queryClient],
+    [updateProfileHistory, queryClient, updateSearchText],
   )
 
   /**
@@ -467,6 +481,17 @@ export function SearchScreenShell({
       setShowAutocomplete(true)
     }
   }, [setShowAutocomplete])
+
+  const onSearchInputBlur = useCallback(() => {
+    /*
+     * Bind autocomplete visibility to focus state on native. On web this
+     * doesn't work because of focus management, which would render the
+     * autocomplete results uninteractable.
+     */
+    if (IS_NATIVE) {
+      setShowAutocomplete(false)
+    }
+  }, [])
 
   const focusSearchInput = useCallback(
     (tab?: TabParam) => {
@@ -579,6 +604,7 @@ export function SearchScreenShell({
                       ref={textInput}
                       value={searchText}
                       onFocus={onSearchInputFocus}
+                      onBlur={onSearchInputBlur}
                       onChangeText={onChangeText}
                       onClearText={onPressClearQuery}
                       onSubmitEditing={onSubmit('typed')}
@@ -625,51 +651,56 @@ export function SearchScreenShell({
         </Layout.Center>
       </View>
 
-      <View
-        style={{
-          display: showAutocomplete && !fixedParams ? 'flex' : 'none',
-          flex: 1,
-        }}>
-        {searchText.length > 0 && IS_NATIVE ? (
-          <AutocompleteResults
-            items={autocompleteItems}
-            isFetching={isAutocompleteFetching}
-            searchText={searchText}
-            onSubmit={onSubmit('autocomplete')}
-            onResultPress={onAutocompleteResultPress}
-            onProfileClick={handleProfileClick}
+      <View style={[a.flex_1, a.relative]}>
+        <View style={[a.flex_1, web(showAutocomplete && a.hidden)]}>
+          <SearchScreenInner
+            key={filters.lang ?? ''}
+            activeTab={activeTab}
+            setActiveTab={setActiveTab}
+            query={query}
+            queryWithParams={queryWithParams}
+            filters={filters}
+            hasFilters={hasFilters}
+            headerHeight={headerHeight}
+            focusSearchInput={focusSearchInput}
           />
-        ) : (
-          <SearchHistory
-            searchHistory={termHistory}
-            selectedProfiles={
-              accountHistoryProfiles?.profiles.filter(p =>
-                accountHistory.includes(p.did),
-              ) ?? []
-            }
-            onItemClick={handleHistoryItemClick}
-            onProfileClick={handleProfileClick}
-            onRemoveItemClick={deleteSearchHistoryItem}
-            onRemoveProfileClick={deleteProfileHistoryItem}
-          />
+        </View>
+
+        {showAutocomplete && !fixedParams && (
+          <Animated.View
+            entering={native(FadeInDown.easing(Easing.out(Easing.cubic)))}
+            exiting={native(FadeOutDown.easing(Easing.out(Easing.cubic)))}
+            style={platform({
+              web: [a.flex_1],
+              native: [t.atoms.bg, a.absolute, a.inset_0],
+            })}
+            accessibilityViewIsModal
+            accessibilityRole="list">
+            {searchText.length > 0 && IS_NATIVE ? (
+              <AutocompleteResults
+                items={autocompleteItems}
+                isFetching={isAutocompleteFetching}
+                searchText={searchText}
+                onSubmit={onSubmit('autocomplete')}
+                onResultPress={onAutocompleteResultPress}
+                onProfileClick={handleProfileClick}
+              />
+            ) : (
+              <SearchHistory
+                searchHistory={termHistory}
+                selectedProfiles={
+                  accountHistoryProfiles?.profiles.filter(p =>
+                    accountHistory.includes(p.did),
+                  ) ?? []
+                }
+                onItemClick={handleHistoryItemClick}
+                onProfileClick={handleProfileClick}
+                onRemoveItemClick={deleteSearchHistoryItem}
+                onRemoveProfileClick={deleteProfileHistoryItem}
+              />
+            )}
+          </Animated.View>
         )}
-      </View>
-      <View
-        style={{
-          display: showAutocomplete ? 'none' : 'flex',
-          flex: 1,
-        }}>
-        <SearchScreenInner
-          key={filters.lang ?? ''}
-          activeTab={activeTab}
-          setActiveTab={setActiveTab}
-          query={query}
-          queryWithParams={queryWithParams}
-          filters={filters}
-          hasFilters={hasFilters}
-          headerHeight={headerHeight}
-          focusSearchInput={focusSearchInput}
-        />
       </View>
     </Layout.Screen>
   )

--- a/src/screens/Search/components/SearchHistory.tsx
+++ b/src/screens/Search/components/SearchHistory.tsx
@@ -1,8 +1,8 @@
-import {Pressable, ScrollView, View} from 'react-native'
+import {ScrollView, View} from 'react-native'
 import {moderateProfile, type ModerationOpts} from '@atproto/api'
 import {Plural, Trans, useLingui} from '@lingui/react/macro'
 
-import {createHitslop, HITSLOP_10} from '#/lib/constants'
+import {createHitslop} from '#/lib/constants'
 import {makeProfileLink} from '#/lib/routes/links'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {sanitizeHandle} from '#/lib/strings/handles'
@@ -89,7 +89,7 @@ export function SearchHistory({
         )}
 
         {searchHistory.length > 0 && (
-          <View style={[a.px_lg, a.pt_sm]}>
+          <View style={[a.pt_sm]}>
             {searchHistory.slice(0, 5).map((historyItem, index) => {
               const {q, filters} = parseHistoryEntry(historyItem)
               const filterCount = countActiveFilters(filters)
@@ -132,38 +132,60 @@ function SearchHistoryItem({
   const {t: l} = useLingui()
 
   return (
-    <View style={[a.flex_row, a.gap_sm, a.align_center]}>
-      <Pressable
-        accessibilityRole="button"
-        onPress={onPress}
-        hitSlop={HITSLOP_10}
-        style={[a.flex_1, a.py_sm, a.flex_row, a.align_center, a.gap_sm]}>
-        <Text style={[a.text_md, a.flex_shrink]} numberOfLines={1}>
-          {q}
-        </Text>
-        {filterCount > 0 ? (
+    <View style={[a.flex_row, a.align_center]}>
+      <Button label={l`Search for ${q}`} onPress={onPress} style={[a.flex_1]}>
+        {({hovered, focused, pressed}) => (
           <View
             style={[
-              a.flex_shrink_0,
-              a.rounded_sm,
-              a.px_sm,
-              a.py_2xs,
-              t.atoms.bg_contrast_25,
+              a.flex_1,
+              a.flex_row,
+              a.align_center,
+              a.gap_sm,
+              a.px_lg,
+              a.py_md,
+              a.pr_5xl,
+              (hovered || focused || pressed) && t.atoms.bg_contrast_25,
             ]}>
             <Text
-              style={[a.text_xs, a.font_medium, t.atoms.text_contrast_medium]}>
-              <Plural value={filterCount} one="+# filter" other="+# filters" />
+              emoji
+              style={[a.text_md, a.leading_snug, a.flex_shrink]}
+              numberOfLines={1}>
+              {q}
             </Text>
+            {filterCount > 0 ? (
+              <View
+                style={[
+                  a.flex_shrink_0,
+                  a.rounded_sm,
+                  a.px_sm,
+                  a.py_2xs,
+                  t.atoms.bg_contrast_25,
+                ]}>
+                <Text
+                  style={[
+                    a.text_xs,
+                    a.font_medium,
+                    t.atoms.text_contrast_medium,
+                  ]}>
+                  <Plural
+                    value={filterCount}
+                    one="+# filter"
+                    other="+# filters"
+                  />
+                </Text>
+              </View>
+            ) : null}
           </View>
-        ) : null}
-      </Pressable>
+        )}
+      </Button>
       <Button
         label={l`Remove ${q}`}
         onPress={onRemove}
         size="small"
         variant="ghost"
         color="secondary"
-        shape="round">
+        shape="round"
+        style={[a.absolute, {right: 16}, a.bg_transparent]}>
         <ButtonIcon icon={XIcon} />
       </Button>
     </View>


### PR DESCRIPTION
Reapplies the changes from #10102, adapted to the current codebase. Mostly for native — web remains broadly the same.

## Summary

- **`SearchScreenInner` stays always mounted on native** instead of being toggled with `display: none/flex`, eliminating costly unmount/remount cycles when focusing the search input
- **Typeahead panel is now absolutely positioned** over the content with `a.absolute, a.inset_0` and an opaque background
- **Reanimated layout animations** (`FadeInDown`/`FadeOutDown`) on native for a smooth overlay transition (skipped on web via `native()` wrapper)
- **Accessible**: `accessibilityViewIsModal` and `accessibilityRole="list"` so screen readers treat the overlay properly
- **Blur hides the autocomplete on native** so visibility is bound to input focus state (web keeps its existing focus management, which would otherwise render results uninteractable)
- **Recent search rows restyled** as full-width pressable rows with hover/press feedback, X button absolutely positioned at the right



https://github.com/user-attachments/assets/0985f87b-5592-43d1-86c0-9460da96aff8



## Adaptations vs #10102

The files had drifted since the original PR (`useAutocomplete` hook, advanced-search filters, filter-count chip on history items), so this is an adaptation rather than a clean reapply:

- Kept the current `searchText.length > 0 && IS_NATIVE` conditional and current prop shapes for `AutocompleteResults`/`SearchHistory`/`SearchScreenInner`
- `handleProfileClick` clears the search text via the current `updateSearchText` wrapper (syncs `searchTextRef`) rather than raw `setSearchText`
- Kept the newer filter-count chip inside history rows, with `a.pr_5xl` so long queries don't run under the absolute X button
- Fixed a bug in the original diff: `onPress={() => onRemove}` on the remove button never fired; now `onPress={onRemove}`

## Test plan

- [ ] Focus/unfocus the search input on iOS and Android — should be noticeably faster with no layout jank
- [ ] Verify typeahead suggestions and search history render correctly over the content
- [ ] Verify fade-in / fade-out animation is smooth on native
- [ ] Verify web has no animation but instant show/hide works correctly
- [ ] Test with VoiceOver (iOS) / TalkBack (Android) — overlay should be announced as a modal list
- [ ] Verify search results / Explore content is not re-mounted when toggling autocomplete
- [ ] Verify removing a recent search item works (bugfix vs original PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)