### PR TITLE
Potentially fix disappearing chat emoji on some devices

### DIFF
--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -580,14 +580,6 @@ let MessageItem = ({
                                 android: {marginTop: a.mt_2xs.marginTop},
                                 default: {marginBottom: -a.mb_sm.marginBottom},
                               }),
-                            /*
-                             * On Android, give the enlarged glyph run a
-                             * self-contained draw box so a re-measure can't clip
-                             * the trailing emoji. `includeFontPadding` restores
-                             * the ascent/descent slack that `leading_tight`
-                             * removes.
-                             */
-                            platform({android: {includeFontPadding: true}}),
                           ],
                         ]}
                         interactiveStyle={a.underline}

--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -246,6 +246,8 @@ let MessageItem = ({
 
   const rt = new RichTextAPI({text: message.text, facets: message.facets})
 
+  const isEmojiOnly = isOnlyEmoji(message.text)
+
   const hasEmbed =
     AppBskyEmbedRecord.isView(message.embed) ||
     ChatBskyEmbedJoinLink.isView(message.embed)
@@ -261,16 +263,33 @@ let MessageItem = ({
   const topRadiusSV = useSharedValue(targetTopRadius)
 
   const showDisplayName =
-    isGroupChat && !isFromSelf && isFirstInCluster && !isOnlyEmoji(message.text)
+    isGroupChat && !isFromSelf && isFirstInCluster && !isEmojiOnly
   const showAvatar = isGroupChat && !isFromSelf && isLastInCluster
 
+  /*
+   * Emoji-only messages have no bubble background (see the `!isOnlyEmoji` gate
+   * on the bubble styling below), so the corner-radius animation is invisible
+   * overhead for them. Worse, on Android the resulting re-layout of the parent
+   * Animated.View re-measures the enlarged emoji `<Text>` and some Android
+   * device's text stack drops the trailing glyph on that second pass (while
+   * keeping its reserved width). Set the radii directly for emoji-only messages
+   * so nothing re-lays-out the glyph after its initial paint.
+   */
   useEffect(() => {
-    bottomRadiusSV.set(withTiming(targetBottomRadius, {duration: 300}))
-  }, [targetBottomRadius, bottomRadiusSV])
+    bottomRadiusSV.set(
+      isEmojiOnly
+        ? targetBottomRadius
+        : withTiming(targetBottomRadius, {duration: 300}),
+    )
+  }, [targetBottomRadius, bottomRadiusSV, isEmojiOnly])
 
   useEffect(() => {
-    topRadiusSV.set(withTiming(targetTopRadius, {duration: 300}))
-  }, [targetTopRadius, topRadiusSV])
+    topRadiusSV.set(
+      isEmojiOnly
+        ? targetTopRadius
+        : withTiming(targetTopRadius, {duration: 300}),
+    )
+  }, [targetTopRadius, topRadiusSV, isEmojiOnly])
 
   // Flash the message background when it's been scrolled to (e.g. by tapping a
   // reply that quotes it), so it's easy to spot. Keyed on the highlight `key`
@@ -521,7 +540,7 @@ let MessageItem = ({
                       accessibilityHint={l`Double tap or long press the message to add a reaction`}
                       style={[
                         !isFromSelf && isGroupChat && a.ml_sm,
-                        !isOnlyEmoji(message.text) && [
+                        !isEmojiOnly && [
                           a.rounded_xl,
                           a.py_sm,
                           a.px_md,
@@ -536,7 +555,7 @@ let MessageItem = ({
                           highlightStyle,
                         ],
                       ]}>
-                      {replyTo && !isOnlyEmoji(message.text) ? (
+                      {replyTo && !isEmojiOnly ? (
                         <ReplyQuote
                           replyTo={replyTo}
                           isFromSelf={isFromSelf}
@@ -553,7 +572,7 @@ let MessageItem = ({
                           // glyph, then pull the bottom up by the same amount so
                           // the glyph bottom-aligns with the avatar instead of
                           // sitting above its line-box baseline.
-                          isOnlyEmoji(message.text) && [
+                          isEmojiOnly && [
                             a.leading_tight,
                             // Visually align bottom of the emoji with the avatar
                             !isFromSelf &&
@@ -561,6 +580,14 @@ let MessageItem = ({
                                 android: {marginTop: a.mt_2xs.marginTop},
                                 default: {marginBottom: -a.mb_sm.marginBottom},
                               }),
+                            /*
+                             * On Android, give the enlarged glyph run a
+                             * self-contained draw box so a re-measure can't clip
+                             * the trailing emoji. `includeFontPadding` restores
+                             * the ascent/descent slack that `leading_tight`
+                             * removes.
+                             */
+                            platform({android: {includeFontPadding: true}}),
                           ],
                         ]}
                         interactiveStyle={a.underline}


### PR DESCRIPTION
This was reported on a Samsung S22 Ultra:

https://github.com/user-attachments/assets/c4624c5d-de33-4406-b2eb-5bde320d938b

I’ve been unable to repro it on other Android devices, so this is a potential fix:

* Don’t bother animating the border radius on emoji-only messages since we don’t show them in bubbles anyway (avoids a second render).