### PR TITLE
Add submit-and-block option to report dialog

### DIFF
--- a/src/components/moderation/ReportDialog/index.tsx
+++ b/src/components/moderation/ReportDialog/index.tsx
@@ -253,30 +253,6 @@ function Inner(props: ReportDialogProps) {
             state,
           }),
         )
-        if (block) {
-          /*
-           * The report has already been sent at this point, so a block
-           * failure shouldn't put the dialog into an error state - surface
-           * it via toast instead.
-           */
-          try {
-            await block()
-            Toast.show(l({message: 'Account blocked', context: 'toast'}))
-          } catch (err) {
-            const e = err as Error
-            if (e?.name !== 'AbortError') {
-              logger.error('Failed to block account after report', {
-                safeMessage: e.message,
-              })
-              Toast.show(
-                l`Your report was sent, but we couldn't block this account. Please try again from their profile.`,
-                {
-                  type: 'error',
-                },
-              )
-            }
-          }
-        }
         setIsSuccess(true)
         ax.metric('reportDialog:success', {
           reason: state.selectedOption?.reason ?? '',
@@ -287,6 +263,28 @@ function Inner(props: ReportDialogProps) {
         setTimeout(() => {
           props.control.close(() => {
             props.onAfterSubmit?.()
+            /*
+             * Run the block only after the dialog has fully closed: blocking
+             * optimistically removes the subject's posts from feeds, which
+             * would unmount this dialog mid-flight if it ran while open. The
+             * report has already been sent, so a block failure is surfaced
+             * via toast rather than a dialog error state.
+             */
+            if (block) {
+              block().catch((err: Error) => {
+                if (err?.name !== 'AbortError') {
+                  logger.error('Failed to block account after report', {
+                    safeMessage: err.message,
+                  })
+                  Toast.show(
+                    l({message: 'Failed to block account', context: 'toast'}),
+                    {
+                      type: 'error',
+                    },
+                  )
+                }
+              })
+            }
           })
         }, 1e3)
       } catch (err) {

--- a/src/components/moderation/ReportDialog/index.tsx
+++ b/src/components/moderation/ReportDialog/index.tsx
@@ -14,7 +14,10 @@ import {wait} from '#/lib/async/wait'
 import {getLabelingServiceTitle} from '#/lib/moderation'
 import {useCallOnce} from '#/lib/once'
 import {sanitizeHandle} from '#/lib/strings/handles'
+import {useProfileShadow} from '#/state/cache/profile-shadow'
 import {useMyLabelersQuery} from '#/state/queries/preferences'
+import {useProfileBlockMutationQueue} from '#/state/queries/profile'
+import {useSession} from '#/state/session'
 import {CharProgress} from '#/view/com/composer/char-progress/CharProgress'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {atoms as a, useGutters, useTheme} from '#/alf'
@@ -29,13 +32,16 @@ import {
   CheckThick_Stroke2_Corner0_Rounded as Check,
 } from '#/components/icons/Check'
 import {PaperPlane_Stroke2_Corner0_Rounded as PaperPlane} from '#/components/icons/PaperPlane'
+import {PersonX_Stroke2_Corner0_Rounded as PersonX} from '#/components/icons/Person'
 import {SquareArrowTopRight_Stroke2_Corner0_Rounded as SquareArrowTopRight} from '#/components/icons/SquareArrowTopRight'
 import {TimesLarge_Stroke2_Corner0_Rounded as X} from '#/components/icons/Times'
 import {createStaticClick, InlineLinkText, Link} from '#/components/Link'
 import {Loader} from '#/components/Loader'
+import * as Toast from '#/components/Toast'
 import {Text} from '#/components/Typography'
 import {useAnalytics} from '#/analytics'
 import {IS_NATIVE} from '#/env'
+import type * as bsky from '#/types/bsky'
 import {useSubmitReportMutation} from './action'
 import {
   BSKY_LABELER_ONLY_REPORT_REASONS,
@@ -133,6 +139,27 @@ function Inner(props: ReportDialogProps) {
   const {mutateAsync: submitReport} = useSubmitReportMutation()
   const [isPending, setIsPending] = useState(false)
   const [isSuccess, setIsSuccess] = useState(false)
+  /**
+   * Whether the in-flight (or completed) submission was triggered via the
+   * "submit and block" button, used to show pending/success state on the
+   * correct button.
+   */
+  const [withBlock, setWithBlock] = useState(false)
+
+  const {currentAccount} = useSession()
+  /**
+   * The user to offer a block action against: the reported account itself,
+   * or the author of a reported post. Other subject types (lists, feeds,
+   * chats, etc.) don't get the block shortcut.
+   */
+  const blockTargetProfile =
+    props.subject.type === 'account'
+      ? props.subject.profile
+      : props.subject.type === 'post'
+        ? props.subject.authorProfile
+        : undefined
+  const canBlockSubject =
+    !!blockTargetProfile && blockTargetProfile.did !== currentAccount?.did
 
   // some reasons ONLY go to Bluesky
   const isBskyOnlyReason = state?.selectedOption?.reason
@@ -209,47 +236,75 @@ function Inner(props: ReportDialogProps) {
   const isAlwaysBskyLabeler =
     hasSingleSupportedLabeler && (isBskyOnlyReason || isBskyOnlySubject)
 
-  const onSubmit = useCallback(async () => {
-    dispatch({type: 'clearError'})
+  const onSubmit = useCallback(
+    async (block?: () => Promise<unknown>) => {
+      dispatch({type: 'clearError'})
 
-    logger.info('submitting')
+      logger.info('submitting')
 
-    try {
-      setIsPending(true)
-      // wait at least 1s, make it feel substantial
-      await wait(
-        1e3,
-        submitReport({
-          subject: props.subject,
-          state,
-        }),
-      )
-      setIsSuccess(true)
-      ax.metric('reportDialog:success', {
-        reason: state.selectedOption?.reason ?? '',
-        labeler: state.selectedLabeler?.creator.handle ?? '',
-        details: !!state.details,
-      })
-      // give time for user feedback
-      setTimeout(() => {
-        props.control.close(() => {
-          props.onAfterSubmit?.()
+      try {
+        setWithBlock(!!block)
+        setIsPending(true)
+        // wait at least 1s, make it feel substantial
+        await wait(
+          1e3,
+          submitReport({
+            subject: props.subject,
+            state,
+          }),
+        )
+        if (block) {
+          /*
+           * The report has already been sent at this point, so a block
+           * failure shouldn't put the dialog into an error state - surface
+           * it via toast instead.
+           */
+          try {
+            await block()
+            Toast.show(l({message: 'Account blocked', context: 'toast'}))
+          } catch (err) {
+            const e = err as Error
+            if (e?.name !== 'AbortError') {
+              logger.error('Failed to block account after report', {
+                safeMessage: e.message,
+              })
+              Toast.show(
+                l`Your report was sent, but we couldn't block this account. Please try again from their profile.`,
+                {
+                  type: 'error',
+                },
+              )
+            }
+          }
+        }
+        setIsSuccess(true)
+        ax.metric('reportDialog:success', {
+          reason: state.selectedOption?.reason ?? '',
+          labeler: state.selectedLabeler?.creator.handle ?? '',
+          details: !!state.details,
         })
-      }, 1e3)
-    } catch (err) {
-      const e = err as Error
-      ax.metric('reportDialog:failure', {})
-      logger.error(e, {
-        source: 'ReportDialog',
-      })
-      dispatch({
-        type: 'setError',
-        error: l`Something went wrong. Please try again.`,
-      })
-    } finally {
-      setIsPending(false)
-    }
-  }, [logger, submitReport, props, state, ax, l])
+        // give time for user feedback
+        setTimeout(() => {
+          props.control.close(() => {
+            props.onAfterSubmit?.()
+          })
+        }, 1e3)
+      } catch (err) {
+        const e = err as Error
+        ax.metric('reportDialog:failure', {})
+        logger.error(e, {
+          source: 'ReportDialog',
+        })
+        dispatch({
+          type: 'setError',
+          error: l`Something went wrong. Please try again.`,
+        })
+      } finally {
+        setIsPending(false)
+      }
+    },
+    [logger, submitReport, props, state, ax, l],
+  )
 
   useCallOnce(() => {
     ax.metric('reportDialog:open', {
@@ -564,21 +619,39 @@ function Inner(props: ReportDialogProps) {
                   </View>
                 )}
               </View>
-              <Button
-                testID="report:submit"
-                label={l`Submit report`}
-                size="large"
-                variant="solid"
-                color="primary"
-                disabled={isPending || isSuccess}
-                onPress={() => void onSubmit()}>
-                <ButtonText>
-                  <Trans>Submit report</Trans>
-                </ButtonText>
-                <ButtonIcon
-                  icon={isSuccess ? CheckThin : isPending ? Loader : PaperPlane}
-                />
-              </Button>
+              <View style={[a.gap_sm]}>
+                <Button
+                  testID="report:submit"
+                  label={l`Submit report`}
+                  size="large"
+                  variant="solid"
+                  color="primary"
+                  disabled={isPending || isSuccess}
+                  onPress={() => void onSubmit()}>
+                  <ButtonText>
+                    <Trans>Submit report</Trans>
+                  </ButtonText>
+                  <ButtonIcon
+                    icon={
+                      isSuccess && !withBlock
+                        ? CheckThin
+                        : isPending && !withBlock
+                          ? Loader
+                          : PaperPlane
+                    }
+                  />
+                </Button>
+
+                {canBlockSubject && blockTargetProfile && (
+                  <SubmitAndBlockButton
+                    profile={blockTargetProfile}
+                    isPending={isPending}
+                    isSuccess={isSuccess}
+                    withBlock={withBlock}
+                    onSubmit={onSubmit}
+                  />
+                )}
+              </View>
 
               {state.error && (
                 <Admonition.Admonition type="error">
@@ -591,6 +664,56 @@ function Inner(props: ReportDialogProps) {
       </View>
       <Dialog.Close />
     </Dialog.ScrollableInner>
+  )
+}
+
+/**
+ * Secondary submit button that sends the report and then blocks the reported
+ * user. Rendered as a separate component so the profile shadow and block
+ * mutation hooks only run when there's a blockable subject.
+ */
+function SubmitAndBlockButton({
+  profile,
+  isPending,
+  isSuccess,
+  withBlock,
+  onSubmit,
+}: {
+  profile: bsky.profile.AnyProfileView
+  isPending: boolean
+  isSuccess: boolean
+  withBlock: boolean
+  onSubmit: (block: () => Promise<unknown>) => Promise<void>
+}) {
+  const {t: l} = useLingui()
+  const shadow = useProfileShadow(profile)
+  const [queueBlock] = useProfileBlockMutationQueue(shadow)
+
+  // already blocked, nothing to offer
+  if (shadow.viewer?.blocking) return null
+
+  return (
+    <Button
+      testID="report:submitAndBlock"
+      label={l`Submit report and block account`}
+      size="large"
+      variant="solid"
+      color="negative"
+      disabled={isPending || isSuccess}
+      onPress={() => void onSubmit(queueBlock)}>
+      <ButtonText>
+        <Trans>Submit report and block account</Trans>
+      </ButtonText>
+      <ButtonIcon
+        icon={
+          isSuccess && withBlock
+            ? CheckThin
+            : isPending && withBlock
+              ? Loader
+              : PersonX
+        }
+      />
+    </Button>
   )
 }
 

--- a/src/components/moderation/ReportDialog/types.ts
+++ b/src/components/moderation/ReportDialog/types.ts
@@ -7,6 +7,7 @@ import {
 } from '@atproto/api'
 
 import type * as Dialog from '#/components/Dialog'
+import type * as bsky from '#/types/bsky'
 
 export type ReportSubjectConvoMessage = {
   view: 'convo' | 'message'
@@ -37,6 +38,11 @@ export type ParsedReportSubject =
       uri: string
       cid: string
       nsid: string
+      /**
+       * The post author's profile, used to offer a block action alongside
+       * report submission.
+       */
+      authorProfile: bsky.profile.AnyProfileView
       attributes: {
         reply: boolean
         image: boolean
@@ -73,6 +79,11 @@ export type ParsedReportSubject =
       type: 'account'
       did: string
       nsid: string
+      /**
+       * The reported account's profile, used to offer a block action
+       * alongside report submission.
+       */
+      profile: bsky.profile.AnyProfileView
     }
   | ({
       type: 'convoMessage'

--- a/src/components/moderation/ReportDialog/utils/parseReportSubject.ts
+++ b/src/components/moderation/ReportDialog/utils/parseReportSubject.ts
@@ -39,6 +39,7 @@ export function parseReportSubject(
       type: 'account',
       did: subject.did,
       nsid: 'app.bsky.actor.profile',
+      profile: subject,
     }
   } else if (AppBskyActorDefs.isStatusView(subject)) {
     if (!subject.uri || !subject.cid) return
@@ -83,6 +84,7 @@ export function parseReportSubject(
         uri: subject.uri,
         cid: subject.cid,
         nsid: 'app.bsky.feed.post',
+        authorProfile: subject.author,
         attributes: {
           reply: !!record.reply,
           image:


### PR DESCRIPTION
Apologies for the drive-by slop, but how would you feel about a "report and block" action in the report flow? Pretty common on other platforms, and eliminates three extra clicks for what I usually want to do anyway.

<img width="432" height="492" alt="image" src="https://github.com/user-attachments/assets/d8582eea-5bec-4b14-b56b-14b364bf8678" />
