### PR TITLE
Fix isAppLabelers being counted towards max labeller counter

### DIFF
--- a/src/state/queries/labeler.ts
+++ b/src/state/queries/labeler.ts
@@ -3,6 +3,7 @@ import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {z} from 'zod'
 
 import {MAX_LABELERS} from '#/lib/constants'
+import {isAppLabeler} from '#/lib/moderation'
 import {GCTIME, STALE} from '#/state/queries'
 import {
   preferencesQueryKey,
@@ -140,7 +141,9 @@ export function useLabelerSubscriptionMutation() {
       }
 
       if (subscribe) {
-        const labelerCount = labelerDids.length - invalidLabelers.length
+        const labelerCount = labelerDids.filter(
+          d => !invalidLabelers.includes(d) && !isAppLabeler(d),
+        ).length
         if (labelerCount >= MAX_LABELERS) {
           throw new Error('MAX_LABELERS')
         }


### PR DESCRIPTION
Currently users can only subscribe to a max of 19 labellers

This is because the check used doesn't remove isAppLabeler declared labellers from the labelerCount like it does with invalidLabelers

So ``moderation.bsky.app`` will always reduce this maximum by 1, and any additional moderation authorities will reduce this number further 

Which seems unfair to the user when informing them of a 20 labeller limit but taking up those slots with entries outside of their control 🐙