### PR TITLE
Split mobile build/submit pipelines and de-duplicate OTA workflow

### DIFF
--- a/.github/actions/compile-i18n/action.yml
+++ b/.github/actions/compile-i18n/action.yml
@@ -1,0 +1,15 @@
+---
+name: Compile translations
+description: Compile i18n translations and fail on compilation errors.
+
+runs:
+  using: composite
+  steps:
+    - name: 🔤 Compile translations
+      shell: bash
+      run: pnpm intl:build 2>&1 | tee i18n.log
+
+    - name: Check for i18n compilation errors
+      shell: bash
+      run: if grep -q "invalid syntax" "i18n.log"; then echo "\n\nFound compilation
+        errors!\n\n" && exit 1; else echo "\n\nNo compilation errors!\n\n"; fi

--- a/.github/actions/setup-expo-project/action.yml
+++ b/.github/actions/setup-expo-project/action.yml
@@ -1,0 +1,47 @@
+---
+name: Setup Expo Project
+description: Install dependencies and set up the Expo/EAS CLI for a build. Does not check out the repo.
+
+inputs:
+  expo-token:
+    description: Expo token (EXPO_TOKEN secret)
+    required: true
+  eas-version:
+    description: EAS CLI version to install
+    required: false
+    default: '19.0.5'
+
+runs:
+  using: composite
+  steps:
+    - name: Check for EXPO_TOKEN
+      shell: bash
+      env:
+        EXPO_TOKEN: ${{ inputs.expo-token }}
+      run: >
+        if [ -z "$EXPO_TOKEN" ]; then
+          echo "You must provide an EXPO_TOKEN secret linked to this project's Expo account in this repo's secrets. Learn more: https://docs.expo.dev/eas-update/github-actions"
+          exit 1
+        fi
+
+    - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+    - name: 🔧 Setup Node
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version-file: package.json
+        cache: pnpm
+
+    - name: 🪛 Setup jq
+      uses: dcarbone/install-jq-action@4fcb5062d7ce9bc4382d1a352d19ba3ba2c317c1 # v4.0.1
+
+    - name: ⚙️ Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
+    - name: 🔨 Setup Expo CLI
+      uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # 9.0.0
+      with:
+        eas-version: ${{ inputs.eas-version }}
+        packager: 'pnpm --allow-build=dtrace-provider'
+        token: ${{ inputs.expo-token }}

--- a/.github/actions/write-env/action.yml
+++ b/.github/actions/write-env/action.yml
@@ -1,0 +1,63 @@
+---
+name: Write Environment Variables
+description: Write the .env file and google-services.json used by the build.
+
+inputs:
+  env-token:
+    description: Base .env contents (ENV_TOKEN secret)
+    required: true
+  sentry-dsn:
+    description: Sentry DSN (SENTRY_DSN secret)
+    required: true
+  bitdrift-api-key:
+    description: Bitdrift API key (BITDRIFT_API_KEY secret)
+    required: true
+  gcp-project-id:
+    description: GCP project ID (EXPO_PUBLIC_GCP_PROJECT_ID secret)
+    required: true
+  google-services-token:
+    description: google-services.json contents (GOOGLE_SERVICES_TOKEN secret)
+    required: true
+  expo-public-env:
+    description: >
+      EXPO_PUBLIC_ENV value. Only set for OTA deploys where eas.json isn't used;
+      for regular builds this is normally handled in eas.json.
+    required: false
+    default: ''
+
+outputs:
+  release-version:
+    description: Version from package.json
+    value: ${{ steps.env.outputs.release-version }}
+  bundle-identifier:
+    description: git SHA of HEAD
+    value: ${{ steps.env.outputs.bundle-identifier }}
+
+runs:
+  using: composite
+  steps:
+    - name: ✏️ Write environment variables
+      id: env
+      shell: bash
+      env:
+        ENV_TOKEN: ${{ inputs.env-token }}
+        SENTRY_DSN: ${{ inputs.sentry-dsn }}
+        BITDRIFT_API_KEY: ${{ inputs.bitdrift-api-key }}
+        GCP_PROJECT_ID: ${{ inputs.gcp-project-id }}
+        GOOGLE_SERVICES_TOKEN: ${{ inputs.google-services-token }}
+        EXPO_PUBLIC_ENV: ${{ inputs.expo-public-env }}
+      run: |
+        echo "$ENV_TOKEN" > .env
+        # EXPO_PUBLIC_ENV is normally handled in eas.json; only written here for OTA deploys.
+        if [ -n "$EXPO_PUBLIC_ENV" ]; then
+          echo "EXPO_PUBLIC_ENV=$EXPO_PUBLIC_ENV" >> .env
+        fi
+        echo "EXPO_PUBLIC_RELEASE_VERSION=$(jq -r '.version' package.json)" >> .env
+        echo "release-version=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
+        echo "EXPO_PUBLIC_BUNDLE_IDENTIFIER=$(git rev-parse HEAD)" >> .env
+        echo "bundle-identifier=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+        echo "EXPO_PUBLIC_BUNDLE_DATE=$(date -u +"%y%m%d%H")" >> .env
+        echo "EXPO_PUBLIC_SENTRY_DSN=$SENTRY_DSN" >> .env
+        echo "EXPO_PUBLIC_BITDRIFT_API_KEY=$BITDRIFT_API_KEY" >> .env
+        echo "EXPO_PUBLIC_GCP_PROJECT_ID=$GCP_PROJECT_ID" >> .env
+        echo "$GOOGLE_SERVICES_TOKEN" > google-services.json

--- a/.github/workflows/build-submit-android.yml
+++ b/.github/workflows/build-submit-android.yml
@@ -10,12 +10,25 @@ on:
         options:
           - testflight-android
           - production
+      submit:
+        type: boolean
+        description: Submit the build to Google Play (disable to only produce the APK artifact)
+        default: true
   workflow_call:
     inputs:
       profile:
         type: string
         description: Build profile to use
         required: true
+      submit:
+        type: boolean
+        description: Submit the build to Google Play (disable to only produce the APK artifact)
+        default: true
+      runner:
+        type: string
+        description: Runner for the build job (defaults to Linux-x64-32core)
+        required: false
+        default: ''
     outputs:
       package-version:
         description: Version from package.json
@@ -56,48 +69,24 @@ permissions:
 jobs:
   build:
     if: github.repository == 'bluesky-social/social-app'
