### PR TITLE
Fix Android silently dropping the last line of wrapped text

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -303,6 +303,7 @@ module.exports = function (_config) {
         './plugins/withAndroidManifestFCMIconPlugin.js',
         './plugins/withAndroidManifestIntentQueriesPlugin.js',
         './plugins/withAndroidStylesAccentColorPlugin.js',
+        './plugins/androidTextWrapWidthFix/withAndroidTextWrapWidthFix.js',
         './plugins/withAndroidNoJitpackPlugin.js',
         './plugins/shareExtension/withShareExtensions.js',
         './plugins/notificationsExtension/withNotificationsExtension.js',

--- a/plugins/androidTextWrapWidthFix/WrapWidthTextFix.kt
+++ b/plugins/androidTextWrapWidthFix/WrapWidthTextFix.kt
@@ -1,0 +1,57 @@
+package xyz.blueskyweb.app.textwrapfix
+
+import android.content.Context
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewManager
+import com.facebook.react.views.text.ReactTextView
+import com.facebook.react.views.text.ReactTextViewManager
+
+/**
+ * Works around Android silently dropping the last line of wrapped post text
+ * (#5235).
+ *
+ * React Native (old architecture) measures text with a StaticLayout built at
+ * ceil(availableWidth), but the TextView later re-breaks the same text at the
+ * Yoga-rounded integer frame width, which can be up to ~2px narrower
+ * (measurement ceil plus frame position rounding). A line whose advance width
+ * falls inside that window fits during measurement but wraps during render,
+ * pushing the last line below the measured bounds where it is clipped.
+ *
+ * TextView computes its wrap width as viewWidth - compoundPadding, so
+ * reporting slightly less right padding widens the render-side wrap width to
+ * cover the window: the renderer can always fit what measurement fit. Worst
+ * case, a knife-edge line paints up to 2px of a glyph edge past the view
+ * bounds instead of dropping a whole word.
+ *
+ * Old architecture only. Remove after migrating to the new architecture:
+ * Fabric's prepared text layouts draw the measured layout directly, so the
+ * two passes cannot disagree.
+ */
+private const val RENDER_WRAP_SLACK_PX = 2
+
+internal class WrapWidthTextView(context: Context) : ReactTextView(context) {
+  override fun getCompoundPaddingRight(): Int =
+      super.getCompoundPaddingRight() - RENDER_WRAP_SLACK_PX
+}
+
+internal class WrapWidthTextViewManager : ReactTextViewManager() {
+  override fun createViewInstance(context: ThemedReactContext): ReactTextView =
+      WrapWidthTextView(context)
+}
+
+/**
+ * Must be registered after the autolinked packages so that its "RCTText"
+ * view manager replaces the stock one (last registration wins).
+ */
+class WrapWidthTextPackage : ReactPackage {
+  override fun createNativeModules(
+      reactContext: ReactApplicationContext
+  ): List<NativeModule> = emptyList()
+
+  override fun createViewManagers(
+      reactContext: ReactApplicationContext
+  ): List<ViewManager<*, *>> = listOf(WrapWidthTextViewManager())
+}

--- a/plugins/androidTextWrapWidthFix/WrapWidthTextFix.kt
+++ b/plugins/androidTextWrapWidthFix/WrapWidthTextFix.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewManager
 import com.facebook.react.views.text.ReactTextView
@@ -53,5 +54,15 @@ class WrapWidthTextPackage : ReactPackage {
 
   override fun createViewManagers(
       reactContext: ReactApplicationContext
-  ): List<ViewManager<*, *>> = listOf(WrapWidthTextViewManager())
+  ): List<ViewManager<*, *>> =
+      if (ReactNativeFeatureFlags.enablePreparedTextLayout()) {
+        /*
+         * Prepared text layouts (new architecture) draw the measured layout
+         * directly, which fixes the bug for real. Registering our manager
+         * would replace PreparedLayoutTextViewManager, so step aside.
+         */
+        emptyList()
+      } else {
+        listOf(WrapWidthTextViewManager())
+      }
 }

