### PR TITLE
fix android carousel jiggle from cdn-rounded aspect ratio

### DIFF
--- a/src/components/images/Gallery/index.tsx
+++ b/src/components/images/Gallery/index.tsx
@@ -485,9 +485,17 @@ function GalleryImage({
             loading={index === 0 ? 'eager' : 'lazy'}
             style={[dims]}
             onLoad={e => {
-              const ar = getAspectRatio(e.source)
-              if (ar && ar !== aspectRatio) {
-                setAspectRatio(ar)
+              /*
+               * Only sync from the loaded thumb if we don't already have a
+               * ratio from the record. The CDN scales thumbs to integer pixel
+               * dims, so its reported ratio drifts a fraction from the
+               * record's - re-syncing would jiggle the FlatList item widths.
+               */
+              if (aspectRatio === undefined) {
+                const ar = getAspectRatio(e.source)
+                if (ar !== undefined) {
+                  setAspectRatio(ar)
+                }
               }
               onThumbDims(index, {
                 width: e.source.width,


### PR DESCRIPTION
Fixes APP-2602 / #10957.

### What changed
`GalleryImage.onLoad` now only syncs `aspectRatio` from the loaded thumb when the record didn't ship one.

### Why
The record's `aspectRatio` is authoritative. The CDN scales feed thumbs to integer pixel dims, so `expo-image`'s reported natural ratio drifts a fraction from the record. The strict `!==` check caught every drift and pushed a new `aspectRatio` into state, which re-ran `computeDims`, changed `dims.width`, and re-laid out the FlatList - a visible jiggle. Darth's post has five near-square images, so five overlapping re-layouts stacked into the reported symptom. #11072 restored the native overscroll physics but didn't touch this path.

### Test plan
- [ ] On Android, open `https://bsky.app/profile/darthbluesky.bsky.social/post/3momdmpdgs22p` in the feed and in full post view - carousel is stable.
- [ ] Swipe the carousel - stretchy overscroll still works, snap-to-0 on the left edge still works.
- [ ] Post an image without an `aspectRatio` field (rare, old clients) - image still sizes correctly once loaded.