-    name: Build and Submit Android
-    runs-on: Linux-x64-32core
+    name: Build Android
+    runs-on: ${{ inputs.runner || 'Linux-x64-32core' }}
     concurrency:
       group: android-build
       cancel-in-progress: false
     outputs:
       package-version: ${{ steps.get-build-info.outputs.PACKAGE_VERSION }}
       version-code: ${{ steps.get-build-info.outputs.BSKY_ANDROID_VERSION_CODE }}
-      apk-artifact-name: build-${{ steps.timestamp.outputs.time }}.apk
     steps:
-      - name: Check for EXPO_TOKEN
-        run: >
-          if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then
-            echo "You must provide an EXPO_TOKEN secret linked to this project's Expo account in this repo's secrets. Learn more: https://docs.expo.dev/eas-update/github-actions"
-            exit 1
-          fi
-
       - name: ⬇️ Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 5
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - name: 🔧 Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: 🔧 Setup Expo project
+        uses: ./.github/actions/setup-expo-project
         with:
-          node-version-file: package.json
-          cache: pnpm
-
-      - name: 🪛 Setup jq
-        uses: dcarbone/install-jq-action@4fcb5062d7ce9bc4382d1a352d19ba3ba2c317c1 # v4.0.1
-
-      - name: ⚙️ Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: 🔨 Setup Expo CLI
-        uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # 9.0.0
-        with:
-          eas-version: '19.0.5'
-          packager: 'pnpm --allow-build=dtrace-provider'
-          token: ${{ secrets.EXPO_TOKEN }}
+          expo-token: ${{ secrets.EXPO_TOKEN }}
 
       - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
@@ -105,35 +94,26 @@ jobs:
           java-version: "17"
 
       - name: 🔤 Compile translations
-        run: pnpm intl:build 2>&1 | tee i18n.log
-
-      - name: Check for i18n compilation errors
-        run: if grep -q "invalid syntax" "i18n.log"; then echo "\n\nFound compilation
-          errors!\n\n" && exit 1; else echo "\n\nNo compilation errors!\n\n"; fi
+        uses: ./.github/actions/compile-i18n
 
       # EXPO_PUBLIC_ENV is handled in eas.json
-      - name: Env
+      - name: ✏️ Write environment variables
         id: env
-        run: |
-          export json='${{ secrets.GOOGLE_SERVICES_TOKEN }}'
-          echo "${{ secrets.ENV_TOKEN }}" > .env
-          echo "EXPO_PUBLIC_RELEASE_VERSION=$(jq -r '.version' package.json)" >> .env
-          echo "EXPO_PUBLIC_RELEASE_VERSION=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
-          echo "EXPO_PUBLIC_BUNDLE_IDENTIFIER=$(git rev-parse HEAD)" >> .env
-          echo "EXPO_PUBLIC_BUNDLE_IDENTIFIER=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-          echo "EXPO_PUBLIC_BUNDLE_DATE=$(date -u +"%y%m%d%H")" >> .env
-          echo "EXPO_PUBLIC_SENTRY_DSN=${{ secrets.SENTRY_DSN }}" >> .env
-          echo "EXPO_PUBLIC_BITDRIFT_API_KEY=${{ secrets.BITDRIFT_API_KEY }}" >> .env
-          echo "EXPO_PUBLIC_GCP_PROJECT_ID=${{ secrets.EXPO_PUBLIC_GCP_PROJECT_ID }}" >> .env
-          echo "$json" > google-services.json
+        uses: ./.github/actions/write-env
+        with:
+          env-token: ${{ secrets.ENV_TOKEN }}
+          sentry-dsn: ${{ secrets.SENTRY_DSN }}
+          bitdrift-api-key: ${{ secrets.BITDRIFT_API_KEY }}
+          gcp-project-id: ${{ secrets.EXPO_PUBLIC_GCP_PROJECT_ID }}
+          google-services-token: ${{ secrets.GOOGLE_SERVICES_TOKEN }}
 
       - name: 🏗️ EAS Build
         env:
           PROFILE: ${{ inputs.profile || 'testflight-android' }}
         run: >
           SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_RELEASE=${{ steps.env.outputs.EXPO_PUBLIC_RELEASE_VERSION }}
-          SENTRY_DIST=${{ steps.env.outputs.EXPO_PUBLIC_BUNDLE_IDENTIFIER }}
+          SENTRY_RELEASE=${{ steps.env.outputs.release-version }}
+          SENTRY_DIST=${{ steps.env.outputs.bundle-identifier }}
           pnpm use-build-number-with-bump
           pnpm eas build -p android
           --profile $PROFILE
@@ -142,6 +122,39 @@ jobs:
       - name: 📚 Get version from package.json
         id: get-build-info
         run: bash scripts/setGitHubOutput.sh
+
+      # Hands the built bundle off to the submit / universalApk jobs. Retention is
+      # deliberately short (1 day) since it's only an intra-run handoff artifact.
+      - name: 🚀 Upload AAB artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: android-aab-${{ github.run_id }}
+          retention-days: 1
+          if-no-files-found: error
+          path: build.aab
+
+  submit:
+    name: Submit to Google Play
+    runs-on: ubuntu-latest
+    needs: [build]
+    # Submit unless explicitly disabled; on events where inputs is empty this still submits.
+    if: ${{ inputs.submit != false }}
+    steps:
+      # eas submit reads app config from the repo, so we need a checkout.
+      - name: ⬇️ Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 5
+
+      - name: 🔧 Setup Expo project
+        uses: ./.github/actions/setup-expo-project
+        with:
+          expo-token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: ⬇️ Download AAB artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: android-aab-${{ github.run_id }}
 
       - name: 🚀 Submit to Google Play
         env:
@@ -156,7 +169,43 @@ jobs:
           webhook-type: incoming-webhook
           payload-templated: true
           payload: |
