### PR TITLE
Fix WelcomeModal sign in button keyboard activation

### DIFF
--- a/src/components/WelcomeModal.tsx
+++ b/src/components/WelcomeModal.tsx
@@ -188,6 +188,7 @@ export function WelcomeModal({control}: WelcomeModalProps) {
                     ]}>
                     <Trans>Already have an account?</Trans>{' '}
                     <Pressable
+                      onPress={onPressSignIn}
                       onPointerEnter={() => setSignInLinkHovered(true)}
                       onPointerLeave={() => setSignInLinkHovered(false)}
                       accessibilityRole="button"
@@ -201,8 +202,7 @@ export function WelcomeModal({control}: WelcomeModalProps) {
                             fontSize: undefined,
                           },
                           signInLinkHovered && a.underline,
-                        ]}
-                        onPress={onPressSignIn}>
+                        ]}>
                         <Trans>Sign in</Trans>
                       </Text>
                     </Pressable>


### PR DESCRIPTION
## Summary

In the welcome modal, the "Sign in" link can be focused with Tab but pressing Enter does nothing.

The root cause is that the `onPress` handler was placed on the inner `Text` component rather than on the focusable `Pressable`. The `Pressable` (with `accessibilityRole=\"button\"`) is what receives keyboard focus, but it had no `onPress`, while the `Text` that had `onPress` is not keyboard-activatable. Moving `onPress` to the `Pressable` fixes Enter-key activation.

Note: as described in the issue, the space key still does not activate the button after this fix. That appears to be an upstream React Native behavior (space is not mapped for `Pressable`), so it is out of scope here — this PR restores Enter-key activation.

Fixes #11214

## Test plan

1. Open the app as a guest so the welcome modal appears
2. Press Tab until the "Sign in" link is focused
3. Press Enter -> the sign in flow is triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)