### PR TITLE
Fix anchor post text getting clipped after rotating an expanded photo

### DIFF
--- a/src/screens/PostThread/components/ThreadItemAnchor.tsx
+++ b/src/screens/PostThread/components/ThreadItemAnchor.tsx
@@ -1,5 +1,5 @@
 import {memo, useMemo} from 'react'
-import {Text as RNText, View} from 'react-native'
+import {Text as RNText, useWindowDimensions, View} from 'react-native'
 import {
   AppBskyFeedDefs,
   AppBskyFeedPost,
@@ -181,6 +181,15 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
   const {currentAccount, hasSession} = useSession()
   const feedFeedback = useFeedFeedback(postSource?.feedSourceInfo, hasSession)
   const formatPostStatCount = useFormatPostStatCount()
+
+  /*
+   * The lightbox unlocks device orientation while open, which re-lays-out this
+   * screen behind it. Rotating to landscape makes the anchor text fit on fewer
+   * lines, and iOS caches that stale single-line measurement while the view is
+   * occluded, so it stays clipped after returning to portrait. Keying the text
+   * on the window width remounts it on rotation, forcing a fresh measurement.
+   */
+  const {width: windowWidth} = useWindowDimensions()
 
   const post = postShadow
   const record = item.value.post.record
@@ -394,6 +403,7 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
               />
               {richText?.text ? (
                 <RichText
+                  key={windowWidth}
                   enableTags
                   selectable
                   value={richText}


### PR DESCRIPTION
Fixes #11198

## What
When you expand a photo in a post thread, rotate to landscape, rotate back,
and dismiss, the anchor post's text stays clipped to a single line.

## Why
The lightbox unlocks device orientation while open, so the whole app (including
the thread behind it) re-lays-out in landscape. The anchor text fits on fewer
lines there, and iOS keeps that stale measurement while the view is occluded,
so it stays clipped after returning to portrait. This reproduces on both the
old and new architectures (the label is `fabric`, but the cause is the iOS text
measurement cache, not arch-specific).

## Fix
Key the anchor `RichText` on window width so it remounts on rotation, forcing a
fresh measurement. Only remounts on an actual width change, which normally never
happens outside the lightbox.

## Test plan
- [x] iOS: open the QT photo in the repro post, rotate, rotate back, dismiss;
      full two-line text remains.

https://github.com/user-attachments/assets/6eec2a8d-8460-4d7a-bfbf-e04114389647