-            {"text": "Android ${{ inputs.profile || 'testflight-android' }} build submitted to Google Play!\n```Version Number: ${{ steps.get-build-info.outputs.PACKAGE_VERSION }}\nBuild Number: ${{ steps.get-build-info.outputs.BSKY_ANDROID_VERSION_CODE }}```"}
+            {"text": "Android ${{ inputs.profile || 'testflight-android' }} build submitted to Google Play!\n```Version Number: ${{ needs.build.outputs.package-version }}\nBuild Number: ${{ needs.build.outputs.version-code }}```"}
+
+      # Record the commit only after a successful submit, so a failed submit doesn't
+      # advance the "most recent testflight" marker.
+      - name: ⬇️ Restore Cache
+        id: get-base-commit
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        if: ${{ inputs.profile == 'testflight-android' }}
+        with:
+          path: most-recent-testflight-commit.txt
+          key: most-recent-testflight-commit
+
+      - name: ✏️ Write commit hash to cache
+        if: ${{ inputs.profile == 'testflight-android' }}
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+        run: echo $GITHUB_SHA > most-recent-testflight-commit.txt
+
+  # Runs in parallel with submit: the QA APK shouldn't be blocked by a Play submission failure.
+  universalApk:
+    name: Build universal APK
+    runs-on: ubuntu-latest
+    needs: [build]
+    outputs:
+      apk-artifact-name: build-${{ steps.timestamp.outputs.time }}.apk
+    steps:
+      - name: ⬇️ Download AAB artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: android-aab-${{ github.run_id }}
+
+      # bundletool needs a JRE. ubuntu-latest ships a default JDK, but pin it explicitly
+      # like the build job so the toolchain is deterministic.
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        with:
+          distribution: "temurin"
+          java-version: "17"
 
       - name: 🔧 Setup bundletool
         uses: amyu/setup-bundletool@cc2e1857284660bd625e43f2c8a45626f034302f # v1.1
@@ -164,19 +213,24 @@ jobs:
           version: "1.18.3"
 
       - name: 🔑 Decode keystore
-        run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode >
-          keystore.jks
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > keystore.jks
 
       - name: 📦 Build signed universal APK
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: |
           bundletool build-apks \
             --bundle=build.aab \
             --output=universal.apks \
             --mode=universal \
             --ks=keystore.jks \
-            --ks-pass=pass:${{ secrets.ANDROID_KEYSTORE_PASSWORD }} \
-            --ks-key-alias=${{ secrets.ANDROID_KEY_ALIAS }} \
-            --key-pass=pass:${{ secrets.ANDROID_KEY_PASSWORD }}
+            --ks-pass=pass:"$ANDROID_KEYSTORE_PASSWORD" \
+            --ks-key-alias="$ANDROID_KEY_ALIAS" \
+            --key-pass=pass:"$ANDROID_KEY_PASSWORD"
 
       - name: 📋 Rename to .zip for extraction
         run: mv universal.apks universal.zip
@@ -204,21 +258,7 @@ jobs:
           webhook-type: incoming-webhook
           payload-templated: true
           payload: |
-            {"text": "Android ${{ inputs.profile || 'testflight-android' }} APK is ready for testing!\n```Artifact: ${{ steps.upload-artifact.outputs.artifact-url }}\nVersion Number: ${{ steps.get-build-info.outputs.PACKAGE_VERSION }}\nBuild Number: ${{ steps.get-build-info.outputs.BSKY_ANDROID_VERSION_CODE }}```"}
-
-      - name: ⬇️ Restore Cache
-        id: get-base-commit
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: ${{ inputs.profile == 'testflight-android' }}
-        with:
-          path: most-recent-testflight-commit.txt
-          key: most-recent-testflight-commit
-
-      - name: ✏️ Write commit hash to cache
-        if: ${{ inputs.profile == 'testflight-android' }}
-        env:
-          GITHUB_SHA: ${{ github.sha }}
-        run: echo $GITHUB_SHA > most-recent-testflight-commit.txt
+            {"text": "Android ${{ inputs.profile || 'testflight-android' }} APK is ready for testing!\n```Artifact: ${{ steps.upload-artifact.outputs.artifact-url }}\nVersion Number: ${{ needs.build.outputs.package-version }}\nBuild Number: ${{ needs.build.outputs.version-code }}```"}
 
   # Releases are cut from tags named after the version (e.g. "1.124.0"), so when a production
   # build is dispatched against such a tag we attach the APK to the matching release. This runs
@@ -226,7 +266,7 @@ jobs:
   attachToRelease:
     name: Attach APK to GitHub Release
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build, universalApk]
     if: ${{ inputs.profile == 'production' && github.ref_type == 'tag' && github.repository == 'bluesky-social/social-app' }}
     permissions:
       contents: write
@@ -254,7 +294,7 @@ jobs:
         if: ${{ steps.release-check.outputs.exists == 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ needs.build.outputs.apk-artifact-name }}
+          name: ${{ needs.universalApk.outputs.apk-artifact-name }}
 
       - name: 🏷️ Rename APK for release
         if: ${{ steps.release-check.outputs.exists == 'true' }}

--- a/.github/workflows/build-submit-ios.yml
+++ b/.github/workflows/build-submit-ios.yml
@@ -28,6 +28,11 @@ on:
         type: string
         description: TestFlight group to assign the build to after submitting ("none" to skip)
         default: none
+      runner:
+        type: string
+        description: Runner for the build job (defaults to macos-26-xlarge)
+        required: false
+        default: ''
     outputs:
       package-version:
         description: Version from package.json
@@ -66,8 +71,8 @@ permissions:
 jobs:
   build:
     if: github.repository == 'bluesky-social/social-app'
-    name: Build and Submit iOS
-    runs-on: macos-26-xlarge
+    name: Build iOS
+    runs-on: ${{ inputs.runner || 'macos-26-xlarge' }}
     concurrency:
       group: ios-build
       cancel-in-progress: false
@@ -75,38 +80,15 @@ jobs:
       package-version: ${{ steps.get-build-info.outputs.PACKAGE_VERSION }}
       build-number: ${{ steps.ipa-build-number.outputs.build-number }}
     steps:
-      - name: Check for EXPO_TOKEN
-        run: >
-          if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then
-            echo "You must provide an EXPO_TOKEN secret linked to this project's Expo account in this repo's secrets. Learn more: https://docs.expo.dev/eas-update/github-actions"
-            exit 1
-          fi
-
       - name: ⬇️ Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 5
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - name: 🔧 Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: 🔧 Setup Expo project
+        uses: ./.github/actions/setup-expo-project
         with:
