### PR TITLE
Add From: Me to advanced search filters

### DIFF
--- a/src/screens/Search/SearchResults.tsx
+++ b/src/screens/Search/SearchResults.tsx
@@ -41,6 +41,7 @@ let SearchResults = ({
   query,
   filters,
   hasFilters,
+  fromMe,
   activeTab,
   onPageSelected,
   headerHeight,
@@ -48,6 +49,7 @@ let SearchResults = ({
   query: string
   filters: SearchFilters
   hasFilters: boolean
+  fromMe: boolean
   activeTab: number
   onPageSelected: (page: number) => void
   headerHeight: number
@@ -58,7 +60,7 @@ let SearchResults = ({
    * to people and feeds too, so it must not hide those tabs (which would also
    * regress the non-v2 legacy language dropdown). Other filters are post-only.
    */
-  const hasPostFilters = hasPostOnlyFilters(filters)
+  const hasPostFilters = hasPostOnlyFilters(filters) || fromMe
   const activePage = hasPostFilters && activeTab > 1 ? 0 : activeTab
   const tabShape = hasPostFilters ? 'filtered' : 'plain'
 

--- a/src/screens/Search/Shell.tsx
+++ b/src/screens/Search/Shell.tsx
@@ -32,6 +32,7 @@ import {
   unstableCacheProfileView,
   useProfilesQuery,
 } from '#/state/queries/profile'
+import {extractFromMe} from '#/state/queries/search-posts-params'
 import {useSession} from '#/state/session'
 import {
   countActiveFilters,
@@ -123,8 +124,18 @@ export function SearchScreenShell({
   const tabParam = (route.params as {q?: string; tab?: TabParam})?.tab
   const [activeTab, setActiveTab] = useState(() => getTabIndex(tabParam))
 
+  /*
+   * A raw `from:me` operator stays visible in the search input. Submitting the
+   * advanced dialog promotes it to a structured `from=me` filter and removes
+   * it from `q`; the API layer reconstructs the operator for post search.
+   */
+  const {query, fromMe, filters, setFilters, hasFilters} = useQueryManager({
+    initialQuery: queryParam,
+    fixedParams,
+  })
+
   // Query terms
-  const [searchText, setSearchText] = useState<string>(queryParam)
+  const [searchText, setSearchText] = useState<string>(query)
   const searchTextRef = useRef(searchText)
   const updateSearchText = useCallback((text: string) => {
     searchTextRef.current = text
@@ -200,10 +211,6 @@ export function SearchScreenShell({
     [accountHistory, setAccountHistory],
   )
 
-  const {query, filters, setFilters, hasFilters} = useQueryManager({
-    initialQuery: queryParam,
-    fixedParams,
-  })
   const showFilters = Boolean((query || hasFilters) && !showAutocomplete)
 
   const onChangeLang = useCallback(
@@ -233,13 +240,13 @@ export function SearchScreenShell({
   useEffect(() => {
     if (IS_NATIVE) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
-      updateSearchText(queryParam)
+      updateSearchText(query)
     }
-  }, [queryParam, updateSearchText])
+  }, [query, updateSearchText])
   useFocusEffect(
     useNonReactiveCallback(() => {
       if (IS_WEB) {
-        updateSearchText(queryParam)
+        updateSearchText(query)
       }
     }),
   )
@@ -329,11 +336,12 @@ export function SearchScreenShell({
   ])
 
   const onSubmit = (source: 'typed' | 'autocomplete') => () => {
+    const nextQuery = searchTextRef.current
     ax.metric('search:query', {
       source,
       filterCount: countActiveFilters(filters),
     })
-    navigateToItem(searchTextRef.current)
+    navigateToItem(nextQuery)
   }
 
   const onSubmitAdvanced = useCallback(
@@ -656,6 +664,7 @@ export function SearchScreenShell({
             query={query}
             filters={filters}
             hasFilters={hasFilters}
+            fromMe={fromMe}
             headerHeight={headerHeight}
             focusSearchInput={focusSearchInput}
           />
@@ -707,6 +716,7 @@ let SearchScreenInner = ({
   query,
   filters,
   hasFilters,
+  fromMe,
   headerHeight,
   focusSearchInput,
 }: {
@@ -715,6 +725,7 @@ let SearchScreenInner = ({
   query: string
   filters: SearchFilters
   hasFilters: boolean
+  fromMe: boolean
   headerHeight: number
   focusSearchInput: (tab?: TabParam) => void
 }): React.ReactNode => {
@@ -731,6 +742,7 @@ let SearchScreenInner = ({
       query={query}
       filters={filters}
       hasFilters={hasFilters}
+      fromMe={fromMe}
       activeTab={activeTab}
       headerHeight={headerHeight}
       onPageSelected={onPageSelected}
@@ -781,8 +793,13 @@ function useQueryManager({
   const navigation = useNavigation<NavigationProp>()
   const route = useRoute()
 
-  // Free text only - structured filters live in sibling route params now.
+  // A raw Me operator remains part of the query until the advanced dialog
+  // promotes it to the structured `from` filter.
   const query = initialQuery
+  const fromMe = useMemo(
+    () => extractFromMe(initialQuery).fromMe,
+    [initialQuery],
+  )
 
   const filters = useMemo(() => {
     const fromRoute = readSearchFilters(route.params as Record<string, unknown>)
@@ -814,11 +831,12 @@ function useQueryManager({
   return useMemo(
     () => ({
       query,
+      fromMe,
       filters,
       setFilters,
       hasFilters: hasActiveFilters(filters),
     }),
-    [query, filters, setFilters],
+    [query, fromMe, filters, setFilters],
   )
 }
 

--- a/src/screens/Search/__tests__/searchParams.test.ts
+++ b/src/screens/Search/__tests__/searchParams.test.ts
@@ -4,6 +4,7 @@ import {
   countActiveFilters,
   definedFilterParams,
   filtersToApiParams,
+  filtersToRouteParams,
   hasPostOnlyFilters,
   parseHistoryEntry,
   readSearchFilters,
@@ -36,7 +37,7 @@ describe(`searchParams`, () => {
 
     it(`maps a legacy following=true param onto from`, () => {
       expect(readSearchFilters({q: 'cats', following: 'true'})).toEqual({
-        from: 'true',
+        from: 'following',
       })
     })
 
@@ -85,6 +86,36 @@ describe(`searchParams`, () => {
         }),
       ).toEqual({q: 'cats', tab: 'latest', name: 'alice'})
     })
+
+    it(`strips the legacy following key so clearing to Anyone sticks (web)`, () => {
+      /*
+       * A legacy link carries following=true. Clearing the author filter to
+       * Anyone writes no from param, so the stale following key must be
+       * dropped or the next read would revive it as from:true.
+       */
+      const next = {
+        ...withoutFilterParams({q: 'cats', following: 'true'}),
+        ...definedFilterParams({}),
+      }
+      expect(next).toEqual({q: 'cats'})
+      expect(readSearchFilters(next)).toEqual({})
+    })
+  })
+
+  describe(`filtersToRouteParams`, () => {
+    it(`clears the legacy following key so clearing to Anyone sticks (native)`, () => {
+      /*
+       * setParams merges, so the rebuilt params must set the legacy following
+       * key to undefined to clear it from a legacy-linked session.
+       */
+      const merged: Record<string, string | undefined> = {
+        q: 'cats',
+        following: 'true',
+        ...filtersToRouteParams({}),
+      }
+      expect(merged.following).toBeUndefined()
+      expect(merged.from).toBeUndefined()
+    })
   })
 
   describe(`filtersToApiParams`, () => {
@@ -112,7 +143,7 @@ describe(`searchParams`, () => {
       expect(
         filtersToApiParams({
           video: 'true',
-          from: 'true',
+          from: 'following',
           replies: 'only',
         }),
       ).toEqual({

--- a/src/screens/Search/__tests__/searchParams.test.ts
+++ b/src/screens/Search/__tests__/searchParams.test.ts
@@ -4,7 +4,7 @@ import {
   countActiveFilters,
   definedFilterParams,
   filtersToApiParams,
-  filtersToRouteParams,
+  hasActiveFilters,
   hasPostOnlyFilters,
   parseHistoryEntry,
   readSearchFilters,
@@ -34,18 +34,6 @@ describe(`searchParams`, () => {
     it(`ignores empty and non-string values`, () => {
       expect(readSearchFilters({author: '', tag: undefined})).toEqual({})
     })
-
-    it(`maps a legacy following=true param onto from`, () => {
-      expect(readSearchFilters({q: 'cats', following: 'true'})).toEqual({
-        from: 'following',
-      })
-    })
-
-    it(`prefers an explicit from over a legacy following param`, () => {
-      expect(readSearchFilters({from: 'me', following: 'true'})).toEqual({
-        from: 'me',
-      })
-    })
   })
 
   describe(`hasPostOnlyFilters`, () => {
@@ -68,6 +56,14 @@ describe(`searchParams`, () => {
     })
   })
 
+  describe(`hasActiveFilters`, () => {
+    it(`includes the structured Me author filter`, () => {
+      expect(hasActiveFilters({})).toBe(false)
+      expect(hasActiveFilters({from: 'me'})).toBe(true)
+      expect(hasActiveFilters({author: 'alice'})).toBe(true)
+    })
+  })
+
   describe(`definedFilterParams`, () => {
     it(`omits absent keys entirely`, () => {
       expect(definedFilterParams({author: 'alice'})).toEqual({author: 'alice'})
@@ -85,36 +81,6 @@ describe(`searchParams`, () => {
           domain: 'undefined',
         }),
       ).toEqual({q: 'cats', tab: 'latest', name: 'alice'})
-    })
-
-    it(`strips the legacy following key so clearing to Anyone sticks (web)`, () => {
-      /*
-       * A legacy link carries following=true. Clearing the author filter to
-       * Anyone writes no from param, so the stale following key must be
-       * dropped or the next read would revive it as from:true.
-       */
-      const next = {
-        ...withoutFilterParams({q: 'cats', following: 'true'}),
-        ...definedFilterParams({}),
-      }
-      expect(next).toEqual({q: 'cats'})
-      expect(readSearchFilters(next)).toEqual({})
-    })
-  })
-
-  describe(`filtersToRouteParams`, () => {
-    it(`clears the legacy following key so clearing to Anyone sticks (native)`, () => {
-      /*
-       * setParams merges, so the rebuilt params must set the legacy following
-       * key to undefined to clear it from a legacy-linked session.
-       */
-      const merged: Record<string, string | undefined> = {
-        q: 'cats',
-        following: 'true',
-        ...filtersToRouteParams({}),
-      }
-      expect(merged.following).toBeUndefined()
-      expect(merged.from).toBeUndefined()
     })
   })
 
@@ -143,7 +109,7 @@ describe(`searchParams`, () => {
       expect(
         filtersToApiParams({
           video: 'true',
-          from: 'following',
+          following: 'true',
           replies: 'only',
         }),
       ).toEqual({
@@ -173,8 +139,9 @@ describe(`searchParams`, () => {
   })
 
   describe(`countActiveFilters`, () => {
-    it(`counts each set filter key once`, () => {
+    it(`counts each structured filter key once`, () => {
       expect(countActiveFilters({})).toBe(0)
+      expect(countActiveFilters({from: 'me'})).toBe(1)
       expect(
         countActiveFilters({author: 'alice bob', domain: 'bsky.app'}),
       ).toBe(2)
@@ -192,6 +159,14 @@ describe(`searchParams`, () => {
       expect(parseHistoryEntry(stored)).toEqual({
         q: 'cats',
         filters: {author: 'alice'},
+      })
+    })
+
+    it(`round-trips a promoted Me-only search`, () => {
+      const stored = serializeHistoryEntry('', {from: 'me'})
+      expect(parseHistoryEntry(stored)).toEqual({
+        q: '',
+        filters: {from: 'me'},
       })
     })
 

--- a/src/screens/Search/__tests__/searchParams.test.ts
+++ b/src/screens/Search/__tests__/searchParams.test.ts
@@ -33,6 +33,18 @@ describe(`searchParams`, () => {
     it(`ignores empty and non-string values`, () => {
       expect(readSearchFilters({author: '', tag: undefined})).toEqual({})
     })
+
+    it(`maps a legacy following=true param onto from`, () => {
+      expect(readSearchFilters({q: 'cats', following: 'true'})).toEqual({
+        from: 'true',
+      })
+    })
+
+    it(`prefers an explicit from over a legacy following param`, () => {
+      expect(readSearchFilters({from: 'me', following: 'true'})).toEqual({
+        from: 'me',
+      })
+    })
   })
 
   describe(`hasPostOnlyFilters`, () => {
@@ -100,7 +112,7 @@ describe(`searchParams`, () => {
       expect(
         filtersToApiParams({
           video: 'true',
-          following: 'true',
+          from: 'true',
           replies: 'only',
         }),
       ).toEqual({

--- a/src/screens/Search/components/AdvancedSearchDialog/FollowingDropdown.tsx
+++ b/src/screens/Search/components/AdvancedSearchDialog/FollowingDropdown.tsx
@@ -20,8 +20,8 @@ export function FollowingDropdown({
 
   const options: {value: FollowingFilter; label: string}[] = [
     {value: 'anyone', label: l`Anyone`},
-    {value: 'following', label: l`People you follow`},
-    {value: 'you', label: l`You`},
+    {value: 'following', label: l`People I follow`},
+    {value: 'you', label: l`Me`},
   ]
   const currentLabel = options.find(o => o.value === value)?.label ?? l`Anyone`
 

--- a/src/screens/Search/components/AdvancedSearchDialog/FollowingDropdown.tsx
+++ b/src/screens/Search/components/AdvancedSearchDialog/FollowingDropdown.tsx
@@ -21,6 +21,7 @@ export function FollowingDropdown({
   const options: {value: FollowingFilter; label: string}[] = [
     {value: 'anyone', label: l`Anyone`},
     {value: 'following', label: l`People you follow`},
+    {value: 'you', label: l`You`},
   ]
   const currentLabel = options.find(o => o.value === value)?.label ?? l`Anyone`
 

--- a/src/screens/Search/components/AdvancedSearchDialog/FromDropdown.tsx
+++ b/src/screens/Search/components/AdvancedSearchDialog/FromDropdown.tsx
@@ -7,21 +7,21 @@ import {
   ChevronTopBottom_Stroke2_Corner0_Rounded as ChevronUpDownIcon,
 } from '#/components/icons/Chevron'
 import * as Menu from '#/components/Menu'
-import {type FollowingFilter} from './utils'
+import {type FromFilter} from './utils'
 
-export function FollowingDropdown({
+export function FromDropdown({
   value,
   onChange,
 }: {
-  value: FollowingFilter
-  onChange: (value: FollowingFilter) => void
+  value: FromFilter
+  onChange: (value: FromFilter) => void
 }) {
   const {t: l} = useLingui()
 
-  const options: {value: FollowingFilter; label: string}[] = [
+  const options: {value: FromFilter; label: string}[] = [
     {value: 'anyone', label: l`Anyone`},
     {value: 'following', label: l`People I follow`},
-    {value: 'you', label: l`Me`},
+    {value: 'me', label: l`Me`},
   ]
   const currentLabel = options.find(o => o.value === value)?.label ?? l`Anyone`
 

--- a/src/screens/Search/components/AdvancedSearchDialog/__tests__/utils.test.ts
+++ b/src/screens/Search/components/AdvancedSearchDialog/__tests__/utils.test.ts
@@ -73,25 +73,53 @@ describe(`AdvancedSearchDialog serialize/parse`, () => {
     expect(state.until).toBe('2024-02-01')
   })
 
-  it(`lifts from:me typed into the query box into the "you" following filter`, () => {
+  it(`lifts from:me typed into the query box into the "me" following filter`, () => {
     const state = parseAdvancedSearch('cats from:me', {})
     expect(state.query).toBe('cats')
-    expect(state.following).toBe('you')
+    expect(state.following).toBe('me')
     expect(state.filters.find(f => f.field === 'authors')).toBeUndefined()
   })
 
-  it(`serializes the "you" following filter into the from param, not the query`, () => {
+  it(`promotes the "me" filter from q to a structured filter`, () => {
     const out = serializeAdvancedSearch({
       ...emptySerializeState,
       query: 'cats',
-      following: 'you',
+      following: 'me',
     })
-    // from:me must not leak into the query text (it'd show in the search input).
+    expect(out.q).toBe('cats')
+    expect(out.filters.from).toBe('me')
+    expect(out.filters.following).toBeUndefined()
+  })
+
+  it(`strips from:me typed after selecting Me`, () => {
+    const out = serializeAdvancedSearch({
+      ...emptySerializeState,
+      query: 'cats from:me',
+      following: 'me',
+    })
     expect(out.q).toBe('cats')
     expect(out.filters.from).toBe('me')
   })
 
-  it(`round-trips cats from:me through the "you" following filter`, () => {
+  it(`promotes from:me typed after the dialog opens`, () => {
+    const out = serializeAdvancedSearch({
+      ...emptySerializeState,
+      query: 'cats from:me',
+    })
+    expect(out.q).toBe('cats')
+    expect(out.filters.from).toBe('me')
+  })
+
+  it(`keeps a quoted from:me as query text`, () => {
+    const out = serializeAdvancedSearch({
+      ...emptySerializeState,
+      query: 'cats "from:me"',
+    })
+    expect(out.q).toBe('cats "from:me"')
+    expect(out.filters.from).toBeUndefined()
+  })
+
+  it(`round-trips cats from:me through the "me" following filter`, () => {
     const state = parseAdvancedSearch('cats from:me', {})
     const out = serializeAdvancedSearch({
       ...emptySerializeState,
@@ -100,10 +128,11 @@ describe(`AdvancedSearchDialog serialize/parse`, () => {
     })
     expect(out.q).toBe('cats')
     expect(out.filters.from).toBe('me')
+    expect(out.filters.following).toBeUndefined()
   })
 
-  it(`parses the from=me param into the "you" following filter`, () => {
-    expect(parseAdvancedSearch('', {from: 'me'}).following).toBe('you')
+  it(`parses the structured Me filter into the From dropdown`, () => {
+    expect(parseAdvancedSearch('cats', {from: 'me'}).following).toBe('me')
   })
 
   it(`merges a query-box operator with the matching filter param`, () => {
@@ -126,7 +155,7 @@ describe(`AdvancedSearchDialog serialize/parse`, () => {
       since: '2024-01-01',
       until: '2024-02-01',
       media: 'true',
-      from: 'following',
+      following: 'true',
       replies: 'only',
     }
 
@@ -164,24 +193,24 @@ describe(`AdvancedSearchDialog serialize/parse`, () => {
     expect(state.media).toBe('video')
   })
 
-  it(`maps the following filter to the from param on serialize`, () => {
+  it(`maps the following filter to the following param on serialize`, () => {
     const out = serializeAdvancedSearch({
       ...emptySerializeState,
       following: 'following',
     })
-    expect(out.filters.from).toBe('following')
+    expect(out.filters.following).toBe('true')
   })
 
-  it(`leaves the from param unset for anyone`, () => {
+  it(`leaves the following param unset for anyone`, () => {
     const out = serializeAdvancedSearch({
       ...emptySerializeState,
       following: 'anyone',
     })
-    expect(out.filters.from).toBeUndefined()
+    expect(out.filters.following).toBeUndefined()
   })
 
-  it(`parses the from param into the following filter`, () => {
-    expect(parseAdvancedSearch('', {from: 'following'}).following).toBe(
+  it(`parses the following param into the following filter`, () => {
+    expect(parseAdvancedSearch('', {following: 'true'}).following).toBe(
       'following',
     )
     expect(parseAdvancedSearch('', {}).following).toBe('anyone')

--- a/src/screens/Search/components/AdvancedSearchDialog/__tests__/utils.test.ts
+++ b/src/screens/Search/components/AdvancedSearchDialog/__tests__/utils.test.ts
@@ -126,7 +126,7 @@ describe(`AdvancedSearchDialog serialize/parse`, () => {
       since: '2024-01-01',
       until: '2024-02-01',
       media: 'true',
-      from: 'true',
+      from: 'following',
       replies: 'only',
     }
 
@@ -169,7 +169,7 @@ describe(`AdvancedSearchDialog serialize/parse`, () => {
       ...emptySerializeState,
       following: 'following',
     })
-    expect(out.filters.from).toBe('true')
+    expect(out.filters.from).toBe('following')
   })
 
   it(`leaves the from param unset for anyone`, () => {
@@ -181,7 +181,9 @@ describe(`AdvancedSearchDialog serialize/parse`, () => {
   })
 
   it(`parses the from param into the following filter`, () => {
-    expect(parseAdvancedSearch('', {from: 'true'}).following).toBe('following')
+    expect(parseAdvancedSearch('', {from: 'following'}).following).toBe(
+      'following',
+    )
     expect(parseAdvancedSearch('', {}).following).toBe('anyone')
   })
 

--- a/src/screens/Search/components/AdvancedSearchDialog/__tests__/utils.test.ts
+++ b/src/screens/Search/components/AdvancedSearchDialog/__tests__/utils.test.ts
@@ -73,10 +73,37 @@ describe(`AdvancedSearchDialog serialize/parse`, () => {
     expect(state.until).toBe('2024-02-01')
   })
 
-  it(`keeps from:me in the query box rather than lifting it into a row`, () => {
-    const state = parseAdvancedSearch('from:me', {})
-    expect(state.query).toBe('from:me')
+  it(`lifts from:me typed into the query box into the "you" following filter`, () => {
+    const state = parseAdvancedSearch('cats from:me', {})
+    expect(state.query).toBe('cats')
+    expect(state.following).toBe('you')
     expect(state.filters.find(f => f.field === 'authors')).toBeUndefined()
+  })
+
+  it(`serializes the "you" following filter into the from param, not the query`, () => {
+    const out = serializeAdvancedSearch({
+      ...emptySerializeState,
+      query: 'cats',
+      following: 'you',
+    })
+    // from:me must not leak into the query text (it'd show in the search input).
+    expect(out.q).toBe('cats')
+    expect(out.filters.from).toBe('me')
+  })
+
+  it(`round-trips cats from:me through the "you" following filter`, () => {
+    const state = parseAdvancedSearch('cats from:me', {})
+    const out = serializeAdvancedSearch({
+      ...emptySerializeState,
+      query: state.query,
+      following: state.following,
+    })
+    expect(out.q).toBe('cats')
+    expect(out.filters.from).toBe('me')
+  })
+
+  it(`parses the from=me param into the "you" following filter`, () => {
+    expect(parseAdvancedSearch('', {from: 'me'}).following).toBe('you')
   })
 
   it(`merges a query-box operator with the matching filter param`, () => {
@@ -99,7 +126,7 @@ describe(`AdvancedSearchDialog serialize/parse`, () => {
       since: '2024-01-01',
       until: '2024-02-01',
       media: 'true',
-      following: 'true',
+      from: 'true',
       replies: 'only',
     }
 
@@ -137,26 +164,24 @@ describe(`AdvancedSearchDialog serialize/parse`, () => {
     expect(state.media).toBe('video')
   })
 
-  it(`maps the following filter to the following param on serialize`, () => {
+  it(`maps the following filter to the from param on serialize`, () => {
     const out = serializeAdvancedSearch({
       ...emptySerializeState,
       following: 'following',
     })
-    expect(out.filters.following).toBe('true')
+    expect(out.filters.from).toBe('true')
   })
 
-  it(`leaves the following param unset for anyone`, () => {
+  it(`leaves the from param unset for anyone`, () => {
     const out = serializeAdvancedSearch({
       ...emptySerializeState,
       following: 'anyone',
     })
-    expect(out.filters.following).toBeUndefined()
+    expect(out.filters.from).toBeUndefined()
   })
 
-  it(`parses the following param into the following filter`, () => {
-    expect(parseAdvancedSearch('', {following: 'true'}).following).toBe(
-      'following',
-    )
+  it(`parses the from param into the following filter`, () => {
+    expect(parseAdvancedSearch('', {from: 'true'}).following).toBe('following')
     expect(parseAdvancedSearch('', {}).following).toBe('anyone')
   })
 

--- a/src/screens/Search/components/AdvancedSearchDialog/index.tsx
+++ b/src/screens/Search/components/AdvancedSearchDialog/index.tsx
@@ -22,12 +22,12 @@ import {SearchLanguageDropdown} from '../SearchLanguageDropdown'
 import {ClearableDateField, DEFAULT_DATE} from './ClearableDateField'
 import {ClearableInput} from './ClearableInput'
 import {FilterBlock} from './FilterBlock'
-import {FollowingDropdown} from './FollowingDropdown'
+import {FromDropdown} from './FromDropdown'
 import {MediaDropdown} from './MediaDropdown'
 import {RepliesDropdown} from './RepliesDropdown'
 import {
   type AdvancedFilter,
-  type FollowingFilter,
+  type FromFilter,
   makeFilter,
   type MediaFilter,
   parseAdvancedSearch,
@@ -124,7 +124,7 @@ function DialogInner({
 
   const [media, setMedia] = useState<MediaFilter>(parsed.media)
   const [replies, setReplies] = useState<RepliesFilter>(parsed.replies)
-  const [following, setFollowing] = useState<FollowingFilter>(parsed.following)
+  const [following, setFollowing] = useState<FromFilter>(parsed.following)
 
   /*
    * The date picker requires a valid date, so these always hold one. The
@@ -389,7 +389,9 @@ function DialogInner({
                 t.atoms.text_contrast_medium,
                 a.mb_sm,
               ]}>
-              <Trans>Include</Trans>
+              <Trans comment="Include search results with or without replies">
+                Include
+              </Trans>
             </Text>
             <View style={[a.flex_row]}>
               <RepliesDropdown value={replies} onChange={setReplies} />
@@ -403,10 +405,12 @@ function DialogInner({
                 t.atoms.text_contrast_medium,
                 a.mb_sm,
               ]}>
-              <Trans>From</Trans>
+              <Trans comment="Filter search results by a specific post author">
+                From
+              </Trans>
             </Text>
             <View style={[a.flex_row]}>
-              <FollowingDropdown value={following} onChange={setFollowing} />
+              <FromDropdown value={following} onChange={setFollowing} />
             </View>
           </View>
         </View>

--- a/src/screens/Search/components/AdvancedSearchDialog/utils.ts
+++ b/src/screens/Search/components/AdvancedSearchDialog/utils.ts
@@ -14,10 +14,12 @@ export type RepliesFilter = 'all' | 'none' | 'only'
 export type MediaFilter = 'all' | 'media' | 'video'
 
 /**
- * Whether to limit results to authors the user follows. Serializes into the
- * `following` sibling param ('following' -> following:true, anyone -> unset).
+ * Which authors to limit results to. Serializes into the `from` sibling param:
+ * 'following' -> from:true (people you follow), 'you' -> from:me (your own
+ * posts, reconstructed into `from:me` at the v2 API boundary), 'anyone' ->
+ * unset.
  */
-export type FollowingFilter = 'anyone' | 'following'
+export type FollowingFilter = 'anyone' | 'following' | 'you'
 
 export type FilterField = 'authors' | 'mentions' | 'domains' | 'urls' | 'tags'
 
@@ -141,18 +143,27 @@ function isSimpleWord(word: string): boolean {
  * populate "none of these words" - but only when their contents are simple
  * words. Anything that wouldn't round-trip (embedded quotes, a negated phrase
  * like -"a b", etc.) is left verbatim in the main "all of these words" query
- * text instead of parsed.
+ * text instead of parsed. A bare `from:me` is pulled out into the `fromMe`
+ * flag, which drives the "You" author filter (the backend resolves `me` to the
+ * viewer, so it never becomes a structured `author` value).
  */
 function parseFreeText(raw: string): {
   query: string
   exactPhrase: string
   negatedWords: string
+  fromMe: boolean
 } {
   const queryParts: string[] = []
   const negatedWords: string[] = []
   let exactPhrase = ''
+  let fromMe = false
 
   for (const token of tokenizeQuery(raw)) {
+    // from:me -> "You" author filter rather than free text.
+    if (token === 'from:me') {
+      fromMe = true
+      continue
+    }
     // "phrase" -> "exact phrase", only if it has no inner quote.
     if (token.startsWith('"') && token.endsWith('"') && token.length > 1) {
       const inner = token.slice(1, -1)
@@ -176,6 +187,7 @@ function parseFreeText(raw: string): {
     query: queryParts.join(' '),
     exactPhrase,
     negatedWords: negatedWords.join(' '),
+    fromMe,
   }
 }
 
@@ -208,7 +220,7 @@ export function parseAdvancedSearch(
    * can be expressed as operators; exclude rows come solely from filter params.
    */
   const lifted = extractSearchPostsParams(q)
-  const freeText = parseFreeText(lifted.q)
+  const {fromMe, ...freeText} = parseFreeText(lifted.q)
 
   const includeValues: Record<FilterField, string> = {
     authors: mergeValues(filters.author, lifted.author),
@@ -255,12 +267,24 @@ export function parseAdvancedSearch(
   const since = filters.since ?? lifted.since
   const until = filters.until ?? lifted.until
 
+  /*
+   * A `from:me` typed into the query box maps to the "You" author filter, same
+   * as the `from=me` param. Either source selects 'you'; the plain `from=true`
+   * param remains "People you follow".
+   */
+  let following: FollowingFilter = 'anyone'
+  if (fromMe || filters.from === 'me') {
+    following = 'you'
+  } else if (filters.from === 'true') {
+    following = 'following'
+  }
+
   return {
     ...freeText,
     language: lang,
     replies,
     media,
-    following: filters.following === 'true' ? 'following' : 'anyone',
+    following,
     since: since && isValidDate(since) ? since : '',
     until: until && isValidDate(until) ? until : '',
     filters: filterRows,
@@ -352,7 +376,15 @@ export function serializeAdvancedSearch(state: {
   if (state.replies === 'only') filters.replies = 'only'
   if (state.media === 'media') filters.media = 'true'
   else if (state.media === 'video') filters.video = 'true'
-  if (state.following === 'following') filters.following = 'true'
+  /*
+   * The "You" filter is stored as `from=me` rather than a `from:me` token in
+   * `q`: this keeps the query text clean (so `from:me` never shows in the
+   * search input) and lets it count as an active filter. It's reconstructed
+   * back into a `from:me` query operator at the v2 API boundary, since the
+   * backend resolves `me` to the viewer.
+   */
+  if (state.following === 'following') filters.from = 'true'
+  else if (state.following === 'you') filters.from = 'me'
 
   return {q: parts.join(' '), filters}
 }

--- a/src/screens/Search/components/AdvancedSearchDialog/utils.ts
+++ b/src/screens/Search/components/AdvancedSearchDialog/utils.ts
@@ -15,7 +15,7 @@ export type MediaFilter = 'all' | 'media' | 'video'
 
 /**
  * Which authors to limit results to. Serializes into the `from` sibling param:
- * 'following' -> from:true (people you follow), 'you' -> from:me (your own
+ * 'following' -> from=following (people you follow), 'you' -> from=me (your own
  * posts, reconstructed into `from:me` at the v2 API boundary), 'anyone' ->
  * unset.
  */
@@ -269,13 +269,13 @@ export function parseAdvancedSearch(
 
   /*
    * A `from:me` typed into the query box maps to the "You" author filter, same
-   * as the `from=me` param. Either source selects 'you'; the plain `from=true`
+   * as the `from=me` param. Either source selects 'you'; the `from=following`
    * param remains "People you follow".
    */
   let following: FollowingFilter = 'anyone'
   if (fromMe || filters.from === 'me') {
     following = 'you'
-  } else if (filters.from === 'true') {
+  } else if (filters.from === 'following') {
     following = 'following'
   }
 
@@ -383,7 +383,7 @@ export function serializeAdvancedSearch(state: {
    * back into a `from:me` query operator at the v2 API boundary, since the
    * backend resolves `me` to the viewer.
    */
-  if (state.following === 'following') filters.from = 'true'
+  if (state.following === 'following') filters.from = 'following'
   else if (state.following === 'you') filters.from = 'me'
 
   return {q: parts.join(' '), filters}

--- a/src/screens/Search/components/AdvancedSearchDialog/utils.ts
+++ b/src/screens/Search/components/AdvancedSearchDialog/utils.ts
@@ -1,4 +1,5 @@
 import {
+  extractFromMe,
   extractSearchPostsParams,
   tokenizeQuery,
 } from '#/state/queries/search-posts-params'
@@ -14,12 +15,11 @@ export type RepliesFilter = 'all' | 'none' | 'only'
 export type MediaFilter = 'all' | 'media' | 'video'
 
 /**
- * Which authors to limit results to. Serializes into the `from` sibling param:
- * 'following' -> from=following (people you follow), 'you' -> from=me (your own
- * posts, reconstructed into `from:me` at the v2 API boundary), 'anyone' ->
- * unset.
+ * Which authors to limit results to. 'following' serializes into the
+ * `following` sibling param (following=true); 'me' serializes into the `from`
+ * sibling param (from=me); 'anyone' leaves both unset.
  */
-export type FollowingFilter = 'anyone' | 'following' | 'you'
+export type FromFilter = 'anyone' | 'following' | 'me'
 
 export type FilterField = 'authors' | 'mentions' | 'domains' | 'urls' | 'tags'
 
@@ -95,7 +95,7 @@ export type DialogState = {
   language: string
   replies: RepliesFilter
   media: MediaFilter
-  following: FollowingFilter
+  following: FromFilter
   since: string
   until: string
   filters: AdvancedFilter[]
@@ -144,7 +144,7 @@ function isSimpleWord(word: string): boolean {
  * words. Anything that wouldn't round-trip (embedded quotes, a negated phrase
  * like -"a b", etc.) is left verbatim in the main "all of these words" query
  * text instead of parsed. A bare `from:me` is pulled out into the `fromMe`
- * flag, which drives the "You" author filter (the backend resolves `me` to the
+ * flag, which drives the "Me" author filter (the backend resolves `me` to the
  * viewer, so it never becomes a structured `author` value).
  */
 function parseFreeText(raw: string): {
@@ -159,7 +159,7 @@ function parseFreeText(raw: string): {
   let fromMe = false
 
   for (const token of tokenizeQuery(raw)) {
-    // from:me -> "You" author filter rather than free text.
+    // from:me -> "Me" author filter rather than free text.
     if (token === 'from:me') {
       fromMe = true
       continue
@@ -268,14 +268,14 @@ export function parseAdvancedSearch(
   const until = filters.until ?? lifted.until
 
   /*
-   * A `from:me` typed into the query box maps to the "You" author filter, same
-   * as the `from=me` param. Either source selects 'you'; the `from=following`
-   * param remains "People you follow".
+   * A raw `from:me` operator and the structured `from=me` filter both map to
+   * the "Me" author filter. The raw operator is promoted to the structured
+   * filter when the dialog is submitted.
    */
-  let following: FollowingFilter = 'anyone'
+  let following: FromFilter = 'anyone'
   if (fromMe || filters.from === 'me') {
-    following = 'you'
-  } else if (filters.from === 'following') {
+    following = 'me'
+  } else if (filters.following === 'true') {
     following = 'following'
   }
 
@@ -303,7 +303,7 @@ export function serializeAdvancedSearch(state: {
   language: string
   replies: RepliesFilter
   media: MediaFilter
-  following: FollowingFilter
+  following: FromFilter
   dateSince: string
   dateSinceActive: boolean
   dateUntil: string
@@ -376,15 +376,21 @@ export function serializeAdvancedSearch(state: {
   if (state.replies === 'only') filters.replies = 'only'
   if (state.media === 'media') filters.media = 'true'
   else if (state.media === 'video') filters.video = 'true'
-  /*
-   * The "You" filter is stored as `from=me` rather than a `from:me` token in
-   * `q`: this keeps the query text clean (so `from:me` never shows in the
-   * search input) and lets it count as an active filter. It's reconstructed
-   * back into a `from:me` query operator at the v2 API boundary, since the
-   * backend resolves `me` to the viewer.
-   */
-  if (state.following === 'following') filters.from = 'following'
-  else if (state.following === 'you') filters.from = 'me'
 
-  return {q: parts.join(' '), filters}
+  /*
+   * Re-parse the final text because a user can type `from:me` after the dialog
+   * has opened. Advanced submission removes every bare token from the search
+   * input and promotes it to the structured From filter. Quoted `"from:me"`
+   * remains ordinary query text.
+   */
+  const {q, fromMe} = extractFromMe(parts.join(' '))
+  if (state.following === 'following') filters.following = 'true'
+  else if (state.following === 'me' || fromMe) filters.from = 'me'
+
+  /*
+   * Submitting the dialog promotes a raw `from:me` operator to `from=me`, so it
+   * leaves the search text and is represented by the From dropdown. The query
+   * hook reconstructs the backend operator at the API boundary.
+   */
+  return {q, filters}
 }

--- a/src/screens/Search/searchParams.ts
+++ b/src/screens/Search/searchParams.ts
@@ -29,8 +29,12 @@ export type SearchFilters = {
   media?: string
   /** 'true' */
   video?: string
-  /** 'true' */
-  following?: string
+  /**
+   * 'true' limits results to people you follow; 'me' limits them to your own
+   * posts (reconstructed into a `from:me` query operator at the v2 API
+   * boundary). v2-only. Serializes to the `from` URL param.
+   */
+  from?: string
 }
 
 export const FILTER_PARAM_KEYS = [
@@ -50,7 +54,7 @@ export const FILTER_PARAM_KEYS = [
   'replies',
   'media',
   'video',
-  'following',
+  'from',
 ] as const
 
 /**
@@ -71,6 +75,15 @@ export function readSearchFilters(
     if (typeof value === 'string' && value && value !== 'undefined') {
       filters[key] = value
     }
+  }
+  /*
+   * Back-compat: the author filter was previously stored under `following`
+   * (following=true). Honor old links/history by mapping it onto `from`, unless
+   * a `from` value is already present.
+   */
+  if (!filters.from) {
+    const legacy = routeParams.following
+    if (legacy === 'true') filters.from = 'true'
   }
   return filters
 }
@@ -249,7 +262,7 @@ export function filtersToApiParams(filters: SearchFilters): {
   if (filters.until) params.until = filters.until
   if (filters.media === 'true') params.hasMedia = true
   if (filters.video === 'true') params.hasVideo = true
-  if (filters.following === 'true') params.following = true
+  if (filters.from === 'true') params.following = true
   if (filters.replies === 'none') params.excludeReplies = true
   else if (filters.replies === 'only') params.repliesOnly = true
   return params

--- a/src/screens/Search/searchParams.ts
+++ b/src/screens/Search/searchParams.ts
@@ -30,8 +30,8 @@ export type SearchFilters = {
   /** 'true' */
   video?: string
   /**
-   * 'true' limits results to people you follow; 'me' limits them to your own
-   * posts (reconstructed into a `from:me` query operator at the v2 API
+   * 'following' limits results to people you follow; 'me' limits them to your
+   * own posts (reconstructed into a `from:me` query operator at the v2 API
    * boundary). v2-only. Serializes to the `from` URL param.
    */
   from?: string
@@ -56,6 +56,14 @@ export const FILTER_PARAM_KEYS = [
   'video',
   'from',
 ] as const
+
+/**
+ * Filter param keys that are no longer written but may still be present in old
+ * URLs/history. `readSearchFilters` maps these onto their current equivalents;
+ * the param-rebuild helpers strip them so a cleared filter can't be resurrected
+ * from a stale legacy key. `following=true` was the old form of `from=following`.
+ */
+export const LEGACY_FILTER_PARAM_KEYS = ['following'] as const
 
 /**
  * Reads filter params out of a route's params object, keeping only non-empty
@@ -83,7 +91,7 @@ export function readSearchFilters(
    */
   if (!filters.from) {
     const legacy = routeParams.following
-    if (legacy === 'true') filters.from = 'true'
+    if (legacy === 'true') filters.from = 'following'
   }
   return filters
 }
@@ -169,6 +177,13 @@ export function filtersToRouteParams(
   for (const key of FILTER_PARAM_KEYS) {
     params[key] = filters[key] || undefined
   }
+  /*
+   * Clear any legacy keys too, so a value the user removed can't be revived
+   * from a stale param on the next read (setParams merges).
+   */
+  for (const key of LEGACY_FILTER_PARAM_KEYS) {
+    params[key] = undefined
+  }
   return params
 }
 
@@ -197,6 +212,9 @@ export function withoutFilterParams(
 ): Record<string, unknown> {
   const base: Record<string, unknown> = {...routeParams}
   for (const key of FILTER_PARAM_KEYS) {
+    delete base[key]
+  }
+  for (const key of LEGACY_FILTER_PARAM_KEYS) {
     delete base[key]
   }
   return base
@@ -262,7 +280,7 @@ export function filtersToApiParams(filters: SearchFilters): {
   if (filters.until) params.until = filters.until
   if (filters.media === 'true') params.hasMedia = true
   if (filters.video === 'true') params.hasVideo = true
-  if (filters.from === 'true') params.following = true
+  if (filters.from === 'following') params.following = true
   if (filters.replies === 'none') params.excludeReplies = true
   else if (filters.replies === 'only') params.repliesOnly = true
   return params

--- a/src/screens/Search/searchParams.ts
+++ b/src/screens/Search/searchParams.ts
@@ -29,11 +29,9 @@ export type SearchFilters = {
   media?: string
   /** 'true' */
   video?: string
-  /**
-   * 'following' limits results to people you follow; 'me' limits them to your
-   * own posts (reconstructed into a `from:me` query operator at the v2 API
-   * boundary). v2-only. Serializes to the `from` URL param.
-   */
+  /** 'true' */
+  following?: string
+  /** 'me' */
   from?: string
 }
 
@@ -54,16 +52,9 @@ export const FILTER_PARAM_KEYS = [
   'replies',
   'media',
   'video',
+  'following',
   'from',
 ] as const
-
-/**
- * Filter param keys that are no longer written but may still be present in old
- * URLs/history. `readSearchFilters` maps these onto their current equivalents;
- * the param-rebuild helpers strip them so a cleared filter can't be resurrected
- * from a stale legacy key. `following=true` was the old form of `from=following`.
- */
-export const LEGACY_FILTER_PARAM_KEYS = ['following'] as const
 
 /**
  * Reads filter params out of a route's params object, keeping only non-empty
@@ -84,26 +75,18 @@ export function readSearchFilters(
       filters[key] = value
     }
   }
-  /*
-   * Back-compat: the author filter was previously stored under `following`
-   * (following=true). Honor old links/history by mapping it onto `from`, unless
-   * a `from` value is already present.
-   */
-  if (!filters.from) {
-    const legacy = routeParams.following
-    if (legacy === 'true') filters.from = 'following'
-  }
   return filters
 }
 
 export function hasActiveFilters(filters: SearchFilters): boolean {
-  return FILTER_PARAM_KEYS.some(key => filters[key])
+  return countActiveFilters(filters) > 0
 }
 
 /**
  * Number of active filter params, used for the "[+N filters]" pill in search
  * history. Each set key counts once (a multi-value field like author counts as
- * one filter regardless of how many handles it holds).
+ * one filter regardless of how many handles it holds). Raw query operators do
+ * not count until the advanced dialog promotes them to structured params.
  */
 export function countActiveFilters(filters: SearchFilters): number {
   return FILTER_PARAM_KEYS.filter(key => filters[key]).length
@@ -177,13 +160,6 @@ export function filtersToRouteParams(
   for (const key of FILTER_PARAM_KEYS) {
     params[key] = filters[key] || undefined
   }
-  /*
-   * Clear any legacy keys too, so a value the user removed can't be revived
-   * from a stale param on the next read (setParams merges).
-   */
-  for (const key of LEGACY_FILTER_PARAM_KEYS) {
-    params[key] = undefined
-  }
   return params
 }
 
@@ -212,9 +188,6 @@ export function withoutFilterParams(
 ): Record<string, unknown> {
   const base: Record<string, unknown> = {...routeParams}
   for (const key of FILTER_PARAM_KEYS) {
-    delete base[key]
-  }
-  for (const key of LEGACY_FILTER_PARAM_KEYS) {
     delete base[key]
   }
   return base
@@ -280,7 +253,7 @@ export function filtersToApiParams(filters: SearchFilters): {
   if (filters.until) params.until = filters.until
   if (filters.media === 'true') params.hasMedia = true
   if (filters.video === 'true') params.hasVideo = true
-  if (filters.from === 'following') params.following = true
+  if (filters.following === 'true') params.following = true
   if (filters.replies === 'none') params.excludeReplies = true
   else if (filters.replies === 'only') params.repliesOnly = true
   return params

--- a/src/screens/Settings/NotificationSettings/components/PreferenceControls.tsx
+++ b/src/screens/Settings/NotificationSettings/components/PreferenceControls.tsx
@@ -156,7 +156,9 @@ export function Inner({
         <>
           <Divider />
           <Text style={[a.font_semi_bold, a.text_md]}>
-            <Trans>From</Trans>
+            <Trans comment="Filter who you receive notifications from">
+              From
+            </Trans>
           </Text>
           <Toggle.Group
             type="radio"

--- a/src/state/queries/__tests__/search-posts-params.test.ts
+++ b/src/state/queries/__tests__/search-posts-params.test.ts
@@ -1,7 +1,9 @@
 import {describe, expect, it} from '@jest/globals'
 
 import {
+  appendFromMe,
   buildSearchPostsV2Filters,
+  extractFromMe,
   extractSearchPostsParams,
 } from '#/state/queries/search-posts-params'
 
@@ -136,6 +138,39 @@ describe(`extractSearchPostsParams`, () => {
 
   it.each(tests)(`$name`, ({input, output}) => {
     expect(extractSearchPostsParams(input)).toEqual(output)
+  })
+})
+
+describe(`extractFromMe / appendFromMe`, () => {
+  it(`strips a bare from:me token and reports it`, () => {
+    expect(extractFromMe(`cats from:me`)).toEqual({q: `cats`, fromMe: true})
+    expect(extractFromMe(`from:me`)).toEqual({q: ``, fromMe: true})
+  })
+
+  it(`reports fromMe false when the token is absent`, () => {
+    expect(extractFromMe(`cats from:alice`)).toEqual({
+      q: `cats from:alice`,
+      fromMe: false,
+    })
+  })
+
+  it(`leaves a quoted from:me in the query text`, () => {
+    expect(extractFromMe(`"from:me"`)).toEqual({q: `"from:me"`, fromMe: false})
+  })
+
+  it(`re-appends the token only when the filter is active`, () => {
+    expect(appendFromMe(`cats`, true)).toBe(`cats from:me`)
+    expect(appendFromMe(`cats`, false)).toBe(`cats`)
+    expect(appendFromMe(``, true)).toBe(`from:me`)
+  })
+
+  it(`does not duplicate an existing from:me token`, () => {
+    expect(appendFromMe(`cats from:me`, true)).toBe(`cats from:me`)
+  })
+
+  it(`round-trips through extract and append`, () => {
+    const {q, fromMe} = extractFromMe(`cats from:me`)
+    expect(appendFromMe(q, fromMe)).toBe(`cats from:me`)
   })
 })
 

--- a/src/state/queries/search-posts-params.ts
+++ b/src/state/queries/search-posts-params.ts
@@ -84,6 +84,30 @@ export function tokenizeQuery(raw: string): string[] {
 }
 
 /**
+ * Splits a bare `from:me` token out of a query. The "Me" author filter always
+ * travels inside `q` as a `from:me` token (the backend resolves `me` to the
+ * viewer), but the UI never shows it as text: the search input strips it for
+ * display and the advanced-search dialog represents it in the From dropdown.
+ * Tokenization keeps quoted phrases intact, so a `from:me` inside quotes stays
+ * in the query text.
+ */
+export function extractFromMe(query: string): {q: string; fromMe: boolean} {
+  const tokens = tokenizeQuery(query)
+  const kept = tokens.filter(token => token !== 'from:me')
+  return {q: kept.join(' '), fromMe: kept.length !== tokens.length}
+}
+
+/**
+ * Re-appends the `from:me` token when the "Me" author filter is active.
+ * Idempotent: a query that already carries a bare `from:me` is returned as-is.
+ */
+export function appendFromMe(query: string, fromMe: boolean): string {
+  if (!fromMe) return query
+  if (tokenizeQuery(query).includes('from:me')) return query
+  return query ? `${query} from:me` : 'from:me'
+}
+
+/**
  * Lifts the operators that `app.bsky.feed.searchPosts` accepts as structured
  * params out of the free-text query, so the backend filters on them directly.
  * Recognized operators are stripped from `q`; everything else (free text,

--- a/src/state/queries/search-posts-v2.ts
+++ b/src/state/queries/search-posts-v2.ts
@@ -16,6 +16,7 @@ import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useAgent} from '#/state/session'
 import {type SearchFilters} from '#/screens/Search/searchParams'
 import {
+  appendFromMe,
   buildSearchPostsV2Filters,
   extractSearchPostsParams,
 } from './search-posts-params'
@@ -79,14 +80,7 @@ export function useSearchPostsV2Query({
        */
       const {q, ...embedded} = extractSearchPostsParams(query)
       const builtFilters = buildSearchPostsV2Filters(embedded, filters)
-      /*
-       * The "You" author filter is carried as `from=me` (rather than a
-       * `from:me` token in the query text, which would leak into the search
-       * input). Reconstruct it into the query operator here, since the backend
-       * resolves `me` to the viewer.
-       */
-      const finalQuery =
-        filters?.from === 'me' ? `${q ? `${q} ` : ''}from:me` : q
+      const finalQuery = appendFromMe(q, filters?.from === 'me')
       const res = await agent.app.bsky.feed.searchPostsV2({
         ...builtFilters,
         query: finalQuery,

--- a/src/state/queries/search-posts-v2.ts
+++ b/src/state/queries/search-posts-v2.ts
@@ -51,10 +51,11 @@ export function useSearchPostsV2Query({
   const moderationOpts = useModerationOpts()
   const selectArgs = useMemo(
     () => ({
-      isSearchingSpecificUser: /from:(\w+)/.test(query) || !!filters?.author,
+      isSearchingSpecificUser:
+        /from:(\w+)/.test(query) || !!filters?.author || filters?.from === 'me',
       moderationOpts,
     }),
-    [query, filters?.author, moderationOpts],
+    [query, filters?.author, filters?.from, moderationOpts],
   )
   const lastRun = useRef<{
     data: InfiniteData<AppBskyFeedSearchPostsV2.OutputSchema>
@@ -78,9 +79,17 @@ export function useSearchPostsV2Query({
        */
       const {q, ...embedded} = extractSearchPostsParams(query)
       const builtFilters = buildSearchPostsV2Filters(embedded, filters)
+      /*
+       * The "You" author filter is carried as `from=me` (rather than a
+       * `from:me` token in the query text, which would leak into the search
+       * input). Reconstruct it into the query operator here, since the backend
+       * resolves `me` to the viewer.
+       */
+      const finalQuery =
+        filters?.from === 'me' ? `${q ? `${q} ` : ''}from:me` : q
       const res = await agent.app.bsky.feed.searchPostsV2({
         ...builtFilters,
-        query: q,
+        query: finalQuery,
         limit: 25,
         cursor: pageParam,
         /*


### PR DESCRIPTION
In addition to searching via `from:me` in the query, this allows selecting yourself from the “Filter by author” dropdown in the UI.

Existing URLs are backwards compatible, so no links or bookmarks are broken.

<img width="402" height="874" alt="ios" src="https://github.com/user-attachments/assets/7a6569b7-22cf-46ea-8111-fea6f26a8468" />
