### PR TITLE
Fix crash when maxHeight is nil at sheet presentation

### DIFF
--- a/modules/bottom-sheet/ios/SheetView.swift
+++ b/modules/bottom-sheet/ios/SheetView.swift
@@ -32,9 +32,12 @@ class SheetView: ExpoView, UISheetPresentationControllerDelegate {
   var cornerRadius: CGFloat?
   var sourceViewTag: Int?
   var minHeight = 0.0
-  var maxHeight: CGFloat! {
+  // getScreenHeight() is nil when no window scene is connected yet (e.g. during
+  // prewarming or a background launch). A nil here previously trapped in
+  // clampHeight, so fall back to the full screen bounds instead.
+  var maxHeight: CGFloat = UIScreen.main.bounds.height {
     didSet {
-      let screenHeight = Util.getScreenHeight() ?? 0
+      let screenHeight = Util.getScreenHeight() ?? UIScreen.main.bounds.height
       if maxHeight > screenHeight {
         maxHeight = screenHeight
       }
@@ -77,7 +80,7 @@ class SheetView: ExpoView, UISheetPresentationControllerDelegate {
 
   required init (appContext: AppContext? = nil) {
     super.init(appContext: appContext)
-    self.maxHeight = Util.getScreenHeight()
+    self.maxHeight = Util.getScreenHeight() ?? UIScreen.main.bounds.height
     self.touchHandler = RCTTouchHandler(bridge: appContext?.reactBridge)
     SheetManager.shared.add(self)
   }


### PR DESCRIPTION
## Why

[APP-SDRW](https://blueskyweb.sentry.io/issues/APP-SDRW) (~1,850 events lifetime, ~230/30d): `EXC_BREAKPOINT` Swift trap in `SheetView`, with a deterministic stack across all sampled events:

```
SheetView.layoutSubviews (SheetView.swift:108)
→ SheetView.present (SheetView.swift:136)
→ SheetView.clampHeight
→ compiler-generated value accessor  ← trap
```

## Root cause

`var maxHeight: CGFloat!` is initialized in `init` from `Util.getScreenHeight()`, which returns `CGFloat?` — nil when no window scene is connected yet (app prewarming, background launch). Property observers don't fire during `init`, so the nil is stored silently, and if the JS `maxHeight` prop never sets it, `clampHeight`'s `height > self.maxHeight` force-unwraps nil and traps on the first sheet presentation.

There's a secondary bug in the same property: the `didSet` clamped against `Util.getScreenHeight() ?? 0`, so a nil at prop-set time would clamp `maxHeight` to 0, producing a zero-height sheet.

## Fix

Make `maxHeight` a non-optional `CGFloat` defaulting to `UIScreen.main.bounds.height`, and use the same full-screen-bounds fallback (instead of nil / 0) in `init` and the `didSet` clamp. `UIScreen.main.bounds` is always available regardless of scene state; the safe-area-adjusted height from `getScreenHeight()` still wins whenever a window exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)