### PR TITLE
Add height constraint to full-height bottom sheets

### DIFF
--- a/modules/bottom-sheet/src/BottomSheetNativeComponent.tsx
+++ b/modules/bottom-sheet/src/BottomSheetNativeComponent.tsx
@@ -146,6 +146,7 @@ function BottomSheetNativeComponentInner({
   const insets = useSafeAreaInsets()
   const cornerRadius = rest.cornerRadius ?? 0
   const {height: screenHeight} = useWindowDimensions()
+  const isHeightConstrained = maxHeight != null || rest.fullHeight === true
 
   // sigh... on older Android versions, screenHeight does not include safe area insets
   // on newer Androids + iOS, it does. we need to find the inner bit + the bottom inset
@@ -182,7 +183,7 @@ function BottomSheetNativeComponentInner({
         ]}>
         <View
           onLayout={onLayout}
-          style={maxHeight == null ? undefined : {flex: 1}}>
+          style={isHeightConstrained ? {flex: 1} : undefined}>
           <BottomSheetPortalProvider>{children}</BottomSheetPortalProvider>
         </View>
       </View>

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -157,7 +157,8 @@ export function Outer({
     [open, close],
   )
 
-  const isHeightConstrained = nativeOptions?.maxHeight != null
+  const isHeightConstrained =
+    nativeOptions?.maxHeight != null || nativeOptions?.fullHeight === true
 
   const context = useMemo(
     () => ({


### PR DESCRIPTION
This notably caused an issue where the edit profile screen was not scrollable for long bios.

https://github.com/user-attachments/assets/2a9af83b-5006-4445-ab4f-303b0ac59c28

With `flex: 1`, the sheet becomes scrollable as intended.

https://github.com/user-attachments/assets/2df0e896-b604-42c9-a079-88efc3b0e0de