### PR TITLE
[APP-2642] Social proof text is truncated on mobile

### DIFF
--- a/src/screens/PostThread/components/LikesStat.tsx
+++ b/src/screens/PostThread/components/LikesStat.tsx
@@ -8,7 +8,7 @@ import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useLikedBySampleQuery} from '#/state/queries/post-liked-by'
 import {useSession} from '#/state/session'
-import {atoms as a, useTheme} from '#/alf'
+import {atoms as a, useBreakpoints, useTheme} from '#/alf'
 import {AvatarStack} from '#/components/AvatarStack'
 import {InlineLinkText, Link} from '#/components/Link'
 import {useFormatPostStatCount} from '#/components/PostControls/util'
@@ -32,6 +32,7 @@ const AVI_SIZE = 20
  */
 export function LikesStat({post}: {post: AppBskyFeedDefs.PostView}) {
   const t = useTheme()
+  const {gtMobile} = useBreakpoints()
   const {t: l} = useLingui()
   const {hasSession, currentAccount} = useSession()
   const moderationOpts = useModerationOpts()
@@ -98,8 +99,9 @@ export function LikesStat({post}: {post: AppBskyFeedDefs.PostView}) {
   const aviStackProfiles = knownLikersAndModeration
     .slice(0, 3)
     .map(({actor}) => actor)
+  const maxNames = gtMobile ? 2 : 1
   const names = knownLikersAndModeration
-    .slice(0, 2)
+    .slice(0, maxNames)
     .map(({actor, moderation}) => {
       return {
         did: actor.did,

--- a/src/screens/PostThread/components/LikesStat.tsx
+++ b/src/screens/PostThread/components/LikesStat.tsx
@@ -5,6 +5,7 @@ import {Plural, Trans, useLingui} from '@lingui/react/macro'
 
 import {makeProfileLink} from '#/lib/routes/links'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
+import {enforceLen} from '#/lib/strings/helpers'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useLikedBySampleQuery} from '#/state/queries/post-liked-by'
 import {useSession} from '#/state/session'
@@ -17,6 +18,7 @@ import {Text} from '#/components/Typography'
 import {useAnalytics} from '#/analytics'
 
 const AVI_SIZE = 20
+const MAX_NAME_LENGTH = 16
 
 /**
  * The likes stat for the expanded anchor post. When the viewer follows some
@@ -106,9 +108,13 @@ export function LikesStat({post}: {post: AppBskyFeedDefs.PostView}) {
       return {
         did: actor.did,
         href: makeProfileLink(actor),
-        displayName: sanitizeDisplayName(
-          actor.displayName || actor.handle,
-          moderation.ui('displayName'),
+        displayName: enforceLen(
+          sanitizeDisplayName(
+            actor.displayName || actor.handle,
+            moderation.ui('displayName'),
+          ),
+          MAX_NAME_LENGTH,
+          true,
         ),
       }
     })


### PR DESCRIPTION
On mobile, we only show one name now. For all platforms and sizes, since we limit the text to 1 line for this prototype, I've clipped all display names to 16 chars, which should ensure it's visible on most screen sizes.

<img width="1346" height="544" alt="CleanShot 2026-07-14 at 17 22 04" src="https://github.com/user-attachments/assets/399be473-b3d8-4a10-9fdd-2c877987de1c" />
<img width="1108" height="406" alt="CleanShot 2026-07-14 at 17 22 11" src="https://github.com/user-attachments/assets/9e6c4756-3580-4db6-9fe9-d501462f7d8b" />
