### PR TITLE
Fix image menu in landscape orientation

### DIFF
--- a/src/components/Lightbox/chrome/ImageMenu.tsx
+++ b/src/components/Lightbox/chrome/ImageMenu.tsx
@@ -78,6 +78,7 @@ export function ImageMenu({onPressShare, onPressSave}: Props) {
         visible={isMounted}
         animationType="none"
         onRequestClose={close}
+        supportedOrientations={['portrait', 'landscape']}
         statusBarTranslucent>
         <Pressable
           accessibilityRole="button"


### PR DESCRIPTION
## Summary

- allow the lightbox image options modal to support landscape orientation
- prevent the modal from rotating back to portrait when opening share or save actions

## Test plan

- open an image in the lightbox and rotate the device to landscape
- open the three-dot menu and verify it stays in landscape
- verify Share image and Save image can be selected