-          node-version-file: package.json
-          cache: pnpm
-
-      - name: 🪛 Setup jq
-        uses: dcarbone/install-jq-action@4fcb5062d7ce9bc4382d1a352d19ba3ba2c317c1 # v4.0.1
-
-      - name: ⚙️ Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: 🔨 Setup Expo CLI
-        uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # 9.0.0
-        with:
-          eas-version: '19.0.5'
-          packager: 'pnpm --allow-build=dtrace-provider'
-          token: ${{ secrets.EXPO_TOKEN }}
+          expo-token: ${{ secrets.EXPO_TOKEN }}
 
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
@@ -133,34 +115,26 @@ jobs:
           key: ${{ runner.os }}-pods-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: 🔤 Compile translations
-        run: pnpm intl:build 2>&1 | tee i18n.log
-
-      - name: Check for i18n compilation errors
-        run: if grep -q "invalid syntax" "i18n.log"; then echo "\n\nFound compilation
-          errors!\n\n" && exit 1; else echo "\n\nNo compilation errors!\n\n"; fi
+        uses: ./.github/actions/compile-i18n
 
       # EXPO_PUBLIC_ENV is handled in eas.json
       - name: ✏️ Write environment variables
         id: env
-        run: |
-          echo "${{ secrets.ENV_TOKEN }}" > .env
-          echo "EXPO_PUBLIC_RELEASE_VERSION=$(jq -r '.version' package.json)" >> .env
-          echo "EXPO_PUBLIC_RELEASE_VERSION=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
-          echo "EXPO_PUBLIC_BUNDLE_IDENTIFIER=$(git rev-parse HEAD)" >> .env
-          echo "EXPO_PUBLIC_BUNDLE_IDENTIFIER=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-          echo "EXPO_PUBLIC_BUNDLE_DATE=$(date -u +"%y%m%d%H")" >> .env
-          echo "EXPO_PUBLIC_SENTRY_DSN=${{ secrets.SENTRY_DSN }}" >> .env
-          echo "EXPO_PUBLIC_BITDRIFT_API_KEY=${{ secrets.BITDRIFT_API_KEY }}" >> .env
-          echo "EXPO_PUBLIC_GCP_PROJECT_ID=${{ secrets.EXPO_PUBLIC_GCP_PROJECT_ID }}" >> .env
-          echo "${{ secrets.GOOGLE_SERVICES_TOKEN }}" > google-services.json
+        uses: ./.github/actions/write-env
+        with:
+          env-token: ${{ secrets.ENV_TOKEN }}
+          sentry-dsn: ${{ secrets.SENTRY_DSN }}
+          bitdrift-api-key: ${{ secrets.BITDRIFT_API_KEY }}
+          gcp-project-id: ${{ secrets.EXPO_PUBLIC_GCP_PROJECT_ID }}
+          google-services-token: ${{ secrets.GOOGLE_SERVICES_TOKEN }}
 
       - name: 🏗️ EAS Build
         env:
           PROFILE: ${{ inputs.profile || 'testflight' }}
         run: >
           SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_RELEASE=${{ steps.env.outputs.EXPO_PUBLIC_RELEASE_VERSION }}
-          SENTRY_DIST=${{ steps.env.outputs.EXPO_PUBLIC_BUNDLE_IDENTIFIER }}
+          SENTRY_RELEASE=${{ steps.env.outputs.release-version }}
+          SENTRY_DIST=${{ steps.env.outputs.bundle-identifier }}
           pnpm use-build-number-with-bump
           pnpm eas build -p ios
           --profile $PROFILE
@@ -201,16 +175,6 @@ jobs:
             exit 1
           fi
 
-      - name: 🚀 Deploy
-        run: pnpm eas submit -p ios --non-interactive --path "$BUILD_DIR/Bluesky.ipa"
-
-      - name: 🪲 Upload dSYM to Sentry
-        run: >
-          SENTRY_ORG=blueskyweb
-          SENTRY_PROJECT=app
-          SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
-          pnpm sentry-cli debug-files upload "$BUILD_DIR/Bluesky.app.dSYM.zip" --include-sources
-
       - name: 📚 Get version from package.json
         id: get-build-info
         run: bash scripts/setGitHubOutput.sh
@@ -220,6 +184,7 @@ jobs:
       # number that actually lands in App Store Connect. `eas build:version:get` reads the
       # remote counter, which a --local build does not advance, so it can be off by one —
       # using it here would make distribute_only poll for a nonexistent build.
+      # PlistBuddy is macOS-only, which is why this stays in the build job.
       - name: 🔢 Read build number from IPA
         id: ipa-build-number
         run: |
@@ -235,18 +200,98 @@ jobs:
           echo "IPA build number: $build_number"
           echo "build-number=$build_number" >> "$GITHUB_OUTPUT"
 
