### PR TITLE
Squish separate imports from the same source in ActivityNotificationSettings

### DIFF
--- a/src/screens/Settings/NotificationSettings/ActivityNotificationSettings.tsx
+++ b/src/screens/Settings/NotificationSettings/ActivityNotificationSettings.tsx
@@ -1,8 +1,7 @@
 import {useCallback, useMemo} from 'react'
 import {type ListRenderItemInfo, Text as RNText, View} from 'react-native'
 import {type ModerationOpts} from '@atproto/api'
-import {useLingui} from '@lingui/react/macro'
-import {Trans} from '@lingui/react/macro'
+import {Trans, useLingui} from '@lingui/react/macro'
 
 import {createSanitizedDisplayName} from '#/lib/moderation/create-sanitized-display-name'
 import {


### PR DESCRIPTION
``Trans`` and ``useLingui`` are being imported separately from the same source

Don't notice any reason this should be the case and can't be a single line 🐙