### PR TITLE
Fix image crop in quote posts, remove `PostEmbedViewContext.FeedEmbedRecordWithMedia`

### DIFF
--- a/src/components/Post/Embed/ImageEmbed.tsx
+++ b/src/components/Post/Embed/ImageEmbed.tsx
@@ -115,6 +115,7 @@ export function ImageEmbed({
           onPress(0, [singleContainerRef.current], [singleDimsRef.current])
         }
       }
+      console.log(rest.viewContext, 'rest.viewContext')
       return (
         <View style={[a.mt_sm, rest.style]}>
           <ImageContextMenu
@@ -127,9 +128,7 @@ export function ImageEmbed({
               crop={
                 rest.viewContext === PostEmbedViewContext.ThreadHighlighted
                   ? 'none'
-                  : rest.isWithinQuote
-                    ? 'square'
-                    : 'constrained'
+                  : 'constrained'
               }
               image={image}
               onContainerRef={ref => {

--- a/src/components/Post/Embed/types.ts
+++ b/src/components/Post/Embed/types.ts
@@ -4,7 +4,6 @@ import {type AppBskyFeedDefs, type ModerationDecision} from '@atproto/api'
 export enum PostEmbedViewContext {
   ThreadHighlighted = 'ThreadHighlighted',
   Feed = 'Feed',
-  FeedEmbedRecordWithMedia = 'FeedEmbedRecordWithMedia',
   ChatMessage = 'ChatMessage',
 }
 

--- a/src/components/images/ImageLayoutGrid.tsx
+++ b/src/components/images/ImageLayoutGrid.tsx
@@ -5,7 +5,7 @@ import {type AppBskyEmbedImages} from '@atproto/api'
 
 import {atoms as a, useBreakpoints} from '#/alf'
 import {type Dimensions} from '#/components/Lightbox/types'
-import {PostEmbedViewContext} from '#/components/Post/Embed/types'
+import {type PostEmbedViewContext} from '#/components/Post/Embed/types'
 import {GalleryItem} from './ImageLayoutGridItem'
 
 interface ImageLayoutGridProps {
@@ -28,9 +28,7 @@ export function ImageLayoutGrid({
   ...props
 }: ImageLayoutGridProps) {
   const {gtMobile} = useBreakpoints()
-  const isWithinQuote =
-    isWithinQuoteProp ??
-    props.viewContext === PostEmbedViewContext.FeedEmbedRecordWithMedia
+  const isWithinQuote = isWithinQuoteProp
   const gap = isWithinQuote ? (gtMobile ? a.gap_xs : a.gap_2xs) : a.gap_xs
 
   return (


### PR DESCRIPTION
Looks like we caught a stray in https://github.com/bluesky-social/social-app/pull/10688/changes#diff-e13f2da63a99cbc51a6d06dc0ccfe22d881080c8df849927de93e0cf97e81db8L90-L91. This just removes that unused property entirely, and falls back to how we would have displayed images beforehand.

Report:
<img width="1184" height="1724" alt="image" src="https://github.com/user-attachments/assets/1afe94df-98eb-406f-8237-04cd32f9323a" />
