### PR TITLE
Fix Android release asset upload

### DIFF
--- a/.github/workflows/build-submit-android.yml
+++ b/.github/workflows/build-submit-android.yml
@@ -265,6 +265,7 @@ jobs:
         if: ${{ steps.release-check.outputs.exists == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
           APK: Bluesky-${{ needs.build.outputs.package-version }}.apk
         run: |


### PR DESCRIPTION
## Summary

- provide explicit repository context to GitHub CLI in the checkout-free release attachment job
- allow the Android APK upload and release URL lookup to work without a local `.git` directory

## Testing

- `git diff --check`
- `pnpm exec prettier --check .github/workflows/build-submit-android.yml`
- verified `GH_REPO` resolves release `1.128.0` from a non-Git directory
