### PR TITLE
Add mark requests as read to chat settings menu

### DIFF
--- a/src/screens/Messages/ChatList.tsx
+++ b/src/screens/Messages/ChatList.tsx
@@ -661,7 +661,7 @@ function ChatSettingsMenu({
             </Menu.ItemText>
           </Menu.Item>
           <Menu.Item
-            label={l`Mark all chats as read`}
+            label={l`Mark all requests as read`}
             onPress={() => markAllRequestsRead()}>
             <Menu.ItemIcon icon={InboxIcon} />
             <Menu.ItemText>

--- a/src/screens/Messages/ChatList.tsx
+++ b/src/screens/Messages/ChatList.tsx
@@ -41,7 +41,10 @@ import {ArrowRotateCounterClockwise_Stroke2_Corner0_Rounded as RetryIcon} from '
 import {BubbleSmile_Stroke2_Corner2_Rounded_Large as BubbleSmileIcon} from '#/components/icons/Bubble'
 import {CircleCheck_Stroke2_Corner0_Rounded as CircleCheckIcon} from '#/components/icons/CircleCheck'
 import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfoIcon} from '#/components/icons/CircleInfo'
-import {Inbox_Stroke2_Corner2_Rounded_Large as InboxLargeIcon} from '#/components/icons/Inbox'
+import {
+  Inbox_Stroke2_Corner2_Rounded as InboxIcon,
+  Inbox_Stroke2_Corner2_Rounded_Large as InboxLargeIcon,
+} from '#/components/icons/Inbox'
 import {
   MessagePlus_Stroke2_Corner0_Rounded as MessagePlusIcon,
   MessagePlus_Stroke2_Corner0_Rounded as NewChatIcon,
@@ -635,6 +638,15 @@ function ChatSettingsMenu({
     },
   })
 
+  const {mutate: markAllRequestsRead} = useUpdateAllRead('request', {
+    onMutate: () => {
+      Toast.show(l`Marked all requests as read`, {type: 'success'})
+    },
+    onError: () => {
+      Toast.show(l`Failed to mark all requests as read`, {type: 'error'})
+    },
+  })
+
   return (
     <Menu.Root>
       <Menu.Trigger label={l`Chat options`}>{children}</Menu.Trigger>
@@ -646,6 +658,14 @@ function ChatSettingsMenu({
             <Menu.ItemIcon icon={CircleCheckIcon} />
             <Menu.ItemText>
               <Trans>Mark all chats as read</Trans>
+            </Menu.ItemText>
+          </Menu.Item>
+          <Menu.Item
+            label={l`Mark all chats as read`}
+            onPress={() => markAllRequestsRead()}>
+            <Menu.ItemIcon icon={InboxIcon} />
+            <Menu.ItemText>
+              <Trans>Mark all requests as read</Trans>
             </Menu.ItemText>
           </Menu.Item>
           <Menu.Item


### PR DESCRIPTION
Adds “Mark all requests as read” to the chat settings menu for parity with the long-press menu.

https://github.com/user-attachments/assets/35c03f3c-4bdf-483c-a302-c07080b98b83