### PR TITLE
Add context comments to "From" strings for translation clarity

### DIFF
--- a/src/screens/Search/components/AdvancedSearchDialog/index.tsx
+++ b/src/screens/Search/components/AdvancedSearchDialog/index.tsx
@@ -403,7 +403,7 @@ function DialogInner({
                 t.atoms.text_contrast_medium,
                 a.mb_sm,
               ]}>
-              <Trans comment="Filter search results by a specific post author">
+              <Trans context="Filter search results by a specific post author">
                 From
               </Trans>
             </Text>

--- a/src/screens/Search/components/AdvancedSearchDialog/index.tsx
+++ b/src/screens/Search/components/AdvancedSearchDialog/index.tsx
@@ -403,7 +403,9 @@ function DialogInner({
                 t.atoms.text_contrast_medium,
                 a.mb_sm,
               ]}>
-              <Trans>From</Trans>
+              <Trans comment="Filter search results by a specific post author">
+                From
+              </Trans>
             </Text>
             <View style={[a.flex_row]}>
               <FollowingDropdown value={following} onChange={setFollowing} />

--- a/src/screens/Settings/NotificationSettings/components/PreferenceControls.tsx
+++ b/src/screens/Settings/NotificationSettings/components/PreferenceControls.tsx
@@ -156,7 +156,7 @@ export function Inner({
         <>
           <Divider />
           <Text style={[a.font_semi_bold, a.text_md]}>
-            <Trans comment="Filter who you receive notifications from">
+            <Trans context="Filter who you receive notifications from">
               From
             </Trans>
           </Text>

--- a/src/screens/Settings/NotificationSettings/components/PreferenceControls.tsx
+++ b/src/screens/Settings/NotificationSettings/components/PreferenceControls.tsx
@@ -156,7 +156,9 @@ export function Inner({
         <>
           <Divider />
           <Text style={[a.font_semi_bold, a.text_md]}>
-            <Trans>From</Trans>
+            <Trans comment="Filter who you receive notifications from">
+              From
+            </Trans>
           </Text>
           <Toggle.Group
             type="radio"


### PR DESCRIPTION
This PR adds translation context comments to the `From` strings in the Advanced Search dialog and Notification Settings.

The word `From` has completely different meanings and grammatical forms depending on the context in target languages. Providing these comments ensures translators can provide accurate localized strings.