### PR TITLE
Cache main bundle stats for PR checks

### DIFF
--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -19,8 +19,48 @@ concurrency:
 permissions: {}
 
 jobs:
+  # Populate this from main so every PR can restore the same trusted baseline.
+  webpack-analyzer-base:
+    runs-on: ubuntu-24.04
+    if: ${{ github.event_name == 'push' }}
+    permissions:
+      contents: read
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: 🔧 Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - name: ⬇️ Get base stats from cache
+        id: get-base-stats
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: stats-base.json
+          key: stats-base-main-${{ github.sha }}
+
+      - name: 🔦 Generate stats file for base commit
+        if: ${{ !steps.get-base-stats.outputs.cache-hit }}
+        run: |
+          pnpm install
+          pnpm intl:build
+          pnpm generate-webpack-stats-file
+          mv stats.json stats-base.json
+
+      - name: ⬆️ Save base stats to cache
+        if: ${{ !steps.get-base-stats.outputs.cache-hit }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: stats-base.json
+          key: stats-base-main-${{ github.sha }}
+
   webpack-analyzer:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request'}}
     permissions:
       contents: read
@@ -71,10 +111,11 @@ jobs:
 
       - name: ⬇️ Get base stats from cache
         id: get-base-stats
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        # Restore-only prevents PR-scoped fallback builds from creating caches.
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: stats-base.json
-          key: stats-base-${{ steps.base-commit.outputs.base-commit }}
+          key: stats-base-main-${{ steps.base-commit.outputs.base-commit }}
 
       - name: Restore to base commit
         if: ${{ !steps.get-base-stats.outputs.cache-hit }}

--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -118,8 +118,10 @@ jobs:
 
       - name: Restore to base commit
         if: ${{ !steps.get-base-stats.outputs.cache-hit }}
+        env:
+          BASE_COMMIT: ${{ steps.base-commit.outputs.base-commit }}
         run: |
-          git reset HEAD~
+          git reset "$BASE_COMMIT"
           git restore .
 
       - name: 🔦 Generate stats file from base commit

--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -41,7 +41,7 @@ jobs:
         id: get-base-stats
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: stats-base.json
+          path: stats.json
           key: stats-base-main-${{ github.sha }}
 
       - name: 🔦 Generate stats file for base commit
@@ -50,13 +50,12 @@ jobs:
           pnpm install
           pnpm intl:build
           pnpm generate-webpack-stats-file
-          mv stats.json stats-base.json
 
       - name: ⬆️ Save base stats to cache
         if: ${{ !steps.get-base-stats.outputs.cache-hit }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: stats-base.json
+          path: stats.json
           key: stats-base-main-${{ github.sha }}
 
   webpack-analyzer:
@@ -114,7 +113,7 @@ jobs:
         # Restore-only prevents PR-scoped fallback builds from creating caches.
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: stats-base.json
+          path: stats.json
           key: stats-base-main-${{ steps.base-commit.outputs.base-commit }}
 
       - name: Restore to base commit
@@ -129,13 +128,12 @@ jobs:
           pnpm install
           pnpm intl:build
           pnpm generate-webpack-stats-file
-          mv stats.json stats-base.json
 
       - name: ％ Get diff
         id: get-diff
         uses: NejcZdovc/bundle-size-diff@5321de41d2d62a7b0f4d6e60f59d1280a0034160 # v1.1.0
         with:
-          base_path: "stats-base.json"
+          base_path: "stats.json"
           pr_path: "../stats-new.json"
           excluded_assets: "(.+).chunk.js|(.+).js.map|(.+).json|(.+).png|(.+).svg|(.+).webp|(.+).jpg|(.+).ico"
 


### PR DESCRIPTION
## Summary

- generate and cache the bundle-size baseline on pushes to `main`
- make PR checks restore-only so they do not create isolated PR-scoped caches
- retain the local baseline build as a race-condition fallback
- run both bundle-size jobs on Ubuntu 24.04

## Why

GitHub scopes caches written by pull request workflows to that PR merge ref. As a result, PRs targeting the same `main` commit were each rebuilding the same baseline. A cache populated from the default branch is shared with PR workflows.

## Validation

- `actionlint -shellcheck "" .github/workflows/pull-request-commit.yml`
- `git diff --check`