--- a/plugins/androidTextWrapWidthFix/withAndroidTextWrapWidthFix.js
+++ b/plugins/androidTextWrapWidthFix/withAndroidTextWrapWidthFix.js
@@ -1,0 +1,55 @@
+/**
+ * @file Fix Android silently dropping the last line of wrapped text (#5235).
+ *
+ * Copies WrapWidthTextFix.kt into the generated Android project and registers
+ * WrapWidthTextPackage in MainApplication, whose "RCTText" view manager
+ * replaces the stock one with a TextView that wraps at a slightly wider
+ * width, covering the measurement/render rounding window that causes the
+ * truncation. See WrapWidthTextFix.kt for the full mechanism.
+ */
+
+// eslint-disable-next-line import-x/no-nodejs-modules
+const {promises: fs} = require('fs')
+// eslint-disable-next-line import-x/no-nodejs-modules
+const path = require('path')
+const {withDangerousMod, withMainApplication} = require('expo/config-plugins')
+
+const SOURCE_FILE = 'WrapWidthTextFix.kt'
+const PACKAGE_PATH = 'xyz/blueskyweb/app/textwrapfix'
+const REGISTRATION =
+  'add(xyz.blueskyweb.app.textwrapfix.WrapWidthTextPackage())'
+const PACKAGES_ANCHOR = 'PackageList(this).packages.apply {'
+
+module.exports = function withAndroidTextWrapWidthFix(appConfig) {
+  appConfig = withDangerousMod(appConfig, [
+    'android',
+    async function copyNativeSource(config) {
+      const destDir = path.join(
+        config.modRequest.platformProjectRoot,
+        'app/src/main/java',
+        PACKAGE_PATH,
+      )
+      await fs.mkdir(destDir, {recursive: true})
+      await fs.copyFile(
+        path.join(__dirname, SOURCE_FILE),
+        path.join(destDir, SOURCE_FILE),
+      )
+      return config
+    },
+  ])
+  return withMainApplication(appConfig, function registerPackage(config) {
+    const {contents} = config.modResults
+    if (!contents.includes(REGISTRATION)) {
+      if (!contents.includes(PACKAGES_ANCHOR)) {
+        throw new Error(
+          `withAndroidTextWrapWidthFix: could not find "${PACKAGES_ANCHOR}" in MainApplication`,
+        )
+      }
+      config.modResults.contents = contents.replace(
+        PACKAGES_ANCHOR,
+        `${PACKAGES_ANCHOR}\n              ${REGISTRATION}`,
+      )
+    }
+    return config
+  })
+}


### PR DESCRIPTION
## Summary

Fixes #5235 (and duplicates #5835, #7122, #8161, #8465).

Replaces #10523, which I am closing after finding the root cause.

On Android, the last word or words of a post are sometimes missing in the feed. The post detail view shows the full text. There is no error and no `…` — the text just ends early. Users have reported this since 2024, on many Android versions, and changing the system font size makes it appear or disappear. The root cause explains all of this.

## Root cause

React Native (old architecture, which this app uses) wraps every `<Text>` into lines **twice**, in two separate places:

1. **Measurement.** `ReactTextShadowNode.measureSpannedText` builds a `StaticLayout` with width `(int) Math.ceil(availableWidth)`. The number of lines from this step decides the height of the text's box. ([RN 0.81 source](https://github.com/facebook/react-native/blob/v0.81.5/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.kt))
2. **Render.** The `ReactTextView` (a normal Android `TextView`) receives the same text and wraps it again on its own, using its final frame width. Because of rounding (the `ceil` above, plus Yoga rounding positions to whole pixels), this width can be **1-2px smaller** than the width used in step 1.

So the two steps can disagree. If a line is almost exactly as wide as the text box, it fits in step 1 but does not fit in step 2. The renderer then needs one more line than the box has room for. The extra line is drawn below the bottom of the box, where it is cut off and invisible.

