### PR TITLE
Don't suggest retrying an unretryable error

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -866,17 +866,6 @@
       "count": 1
     }
   },
-  "src/lib/strings/errors.ts": {
-    "typescript/no-explicit-any": {
-      "count": 1
-    },
-    "typescript/no-unsafe-call": {
-      "count": 14
-    },
-    "typescript/no-unsafe-member-access": {
-      "count": 14
-    }
-  },
   "src/lib/useGetEmojis/getEmojis.ts": {
     "typescript/require-await": {
       "count": 1

--- a/src/lib/strings/errors.ts
+++ b/src/lib/strings/errors.ts
@@ -1,13 +1,12 @@
 import {XRPCError} from '@atproto/api'
 import {t} from '@lingui/core/macro'
 
-export function cleanError(str: any): string {
-  if (!str) {
+export function cleanError(e: unknown): string {
+  if (!e) {
     return ''
   }
-  if (typeof str !== 'string') {
-    str = str.toString()
-  }
+  // oxlint-disable-next-line typescript/no-base-to-string
+  const str = typeof e === 'string' ? e : e.toString()
   if (isNetworkError(str)) {
     return t`Unable to connect. Please check your internet connection and try again.`
   }

--- a/src/lib/strings/errors.ts
+++ b/src/lib/strings/errors.ts
@@ -86,3 +86,9 @@ export function isCancelledError(e: unknown) {
   const str = String(e).toLowerCase()
   return str.includes('cancel')
 }
+
+// TODO Replace this with error.shouldRetry() when available. -dsb
+const RETRYABLE_ERRORS = [408, 425, 429, 500, 502, 503, 504, 522, 524]
+export function shouldRetryError(e: unknown) {
+  return e instanceof XRPCError && RETRYABLE_ERRORS.includes(e.status)
+}

--- a/src/screens/Search/SearchResults.tsx
+++ b/src/screens/Search/SearchResults.tsx
@@ -1,12 +1,16 @@
 import {memo, useCallback, useMemo, useState} from 'react'
 import {ActivityIndicator, View} from 'react-native'
-import {type AppBskyFeedDefs, XRPCError} from '@atproto/api'
+import {type AppBskyFeedDefs} from '@atproto/api'
 import {Trans, useLingui} from '@lingui/react/macro'
 
 import {urls} from '#/lib/constants'
 import {usePostViewTracking} from '#/lib/hooks/usePostViewTracking'
 import {useCallOnce} from '#/lib/once'
-import {cleanError} from '#/lib/strings/errors'
+import {
+  cleanError,
+  isNetworkError,
+  shouldRetryError,
+} from '#/lib/strings/errors'
 import {augmentSearchQuery} from '#/lib/strings/helpers'
 import {useActorSearch} from '#/state/queries/actor-search'
 import {usePopularFeedsSearch} from '#/state/queries/feed'
@@ -32,12 +36,6 @@ import {SearchError} from '#/components/SearchError'
 import {Text} from '#/components/Typography'
 import {type Metrics, useAnalytics} from '#/analytics'
 import type * as bsky from '#/types/bsky'
-
-// TODO Replace this with error.shouldRetry() when available. -dsb
-const RETRYABLE_ERRORS = [408, 425, 429, 500, 502, 503, 504, 522, 524]
-function shouldRetry(error: unknown) {
-  return error instanceof XRPCError && RETRYABLE_ERRORS.includes(error.status)
-}
 
 let SearchResults = ({
   query,
@@ -409,7 +407,7 @@ let SearchScreenPostResults = ({
   return error ? (
     <EmptyState
       messageText={
-        shouldRetry(error)
+        shouldRetryError(error) || isNetworkError(error)
           ? l`We’re sorry, but your search could not be completed. Please try again in a few minutes.`
           : l`We’re sorry, but your search could not be completed.`
       }
@@ -550,7 +548,7 @@ let SearchScreenUserResults = ({
     return (
       <EmptyState
         messageText={
-          shouldRetry(error)
+          shouldRetryError(error) || isNetworkError(error)
             ? l`We’re sorry, but your search could not be completed. Please try again in a few minutes.`
             : l`We’re sorry, but your search could not be completed.`
         }

--- a/src/screens/Search/SearchResults.tsx
+++ b/src/screens/Search/SearchResults.tsx
@@ -1,6 +1,6 @@
 import {memo, useCallback, useMemo, useState} from 'react'
 import {ActivityIndicator, View} from 'react-native'
-import {type AppBskyFeedDefs} from '@atproto/api'
+import {type AppBskyFeedDefs, XRPCError} from '@atproto/api'
 import {Trans, useLingui} from '@lingui/react/macro'
 
 import {urls} from '#/lib/constants'
@@ -32,6 +32,12 @@ import {SearchError} from '#/components/SearchError'
 import {Text} from '#/components/Typography'
 import {type Metrics, useAnalytics} from '#/analytics'
 import type * as bsky from '#/types/bsky'
+
+// TODO Replace this with error.shouldRetry() when available. -dsb
+const RETRYABLE_ERRORS = [408, 425, 429, 500, 502, 503, 504, 522, 524]
+function shouldRetry(error: unknown) {
+  return error instanceof XRPCError && RETRYABLE_ERRORS.includes(error.status)
+}
 
 let SearchResults = ({
   query,
@@ -402,7 +408,11 @@ let SearchScreenPostResults = ({
 
   return error ? (
     <EmptyState
-      messageText={l`We’re sorry, but your search could not be completed. Please try again in a few minutes.`}
+      messageText={
+        shouldRetry(error)
+          ? l`We’re sorry, but your search could not be completed. Please try again in a few minutes.`
+          : l`We’re sorry, but your search could not be completed.`
+      }
       error={cleanError(error)}
     />
   ) : (
@@ -539,7 +549,11 @@ let SearchScreenUserResults = ({
   if (error) {
     return (
       <EmptyState
-        messageText={l`We’re sorry, but your search could not be completed. Please try again in a few minutes.`}
+        messageText={
+          shouldRetry(error)
+            ? l`We’re sorry, but your search could not be completed. Please try again in a few minutes.`
+            : l`We’re sorry, but your search could not be completed.`
+        }
         error={error.toString()}
       />
     )


### PR DESCRIPTION
The new lex tooling provides this via `error.shouldRetry()`, but this addresses the issue in the interim.