### PR TITLE
Add DM button to labeller profiles

### DIFF
--- a/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
@@ -25,6 +25,7 @@ import {ProfileMenu} from '#/view/com/profile/ProfileMenu'
 import {atoms as a, tokens, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
 import {type DialogOuterProps, useDialogControl} from '#/components/Dialog'
+import {MessageProfileButton} from '#/components/dms/MessageProfileButton'
 import {
   Heart2_Filled_Stroke2_Corner0_Rounded as HeartFilled,
   Heart2_Stroke2_Corner0_Rounded as Heart,
@@ -240,7 +241,7 @@ export function HeaderLabelerButtons({
   const t = useTheme()
   const ax = useAnalytics()
   const {_} = useLingui()
-  const {currentAccount} = useSession()
+  const {currentAccount, hasSession} = useSession()
   const requireAuth = useRequireAuth()
   const playHaptic = useHaptics()
   const editProfileControl = useDialogControl()
@@ -286,6 +287,11 @@ export function HeaderLabelerButtons({
     })
   return (
     <>
+      {hasSession &&
+        !isMe &&
+        !profile.viewer?.blockedBy &&
+        !profile.viewer?.blocking && <MessageProfileButton profile={profile} />}
+
       {isMe ? (
         <>
           <Button


### PR DESCRIPTION
Currently users have to navigate to the Chat tab and initiate conversations with labellers from there, unlike regular users who have a dedicated DM button on the profile itself

This is unintuitive, inconsistent, and often needs to be explained by labellers themselves if they use DMs in any way

It doesn't make a ton of sense to not include it, as if a labeller didn't want DMs then this would be disabled on the account level. Logically, at no point should the app itself attempt to hide away the functionality, as it hinders the labellers that do use them 🐙️