+      # Hand the IPA and dSYM off to the submit job. Retention is deliberately short since
+      # this artifact only exists to bridge the two jobs within a single run.
+      - name: 🚀 Upload build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ios-build-${{ github.run_id }}
+          retention-days: 1
+          if-no-files-found: error
+          path: |
+            ${{ env.BUILD_DIR }}/Bluesky.ipa
+            ${{ env.BUILD_DIR }}/Bluesky.app.dSYM.zip
+
+  submit:
+    name: Submit iOS
+    # Submission and dSYM upload are I/O bound and don't need the xlarge builder.
+    runs-on: macos-26
+    needs: [build]
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # eas submit reads the app config from the repo
+          fetch-depth: 5
+
+      - name: 🔧 Setup Expo project
+        uses: ./.github/actions/setup-expo-project
+        with:
+          expo-token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: ⬇️ Download build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ios-build-${{ github.run_id }}
+          path: ios-build
+
+      - name: 🚀 Deploy
+        run: pnpm eas submit -p ios --non-interactive --path ios-build/Bluesky.ipa
+
+      - name: 🪲 Upload dSYM to Sentry
+        env:
+          SENTRY_ORG: blueskyweb
+          SENTRY_PROJECT: app
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: pnpm sentry-cli debug-files upload ios-build/Bluesky.app.dSYM.zip --include-sources
+
+      - name: 🔔 Notify Slack of Production Build
+        if: ${{ inputs.profile == 'production' }}
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          webhook: ${{ secrets.SLACK_CLIENT_ALERT_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload-templated: true
+          payload: |
+            {"text": "iOS production build for App Store submission is ready!\n```Artifact: Check TestFlight to know when it is available\nVersion Number: ${{ needs.build.outputs.package-version }}\nBuild Number: ${{ needs.build.outputs.build-number }}```"}
+
+      # Record the commit only after a successful submit, so a failed submit doesn't advance
+      # the baseline used for the next testflight build's changelog.
+      - name: ⬇️ Restore Cache
+        id: get-base-commit
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        if: ${{ inputs.profile == 'testflight' }}
+        with:
+          path: most-recent-testflight-commit.txt
+          key: most-recent-testflight-commit
+
+      - name: ✏️ Write commit hash to cache
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+        if: ${{ inputs.profile == 'testflight' }}
+        run: echo $GITHUB_SHA > most-recent-testflight-commit.txt
+
+  distribute:
+    name: Assign build to TestFlight group
+    # fastlane and jq ship preinstalled on the macOS runner image, and this step mostly idles
+    # polling Apple processing, so it runs on a normal-size runner.
+    runs-on: macos-26
+    needs: [build, submit]
+    # testFlightGroup defaults to 'none' on both workflow_call and dispatch; guard against the
+    # empty string too, since `!= 'none'` alone would be true for ''.
+    if: ${{ inputs.testFlightGroup && inputs.testFlightGroup != 'none' }}
+    steps:
       # eas submit only uploads to App Store Connect; it can't assign a build to a
       # TestFlight group. fastlane's distribute_only mode skips the upload and assigns the
       # already-submitted build to the group, polling until Apple finishes processing it.
       - name: 🧪 Assign build to TestFlight group
-        if: ${{ inputs.testFlightGroup != 'none' }}
         env:
           TESTFLIGHT_GROUP: ${{ inputs.testFlightGroup }}
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
           ASC_KEY_P8_BASE64: ${{ secrets.ASC_KEY_P8_BASE64 }}
-          APP_VERSION: ${{ steps.get-build-info.outputs.PACKAGE_VERSION }}
-          BUILD_NUMBER: ${{ steps.ipa-build-number.outputs.build-number }}
+          APP_VERSION: ${{ needs.build.outputs.package-version }}
+          BUILD_NUMBER: ${{ needs.build.outputs.build-number }}
         run: |
           # Ensure the API key material is removed even if fastlane exits non-zero
           # (the step runs under `bash -e`, which would otherwise abort before cleanup).
@@ -271,27 +316,3 @@ jobs:
             build_number:"$BUILD_NUMBER" \
             groups:"$TESTFLIGHT_GROUP" \
             notify_external_testers:true
-
-      - name: 🔔 Notify Slack of Production Build
-        if: ${{ inputs.profile == 'production' }}
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
-        with:
-          webhook: ${{ secrets.SLACK_CLIENT_ALERT_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload-templated: true
-          payload: |
-            {"text": "iOS production build for App Store submission is ready!\n```Artifact: Check TestFlight to know when it is available\nVersion Number: ${{ steps.get-build-info.outputs.PACKAGE_VERSION }}\nBuild Number: ${{ steps.ipa-build-number.outputs.build-number }}```"}
-
-      - name: ⬇️ Restore Cache
-        id: get-base-commit
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: ${{ inputs.profile == 'testflight' }}
-        with:
-          path: most-recent-testflight-commit.txt
-          key: most-recent-testflight-commit
-
-      - name: ✏️ Write commit hash to cache
-        env:
-          GITHUB_SHA: ${{ github.sha }}
-        if: ${{ inputs.profile == 'testflight' }}
-        run: echo $GITHUB_SHA > most-recent-testflight-commit.txt

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -99,11 +99,7 @@ jobs:
           previous-commit-tag: ${{ inputs.runtimeVersion }}
 
       - name: 🔤 Compile translations
-        run: pnpm intl:build 2>&1 | tee i18n.log
-
-      - name: Check for i18n compilation errors
-        run: if grep -q "invalid syntax" "i18n.log"; then echo "\n\nFound compilation
-          errors!\n\n" && exit 1; else echo "\n\nNo compilation errors!\n\n"; fi
+        uses: ./.github/actions/compile-i18n
 
       - name: Lint check
         run: pnpm lint
@@ -128,35 +124,26 @@ jobs:
           !steps.version.outputs.version-changed }}
         uses: dcarbone/install-jq-action@4fcb5062d7ce9bc4382d1a352d19ba3ba2c317c1 # v4.0.1
 
-      # eas.json not used here, set EXPO_PUBLIC_ENV
-      - name: Env
-        env:
-          CHANNEL: ${{ inputs.channel || 'testflight' }}
-          GITHUB_SHA: ${{ github.sha }}
+      # eas.json not used here, so EXPO_PUBLIC_ENV must be written explicitly
+      - name: ✏️ Write environment variables
         id: env
-        if: ${{ !steps.fingerprint.outputs.includes-changes &&
-          !steps.version.outputs.version-changed }}
-        run: |
-          export json='${{ secrets.GOOGLE_SERVICES_TOKEN }}'
-          echo "${{ secrets.ENV_TOKEN }}" > .env
-          echo "EXPO_PUBLIC_ENV=$CHANNEL" >> .env
-          echo "EXPO_PUBLIC_RELEASE_VERSION=$(jq -r '.version' package.json)" >> .env
-          echo "EXPO_PUBLIC_RELEASE_VERSION=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
-          echo "EXPO_PUBLIC_BUNDLE_IDENTIFIER=$(git rev-parse HEAD)" >> .env
-          echo "EXPO_PUBLIC_BUNDLE_IDENTIFIER=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-          echo "EXPO_PUBLIC_BUNDLE_DATE=$(date -u +"%y%m%d%H")" >> .env
-          echo "EXPO_PUBLIC_SENTRY_DSN=${{ secrets.SENTRY_DSN }}" >> .env
-          echo "EXPO_PUBLIC_BITDRIFT_API_KEY=${{ secrets.BITDRIFT_API_KEY }}" >> .env
-          echo "EXPO_PUBLIC_GCP_PROJECT_ID=${{ secrets.EXPO_PUBLIC_GCP_PROJECT_ID }}" >> .env
-          echo "$json" > google-services.json
+        if: ${{ !steps.fingerprint.outputs.includes-changes && !steps.version.outputs.version-changed }}
+        uses: ./.github/actions/write-env
+        with:
+          env-token: ${{ secrets.ENV_TOKEN }}
+          sentry-dsn: ${{ secrets.SENTRY_DSN }}
+          bitdrift-api-key: ${{ secrets.BITDRIFT_API_KEY }}
+          gcp-project-id: ${{ secrets.EXPO_PUBLIC_GCP_PROJECT_ID }}
+          google-services-token: ${{ secrets.GOOGLE_SERVICES_TOKEN }}
+          expo-public-env: ${{ inputs.channel || 'testflight' }}
 
       - name: 🏗️ Create Bundle
         if: ${{ !steps.fingerprint.outputs.includes-changes &&
           !steps.version.outputs.version-changed }}
         run: >
           SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_RELEASE=${{ steps.env.outputs.EXPO_PUBLIC_RELEASE_VERSION }}
-          SENTRY_DIST=${{ steps.env.outputs.EXPO_PUBLIC_BUNDLE_IDENTIFIER }}
+          SENTRY_RELEASE=${{ steps.env.outputs.release-version }}
+          SENTRY_DIST=${{ steps.env.outputs.bundle-identifier }}
           pnpm export
 
       - name: 📦 Package Bundle and 🚀 Deploy
@@ -182,305 +169,64 @@ jobs:
           !steps.version.outputs.version-changed }}
         run: echo $GITHUB_SHA > most-recent-testflight-commit.txt
 
