### PR TITLE
Don't roll up account labels into additional post alerts

### DIFF
--- a/src/components/moderation/PostAlerts.tsx
+++ b/src/components/moderation/PostAlerts.tsx
@@ -54,7 +54,15 @@ export function PostAlerts({
   const isOwnPost = !!post && post.author.did === currentAccount?.did
   const allLabels: ComAtprotoLabelDefs.Label[] =
     isOwnPost && view === 'expanded'
-      ? [...(post.labels ?? []), ...(post.author.labels ?? [])]
+      ? [
+          ...(post.labels ?? []),
+          /*
+           * Account labels appear on Profile. We don't show them here unless the
+           * user's mod settings are configured such that the labels land in the
+           * modui handling.
+           */
+          // ...(post.author.labels ?? [])
+        ]
       : []
   /*
    * Labels that the moderation system already surfaces in this context -


### PR DESCRIPTION
From a viewer standpoint, the logic is pretty simple. If you've configured labels to "Show" or "Warn", they'll appear in `PostAlerts` regardless of if they apply to your post or your account as a whole

From an author standpoint, it's similar but subtle. If you've configured labels to "Show" or "Warn", they'll appear in `PostAlerts` regardless of if they apply to your post or your account as a whole. However, labels that you've configured to be hidden will show _if they're applied to the post itself_, because we want to give you a path to appeal them. Labels applied to your account that are not configured to be visible do not show, since that appeal path remains accessible on your profile.

The `+n` pill only shows if there are some labels configured to be visible on the post, and `n` others configured to be hidden, after the logic above is applied.