To confirm this, I built a debug version of the app that logs the internal text layout of every `TextView`, and tested two live posts that show the bug (Pixel 9 Pro XL):

- On normal lines, the two steps produce **identical line widths** (within 0.03px). Fonts and sizes agree perfectly. Only the wrap width differs.
- Post 1: one line was 816.57px wide. Measurement wrapped the text at width 817, so this line fit. The renderer wrapped at width 816, so the last word (`eyes.`) moved to a 10th line — below a box with room for only 9 lines.
- Post 2: the two steps disagreed already at **line 1**. Every line after it changed too, and the renderer needed 4 lines for a 3-line box.

Post 2 shows why the NBSP idea in #10523 cannot fully work: it only adds width to the *last* line, but the problem can start at any line. @arturo32's observation in #7122 — "the length of each character matters" — was exactly right. Credit to him, and to @surfdude29 for collecting the duplicate issues.

I also ruled out other suspects: `useBoundsForWidth` (turned it off at runtime; the line breaks did not change), font scale (it only changes which lines are near the limit), and `elegantTextHeight` / `letterSpacing` (identical in both steps). A JavaScript fix is not possible: the `onTextLayout` event is produced by the measurement step, so JavaScript can never see what the renderer did differently. This is also why the bug was so hard to find.

## Fix

A config plugin (same pattern as our other plugins that add native code) registers a `ReactPackage` whose view manager for `RCTText` replaces the default one. Its `TextView` subclass reports 2px less right padding. `TextView` computes its wrap width as `view width - padding`, so this makes the render-side wrap width 2px wider. That covers the full rounding difference: the renderer can now always fit what measurement fit, and the two steps agree on the line count again.

Worst case after this change: a near-limit line can draw up to 2px of its last letter outside the view. In practice this is not visible, because the outer 2px of a letter are almost always empty space. Very rarely, a text box can be one line taller than needed. Both outcomes are harmless compared to losing words.

This fix is for the old architecture only. It should be removed when the app moves to the new architecture: Fabric's prepared text layouts (`PreparedLayoutTextView`) draw the measured layout directly, so the two steps cannot disagree there.

## Test plan

- [x] Built this branch (release, Pixel 9 Pro XL, Android 17, font scale 1.15). A live post that reproduces the bug now shows its full text in the feed, and the line breaks match the measurement step within 0.1px. Screenshots below.
- [x] Used the debug probe to confirm the fix is active and works as designed. Same post, control build vs. this branch (`WrapWidthTextView` running, wrap width 818 vs. the 816px frame, layout height == view height):

  ```
  control: viewWH=816x150 layoutWH=816x200 lines=4 [.. |IS going to be w=756.7 |different w=154.7]
  fixed:   viewWH=816x150 layoutWH=818x150 lines=3 [.. |to be different w=788.3]  (WrapWidthTextView)
  ```

  The second reproducer post (the one where only the last line is affected) was checked the same way: on the control build the renderer produced 10 lines for a 9-line box; with the fix, the layout fits the box.
- [x] Scrolled Following, Likes, profile feeds, and post threads. No visual regressions, no changed line wraps outside the near-limit cases, spacing unchanged.
- [x] Text selection and copy work the same as before (the fix does not change the text).
- [ ] Testing on more devices and screen densities is welcome. The mechanism does not depend on density (the difference is a fixed ~2px from pixel rounding), but more coverage is always good.

| Before (control build of main) | After (this branch) |
|---|---|
| ![Post ends "this time it IS going to be" - the last word is missing](https://raw.githubusercontent.com/diabler-ie/social-app/assets/text-wrap-fix/lauren-before-truncated-crop.png) | ![Full text: "this time it IS going to be different"](https://raw.githubusercontent.com/diabler-ie/social-app/assets/text-wrap-fix/lauren-after-fixed-crop.png) |

Same post, same feed position. Note that line 1 also wraps differently in the fixed build: the renderer now uses the same line breaks as the measurement step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