-  # GitHub actions are horrible so let's just copy paste this in
   buildIfNecessaryIOS:
     name: Build and Submit iOS
-    runs-on: macos-26
-    concurrency:
-      group: ios-build
-      cancel-in-progress: false
     needs: [bundleDeploy]
     # Gotta check if its NOT '[]' because any md5 hash in the outputs is detected as a possible secret and won't be
     # available here
     if: ${{ inputs.channel != 'production' &&
       needs.bundleDeploy.outputs.changes-detected && github.repository ==
       'bluesky-social/social-app' }}
-    steps:
-      - name: Check for EXPO_TOKEN
-        run: >
-          if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then
-            echo "You must provide an EXPO_TOKEN secret linked to this project's Expo account in this repo's secrets. Learn more: https://docs.expo.dev/eas-update/github-actions"
-            exit 1
-          fi
-
-      - name: ⬇️ Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 5
-
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - name: 🔧 Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: package.json
-          cache: pnpm
-
-      - name: 🔨 Setup EAS
-        uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # 9.0.0
-        with:
-          eas-version: '19.0.5'
-          packager: 'pnpm --allow-build=dtrace-provider'
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: ⚙️ Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
-        with:
-          xcode-version: "26.4"
-
-      - name: ☕️ Assert Cocoapods version
-        run: |
-          EXPECTED=1.17.0
-          ACTUAL=$(pod --version)
-          if [ "$ACTUAL" != "$EXPECTED" ]; then
-            echo "Expected Cocoapods $EXPECTED but runner has $ACTUAL."
-            echo "The version ships preinstalled with the macOS runner image: https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md"
-            echo "If the runner image changed, update EXPECTED here or reinstall the pinned version."
-            exit 1
-          fi
-
-      - name: 💾 Cache Pods
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: pods-cache
-        with:
-          path: ./ios/Pods
-          # We'll use the pnpm-lock.yaml for our hash since we don't yet have a Podfile.lock. Pod versions will not
-          # change unless the pnpm version changes as well.
-          key: ${{ runner.os }}-pods-${{ hashFiles('pnpm-lock.yaml') }}
-
-      - name: 🔤 Compile translations
-        run: pnpm intl:build
-
-      # EXPO_PUBLIC_ENV is handled in eas.json
-      - name: Env
-        id: env
-        run: |
-          echo "${{ secrets.ENV_TOKEN }}" > .env
-          echo "EXPO_PUBLIC_RELEASE_VERSION=$(jq -r '.version' package.json)" >> .env
-          echo "EXPO_PUBLIC_RELEASE_VERSION=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
-          echo "EXPO_PUBLIC_BUNDLE_IDENTIFIER=$(git rev-parse HEAD)" >> .env
-          echo "EXPO_PUBLIC_BUNDLE_IDENTIFIER=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-          echo "EXPO_PUBLIC_BUNDLE_DATE=$(date -u +"%y%m%d%H")" >> .env
-          echo "EXPO_PUBLIC_SENTRY_DSN=${{ secrets.SENTRY_DSN }}" >> .env
-          echo "EXPO_PUBLIC_BITDRIFT_API_KEY=${{ secrets.BITDRIFT_API_KEY }}" >> .env
-          echo "EXPO_PUBLIC_GCP_PROJECT_ID=${{ secrets.EXPO_PUBLIC_GCP_PROJECT_ID }}" >> .env
-          echo "${{ secrets.GOOGLE_SERVICES_TOKEN }}" > google-services.json
-
-      - name: 🏗️ EAS Build
-        run: >
-          SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_RELEASE=${{ steps.env.outputs.EXPO_PUBLIC_RELEASE_VERSION }}
-          SENTRY_DIST=${{ steps.env.outputs.EXPO_PUBLIC_BUNDLE_IDENTIFIER }}
-          pnpm use-build-number-with-bump
-          pnpm eas build -p ios
-          --profile testflight
-          --local --output build.tar.gz --non-interactive
-
-      - name: 📂 Extract build artifact
-        run: |
-          if [ -f "build.tar.gz" ]; then
-            echo "Extracting build.tar.gz..."
-            rm -rf ios-build
-            mkdir -p ios-build
-            tar -xzf build.tar.gz -C ios-build
-            echo "Extraction completed successfully"
-
-            echo ""
-            echo "Top-level extracted files:"
-            find ios-build -maxdepth 3 -print
-
-            echo ""
-            echo "Searching for IPA..."
-            IPA_PATH="$(find ios-build -type f -name '*.ipa' -print -quit)"
-            if [ -z "$IPA_PATH" ]; then
-              echo "ERROR: No .ipa found anywhere under ios-build."
-              echo "Archive contents:"
-              tar -tzf build.tar.gz | sed -n '1,200p'
-              exit 1
-            fi
-
-            BUILD_DIR="$(dirname "$IPA_PATH")"
-            echo "Found IPA at: $IPA_PATH"
-            echo "Build dir: $BUILD_DIR"
-            echo ""
-            echo "Build dir contents:"
-            ls -la "$BUILD_DIR"
-            echo "BUILD_DIR=$BUILD_DIR" >> $GITHUB_ENV
-          else
-            echo "Archive file not found!"
-            exit 1
-          fi
-
-      - name: 🚀 Deploy
-        run: pnpm eas submit -p ios --non-interactive --path "$BUILD_DIR/Bluesky.ipa"
-
-      - name: 🪲 Upload dSYM to Sentry
-        run: >
-          SENTRY_ORG=blueskyweb
-          SENTRY_PROJECT=app
-          SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
-          pnpm sentry-cli debug-files upload "$BUILD_DIR/Bluesky.app.dSYM.zip" --include-sources
-
-      - name: ⬇️ Restore Cache
-        id: get-base-commit
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: ${{ inputs.channel == 'testflight' }}
-        with:
-          path: most-recent-testflight-commit.txt
-          key: most-recent-testflight-commit
-
-      - name: ✏️ Write commit hash to cache
-        if: ${{ inputs.channel == 'testflight' }}
-        env:
-          GITHUB_SHA: ${{ github.sha }}
-        run: echo $GITHUB_SHA > most-recent-testflight-commit.txt
+    uses: ./.github/workflows/build-submit-ios.yml
+    with:
+      profile: testflight
+      testFlightGroup: none
+      # OTA rebuilds don't need the xlarge builder used for releases
+      runner: macos-26
+    # Pass only the secrets the reusable workflow declares, rather than `secrets: inherit`,
+    # so this workflow never hands the reusable workflow the entire repo secret store.
+    secrets:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      ENV_TOKEN: ${{ secrets.ENV_TOKEN }}
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      BITDRIFT_API_KEY: ${{ secrets.BITDRIFT_API_KEY }}
+      EXPO_PUBLIC_GCP_PROJECT_ID: ${{ secrets.EXPO_PUBLIC_GCP_PROJECT_ID }}
+      GOOGLE_SERVICES_TOKEN: ${{ secrets.GOOGLE_SERVICES_TOKEN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+      ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+      ASC_KEY_P8_BASE64: ${{ secrets.ASC_KEY_P8_BASE64 }}
+      SLACK_CLIENT_ALERT_WEBHOOK: ${{ secrets.SLACK_CLIENT_ALERT_WEBHOOK }}
 
   buildIfNecessaryAndroid:
     name: Build and Submit Android
-    runs-on: ubuntu-latest
-    concurrency:
-      group: android-build
-      cancel-in-progress: false
     needs: [bundleDeploy]
     # Gotta check if its NOT '[]' because any md5 hash in the outputs is detected as a possible secret and won't be
     # available here
     if: ${{ inputs.channel != 'production' &&
       needs.bundleDeploy.outputs.changes-detected && github.repository ==
-      'bluesky-social/social-app'}}
-
-    steps:
-      - name: Check for EXPO_TOKEN
-        run: >
-          if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then
-            echo "You must provide an EXPO_TOKEN secret linked to this project's Expo account in this repo's secrets. Learn more: https://docs.expo.dev/eas-update/github-actions"
-            exit 1
-          fi
-
-      - name: ⬇️ Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 5
-
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - name: 🔧 Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: package.json
-          cache: pnpm
-
-      - name: 🔨 Setup EAS
-        uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # 9.0.0
-        with:
-          eas-version: '19.0.5'
-          packager: 'pnpm --allow-build=dtrace-provider'
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
-        with:
-          distribution: "temurin"
-          java-version: "17"
-
-      - name: ⚙️ Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: 🔤 Compile translations
-        run: pnpm intl:build
-
-      # EXPO_PUBLIC_ENV is handled in eas.json
-      - name: Env
-        id: env
-        run: |
-          export json='${{ secrets.GOOGLE_SERVICES_TOKEN }}'
-          echo "${{ secrets.ENV_TOKEN }}" > .env
-          echo "EXPO_PUBLIC_RELEASE_VERSION=$(jq -r '.version' package.json)" >> .env
-          echo "EXPO_PUBLIC_RELEASE_VERSION=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
-          echo "EXPO_PUBLIC_BUNDLE_IDENTIFIER=$(git rev-parse HEAD)" >> .env
-          echo "EXPO_PUBLIC_BUNDLE_IDENTIFIER=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-          echo "EXPO_PUBLIC_BUNDLE_DATE=$(date -u +"%y%m%d%H")" >> .env
-          echo "EXPO_PUBLIC_SENTRY_DSN=${{ secrets.SENTRY_DSN }}" >> .env
-          echo "EXPO_PUBLIC_BITDRIFT_API_KEY=${{ secrets.BITDRIFT_API_KEY }}" >> .env
-          echo "EXPO_PUBLIC_GCP_PROJECT_ID=${{ secrets.EXPO_PUBLIC_GCP_PROJECT_ID }}" >> .env
-          echo "$json" > google-services.json
-
-      - name: 🏗️ EAS Build
-        run: >
-          SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_RELEASE=${{ steps.env.outputs.EXPO_PUBLIC_RELEASE_VERSION }}
-          SENTRY_DIST=${{ steps.env.outputs.EXPO_PUBLIC_BUNDLE_IDENTIFIER }}
-          pnpm use-build-number-with-bump
-          pnpm eas build -p android
-          --profile testflight-android
-          --local --output build.aab --non-interactive
-
-      - name: 📚 Get version from package.json
-        id: get-build-info
-        run: bash scripts/setGitHubOutput.sh
-
-      - name: 🚀 Submit to Google Play
-        run: pnpm eas submit -p android --profile testflight-android --non-interactive --path
-          build.aab
-
-      - name: 🔧 Setup bundletool
-        uses: amyu/setup-bundletool@cc2e1857284660bd625e43f2c8a45626f034302f # v1.1
-        with:
-          version: "1.18.3"
-
-      - name: 🔑 Decode keystore
-        run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode >
-          keystore.jks
-
-      - name: 📦 Build signed universal APK
-        run: |
-          bundletool build-apks \
-            --bundle=build.aab \
-            --output=universal.apks \
-            --mode=universal \
-            --ks=keystore.jks \
-            --ks-pass=pass:${{ secrets.ANDROID_KEYSTORE_PASSWORD }} \
-            --ks-key-alias=${{ secrets.ANDROID_KEY_ALIAS }} \
-            --key-pass=pass:${{ secrets.ANDROID_KEY_PASSWORD }}
-
-      - name: 📋 Rename to .zip for extraction
-        run: mv universal.apks universal.zip
-
-      - name: 📦 Extract universal APK
-        run: unzip -p universal.zip universal.apk > build.apk
-
-      - name: ⏰ Get a timestamp
-        id: timestamp
-        run: echo "time=$(date -u +'%m-%d-%H-%M-%S')" >> "$GITHUB_OUTPUT"
-
-      - name: 🚀 Upload Artifact
-        id: upload-artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          retention-days: 30
-          compression-level: 0
-          name: build-${{ steps.timestamp.outputs.time }}.apk
-          path: build.apk
-
-      - name: 🔔 Notify Slack
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
-        with:
-          webhook: ${{ secrets.SLACK_CLIENT_ALERT_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload-templated: true
-          payload: |
-            {"text": "Android build is ready for testing. Download the artifact here: ${{ steps.upload-artifact.outputs.artifact-url }}"}
-
-      - name: ⬇️ Restore Cache
-        id: get-base-commit
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: ${{ inputs.channel != 'testflight' && inputs.channel != 'production' }}
-        with:
-          path: most-recent-testflight-commit.txt
-          key: most-recent-testflight-commit
-
-      - name: ✏️ Write commit hash to cache
-        env:
-          GITHUB_SHA: ${{ github.sha }}
-        if: ${{ inputs.channel != 'testflight' && inputs.channel != 'production' }}
-        run: echo $GITHUB_SHA > most-recent-testflight-commit.txt
+      'bluesky-social/social-app' }}
+    # build-submit-android.yml contains an attachToRelease job that requests contents: write.
+    # That job is skipped here (it needs a production tag build), but GitHub statically
+    # validates the reusable-workflow permission ceiling, so the caller must grant it.
+    permissions:
+      contents: write
+    uses: ./.github/workflows/build-submit-android.yml
+    with:
+      profile: testflight-android
+      runner: ubuntu-latest
+    # Pass only the secrets the reusable workflow declares, rather than `secrets: inherit`,
+    # so this workflow never hands the reusable workflow the entire repo secret store.
+    secrets:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      ENV_TOKEN: ${{ secrets.ENV_TOKEN }}
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      BITDRIFT_API_KEY: ${{ secrets.BITDRIFT_API_KEY }}
+      EXPO_PUBLIC_GCP_PROJECT_ID: ${{ secrets.EXPO_PUBLIC_GCP_PROJECT_ID }}
+      GOOGLE_SERVICES_TOKEN: ${{ secrets.GOOGLE_SERVICES_TOKEN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SLACK_CLIENT_ALERT_WEBHOOK: ${{ secrets.SLACK_CLIENT_ALERT_WEBHOOK }}
+      ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+      ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+      ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}


### PR DESCRIPTION
## Why

The three mobile CI entrypoints had grown into monolithic jobs:

- **iOS**: one job on `macos-26-xlarge` did build → `eas submit` → dSYM upload → fastlane TestFlight-group assignment. The fastlane step polls Apple processing for a long time, idling the most expensive runner in the fleet.
- **Android**: one job on `Linux-x64-32core` did build → submit → bundletool universal APK → artifact upload → Slack — everything after the build only needs `build.aab` + secrets.
- **OTA** (`bundle-deploy-eas-update.yml`): contained verbatim copy-pastes of both build jobs ("GitHub actions are horrible so let's just copy paste this in"), which had already drifted from the originals.

## What

### New composite actions (`.github/actions/`)
- `setup-expo-project` — pnpm/node/jq/install/EAS CLI prologue (was duplicated 4×)
- `write-env` — writes `.env` + `google-services.json`, outputs `release-version`/`bundle-identifier`
- `compile-i18n` — `intl:build` + the "invalid syntax" error gate

### iOS: 1 job → 3
- `build` (`macos-26-xlarge`, overridable via new `runner` input): EAS build, read build number from the IPA (PlistBuddy is macOS-only), upload IPA+dSYM as a 1-day handoff artifact
- `submit` (`macos-26`): `eas submit`, dSYM Sentry upload, Slack notify, testflight-commit cache
- `distribute` (`macos-26`): fastlane TestFlight-group assignment — the long Apple-processing poll now idles a normal-size runner instead of the xlarge

### Android: 2 jobs → 4
- `build` (`Linux-x64-32core`, overridable via `runner` input): EAS build, upload `build.aab` as a 1-day handoff artifact
- `submit` (`ubuntu-latest`): Play Store submission — skippable via a new `submit` boolean input, so a build can be dispatched that only produces the APK artifact
- `universalApk` (`ubuntu-latest`): bundletool signed universal APK + artifact + Slack, running in parallel with `submit`
- `attachToRelease`: unchanged, now consumes the APK from `universalApk`

### OTA de-dup (487 → 233 lines)
Both copy-pasted `buildIfNecessary*` jobs are replaced with `uses:` calls to the reusable workflows (passing the smaller runners the OTA path already used), with explicit secret passthrough matching `nightly-build.yml`'s convention. `bundleDeploy` also adopts the `write-env` and `compile-i18n` actions.

`nightly-build.yml` is untouched — workflow outputs still map to the `build` jobs.

## Intentional behavior changes

1. **Android APK generation no longer blocked by Play submission**: `universalApk` runs in parallel with `submit`, so QA gets its APK even if the Play upload fails.
2. **OTA builds regain the i18n error grep** (dropped in the copy-pastes).
3. **OTA Android testflight-commit cache actually records now**: the copied condition (`channel != 'testflight' && != 'production'`) was never true. Both platforms now record on their testflight profiles via the reusable workflows.
4. **OTA Android APK artifact compression 0 → 6** (matches the standalone workflow).
5. **New handoff artifacts** (`ios-build-*`, `android-aab-*`, 1-day retention) are downloadable by anyone with repo read, like the existing APK artifact. The IPA is store-signed/encrypted.

## Verification

- `zizmor --min-confidence medium` clean across all workflows + new actions (matches CI config)
- `actionlint`: only pre-existing info-level SC2086 notes (same class as on main)
- Manual end-to-end testing to follow before marking ready:
  ```
  gh workflow run build-submit-android.yml --ref samuel/split-build-pipelines -f profile=testflight-android -f submit=false
  gh workflow run build-submit-ios.yml --ref samuel/split-build-pipelines -f profile=testflight -f testFlightGroup=none
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)