### PR TITLE
Fix silently-frozen OTA fingerprint baseline with artifacts

### DIFF
--- a/.github/workflows/build-submit-android.yml
+++ b/.github/workflows/build-submit-android.yml
@@ -170,22 +170,6 @@ jobs:
           payload: |
             {"text": "Android ${{ inputs.profile || 'testflight-android' }} build submitted to Google Play!\n```Version Number: ${{ needs.build.outputs.package-version }}\nBuild Number: ${{ needs.build.outputs.version-code }}```"}
 
-      # Record the commit only after a successful submit, so a failed submit doesn't
-      # advance the "most recent testflight" marker.
-      - name: ⬇️ Restore Cache
-        id: get-base-commit
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: ${{ inputs.profile == 'testflight-android' }}
-        with:
-          path: most-recent-testflight-commit.txt
-          key: most-recent-testflight-commit
-
-      - name: ✏️ Write commit hash to cache
-        if: ${{ inputs.profile == 'testflight-android' }}
-        env:
-          GITHUB_SHA: ${{ github.sha }}
-        run: echo $GITHUB_SHA > most-recent-testflight-commit.txt
-
   # Runs in parallel with submit: the QA APK shouldn't be blocked by a Play submission failure.
   universalApk:
     name: Build universal APK

--- a/.github/workflows/build-submit-ios.yml
+++ b/.github/workflows/build-submit-ios.yml
@@ -254,22 +254,6 @@ jobs:
           payload: |
             {"text": "iOS production build for App Store submission is ready!\n```Artifact: Check TestFlight to know when it is available\nVersion Number: ${{ needs.build.outputs.package-version }}\nBuild Number: ${{ needs.build.outputs.build-number }}```"}
 
-      # Record the commit only after a successful submit, so a failed submit doesn't advance
-      # the baseline used for the next testflight build's changelog.
-      - name: ⬇️ Restore Cache
-        id: get-base-commit
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: ${{ inputs.profile == 'testflight' }}
-        with:
-          path: most-recent-testflight-commit.txt
-          key: most-recent-testflight-commit
-
-      - name: ✏️ Write commit hash to cache
-        env:
-          GITHUB_SHA: ${{ github.sha }}
-        if: ${{ inputs.profile == 'testflight' }}
-        run: echo $GITHUB_SHA > most-recent-testflight-commit.txt
-
   distribute:
     name: Assign build to TestFlight group
     # fastlane and jq ship preinstalled on the macOS runner image, and this step mostly idles

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -44,6 +44,9 @@ jobs:
       # A version bump forces a native build even if the fingerprint is unchanged
       changes-detected: ${{ steps.fingerprint.outputs.includes-changes ||
         steps.version.outputs.version-changed }}
+      # Native-autolinking hash of this commit. recordBaseline persists it as the
+      # next baseline once both native builds have shipped this native surface.
+      native-hash: ${{ steps.fingerprint.outputs.current-native-hash }}
 
     steps:
       - name: Check for EXPO_TOKEN
@@ -103,10 +106,15 @@ jobs:
 
       - name: 📷 Check fingerprint and install dependencies
         id: fingerprint
-        uses: bluesky-social/github-actions/fingerprint-native@b5556913e4aef3964cfd5936d0add3fc0d809bdb # v0.2.0
+        uses: bluesky-social/github-actions/fingerprint-native@c816fb4e387f8d53b8c81ec20b4cabdee8840d00 # v0.3.0
         with:
           profile: ${{ inputs.channel || 'testflight' }}
           previous-commit-tag: ${{ inputs.runtimeVersion }}
+          # Baseline is a repo variable advanced by the recordBaseline job after
+          # each successful native deploy, instead of a frozen actions/cache entry.
+          # Empty on the very first run, in which case the action falls back to the
+          # legacy cache baseline.
+          baseline-native-hash: ${{ vars.MOST_RECENT_TESTFLIGHT_NATIVE_HASH }}
 
       - name: 🔤 Compile translations
         uses: ./.github/actions/compile-i18n
@@ -195,20 +203,6 @@ jobs:
           RUNTIME_VERSION: ${{ inputs.runtimeVersion }}
           CHANNEL_NAME: ${{ inputs.channel || 'testflight' }}
 
-      - name: ⬇️ Restore Cache
-        id: get-base-commit
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: ${{ !steps.fingerprint.outputs.includes-changes &&
-          !steps.version.outputs.version-changed }}
-        with:
-          path: most-recent-testflight-commit.txt
-          key: most-recent-testflight-commit
-
-      - name: ✏️ Write commit hash to cache
-        if: ${{ !steps.fingerprint.outputs.includes-changes &&
-          !steps.version.outputs.version-changed }}
-        run: echo $GITHUB_SHA > most-recent-testflight-commit.txt
-
   buildIfNecessaryIOS:
     name: Build and Submit iOS
     needs: [bundleDeploy]
@@ -270,3 +264,47 @@ jobs:
       ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
       ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
       ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+
+  # Advance the fingerprint baseline only after BOTH native builds have shipped
+  # the new native surface. This replaces the old actions/cache baseline, which
+  # only advanced on cache eviction and so silently froze - freezing meant every
+  # fingerprint looked changed and OTA updates stopped deploying entirely.
+  #
+  # This runs only on the native-build path (both build jobs succeeded). On the
+  # OTA path those jobs are skipped, so this job is skipped too - correct, since
+  # an OTA update by definition leaves the native surface (and thus the hash)
+  # unchanged, so there is nothing to advance.
+  #
+  # Isolated as its own job so the token that can write repo variables lives
+  # nowhere else in the pipeline. The built-in GITHUB_TOKEN cannot manage Actions
+  # variables under any `permissions:` setting, so a PAT/App token with
+  # `variables: write` is required (EAS_BASELINE_VARIABLE_TOKEN).
+  recordBaseline:
+    name: Record fingerprint baseline
+    runs-on: ubuntu-latest
+    needs: [bundleDeploy, buildIfNecessaryIOS, buildIfNecessaryAndroid]
+    if: ${{ (inputs.channel || 'testflight') == 'testflight' &&
+      needs.buildIfNecessaryIOS.result == 'success' &&
+      needs.buildIfNecessaryAndroid.result == 'success' &&
+      github.repository == 'bluesky-social/social-app' }}
+    # No repo checkout or GITHUB_TOKEN work happens here; only the PAT is used.
+    permissions: {}
+    steps:
+      - name: ✏️ Advance baseline repo variable
+        env:
+          # PAT/App token with `variables: write`; see the job comment above
+          GH_TOKEN: ${{ secrets.EAS_BASELINE_VARIABLE_TOKEN }}
+          REPO: ${{ github.repository }}
+          NATIVE_HASH: ${{ needs.bundleDeploy.outputs.native-hash }}
+        run: |
+          # Fail loudly rather than writing an empty baseline. A blank value here
+          # would make the next run's fast-path comparison always mismatch and
+          # force perpetual native builds - the exact silent failure we're fixing.
+          if [ -z "$NATIVE_HASH" ]; then
+            echo "::error::bundleDeploy did not emit a native hash; refusing to write an empty baseline."
+            exit 1
+          fi
+          echo "Advancing MOST_RECENT_TESTFLIGHT_NATIVE_HASH to $NATIVE_HASH"
+          gh variable set MOST_RECENT_TESTFLIGHT_NATIVE_HASH \
+            --repo "$REPO" \
+            --body "$NATIVE_HASH"

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -108,10 +108,15 @@ jobs:
         if: ${{ (inputs.channel || 'testflight') == 'testflight' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          REPOSITORY_ID: ${{ github.repository_id }}
         run: |
           url=$(gh api \
             "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=testflight-native-fingerprint&per_page=100" \
-            --jq 'first(.artifacts[] | select(.expired == false)) | .archive_download_url' \
+            --jq "[.artifacts[] | select(
+              .expired == false and
+              .workflow_run.head_branch == \"main\" and
+              .workflow_run.head_repository_id == (\$ENV.REPOSITORY_ID | tonumber)
+            )] | max_by(.created_at) | .archive_download_url" \
             2>/dev/null || true)
 
           if [ -n "$url" ] && [ "$url" != "null" ]; then
@@ -131,7 +136,7 @@ jobs:
 
       - name: 📷 Check fingerprint and install dependencies
         id: fingerprint
-        uses: bluesky-social/github-actions/fingerprint-native@594f8b014440e76aa4e12cc0110d602fe3b5c348 # v0.3.0
+        uses: bluesky-social/github-actions/fingerprint-native@dbb7ac9d2fed7cafc8488ba707d315b3fb3ea431 # v0.3.0
         with:
           profile: ${{ inputs.channel || 'testflight' }}
           previous-commit-tag: ${{ inputs.runtimeVersion }}

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -44,9 +44,6 @@ jobs:
       # A version bump forces a native build even if the fingerprint is unchanged
       changes-detected: ${{ steps.fingerprint.outputs.includes-changes ||
         steps.version.outputs.version-changed }}
-      # Native-autolinking hash of this commit. recordBaseline persists it as the
-      # next baseline once both native builds have shipped this native surface.
-      native-hash: ${{ steps.fingerprint.outputs.current-native-hash }}
 
     steps:
       - name: Check for EXPO_TOKEN
@@ -106,7 +103,7 @@ jobs:
 
       - name: 📷 Check fingerprint and install dependencies
         id: fingerprint
-        uses: bluesky-social/github-actions/fingerprint-native@c816fb4e387f8d53b8c81ec20b4cabdee8840d00 # v0.3.0
+        uses: bluesky-social/github-actions/fingerprint-native@a2423573f4de195827afd4e88017d8a21260bff6 # v0.3.0
         with:
           profile: ${{ inputs.channel || 'testflight' }}
           previous-commit-tag: ${{ inputs.runtimeVersion }}
@@ -115,6 +112,25 @@ jobs:
           # Empty on the very first run, in which case the action falls back to the
           # legacy cache baseline.
           baseline-native-hash: ${{ vars.MOST_RECENT_TESTFLIGHT_NATIVE_HASH }}
+
+      # Hand the native hash to recordBaseline via an artifact rather than a job
+      # output: this workflow has documented (see buildIfNecessary* below) that
+      # GitHub suppresses md5-like hash values in job outputs as possible secrets,
+      # which would leave recordBaseline with an empty value. An artifact is not
+      # subject to that filtering. Written unconditionally so it exists on both
+      # the OTA and native-build paths.
+      - name: 💾 Save native hash
+        env:
+          NATIVE_HASH: ${{ steps.fingerprint.outputs.current-native-hash }}
+        run: printf '%s' "$NATIVE_HASH" > native-hash.txt
+
+      - name: 🚀 Upload native hash
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-hash-${{ github.run_id }}
+          path: native-hash.txt
+          retention-days: 1
+          if-no-files-found: error
 
       - name: 🔤 Compile translations
         uses: ./.github/actions/compile-i18n
@@ -287,21 +303,28 @@ jobs:
       needs.buildIfNecessaryIOS.result == 'success' &&
       needs.buildIfNecessaryAndroid.result == 'success' &&
       github.repository == 'bluesky-social/social-app' }}
-    # No repo checkout or GITHUB_TOKEN work happens here; only the PAT is used.
-    permissions: {}
+    # Only actions:read (to download the intra-run artifact) is needed from the
+    # built-in token; the repo-variable write uses the PAT, not GITHUB_TOKEN.
+    permissions:
+      actions: read
     steps:
+      - name: ⬇️ Download native hash
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: native-hash-${{ github.run_id }}
+
       - name: ✏️ Advance baseline repo variable
         env:
           # PAT/App token with `variables: write`; see the job comment above
           GH_TOKEN: ${{ secrets.EAS_BASELINE_VARIABLE_TOKEN }}
           REPO: ${{ github.repository }}
-          NATIVE_HASH: ${{ needs.bundleDeploy.outputs.native-hash }}
         run: |
+          NATIVE_HASH="$(cat native-hash.txt)"
           # Fail loudly rather than writing an empty baseline. A blank value here
           # would make the next run's fast-path comparison always mismatch and
           # force perpetual native builds - the exact silent failure we're fixing.
           if [ -z "$NATIVE_HASH" ]; then
-            echo "::error::bundleDeploy did not emit a native hash; refusing to write an empty baseline."
+            echo "::error::native hash artifact was empty; refusing to write an empty baseline."
             exit 1
           fi
           echo "Advancing MOST_RECENT_TESTFLIGHT_NATIVE_HASH to $NATIVE_HASH"

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -33,9 +33,11 @@ jobs:
     name: Bundle and Deploy EAS Update
     runs-on: ubuntu-latest
     # id-token: write lets this job mint an OIDC token to assume the denis
-    # publish role; contents: read is still needed for the checkout.
+    # publish role; actions: read loads the fingerprint baseline artifact;
+    # contents: read is still needed for the checkout.
     permissions:
       id-token: write
+      actions: read
       contents: read
     concurrency:
       group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-deploy
@@ -101,34 +103,51 @@ jobs:
           node-version-file: package.json
           cache: pnpm
 
+      - name: ⬇️ Load fingerprint baseline
+        id: baseline
+        if: ${{ (inputs.channel || 'testflight') == 'testflight' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          url=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=testflight-native-fingerprint&per_page=100" \
+            --jq 'first(.artifacts[] | select(.expired == false)) | .archive_download_url' \
+            2>/dev/null || true)
+
+          if [ -n "$url" ] && [ "$url" != "null" ]; then
+            mkdir baseline-artifact
+            if curl -sSL -H "Authorization: Bearer $GH_TOKEN" -o baseline.zip "$url" \
+              && unzip -q baseline.zip -d baseline-artifact; then
+              if jq -e '.sources | type == "array"' \
+                baseline-artifact/native-fingerprint.json >/dev/null; then
+                echo "path=baseline-artifact/native-fingerprint.json" >> "$GITHUB_OUTPUT"
+              else
+                echo "::warning::Ignoring invalid fingerprint baseline artifact."
+              fi
+            else
+              echo "::warning::Could not download fingerprint baseline artifact."
+            fi
+          fi
+
       - name: 📷 Check fingerprint and install dependencies
         id: fingerprint
-        uses: bluesky-social/github-actions/fingerprint-native@a2423573f4de195827afd4e88017d8a21260bff6 # v0.3.0
+        uses: bluesky-social/github-actions/fingerprint-native@21761a2827a7f9f0c9cb31ce973ac55ccab3b74f # v0.3.0
         with:
           profile: ${{ inputs.channel || 'testflight' }}
           previous-commit-tag: ${{ inputs.runtimeVersion }}
-          # Baseline is a repo variable advanced by the recordBaseline job after
-          # each successful native deploy, instead of a frozen actions/cache entry.
-          # Empty on the very first run, in which case the action falls back to the
-          # legacy cache baseline.
-          baseline-native-hash: ${{ vars.MOST_RECENT_TESTFLIGHT_NATIVE_HASH }}
+          # The recordBaseline job uploads this marker after a successful deploy;
+          # on the native path, that requires both builds to succeed. A missing
+          # marker forces native builds so they can seed the baseline safely.
+          baseline-fingerprint-path: ${{ steps.baseline.outputs.path }}
 
-      # Hand the native hash to recordBaseline via an artifact rather than a job
-      # output: this workflow has documented (see buildIfNecessary* below) that
-      # GitHub suppresses md5-like hash values in job outputs as possible secrets,
-      # which would leave recordBaseline with an empty value. An artifact is not
-      # subject to that filtering. Written unconditionally so it exists on both
-      # the OTA and native-build paths.
-      - name: 💾 Save native hash
-        env:
-          NATIVE_HASH: ${{ steps.fingerprint.outputs.current-native-hash }}
-        run: printf '%s' "$NATIVE_HASH" > native-hash.txt
-
-      - name: 🚀 Upload native hash
+      # Hand the full fingerprint to recordBaseline through a short-lived
+      # artifact. It is uploaded unconditionally but promoted to the persistent
+      # baseline only after both native builds succeed.
+      - name: 🚀 Upload native fingerprint
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: native-hash-${{ github.run_id }}
-          path: native-hash.txt
+          name: native-fingerprint-${{ github.run_id }}
+          path: ${{ steps.fingerprint.outputs.current-fingerprint-path }}
           retention-days: 1
           if-no-files-found: error
 
@@ -286,48 +305,42 @@ jobs:
   # only advanced on cache eviction and so silently froze - freezing meant every
   # fingerprint looked changed and OTA updates stopped deploying entirely.
   #
-  # This runs only on the native-build path (both build jobs succeeded). On the
-  # OTA path those jobs are skipped, so this job is skipped too - correct, since
-  # an OTA update by definition leaves the native surface (and thus the hash)
-  # unchanged, so there is nothing to advance.
+  # On the native-build path, this runs only after both builds succeed. A
+  # successful OTA deploy also records its fingerprint, refreshing the
+  # persistent marker's retention without changing the native baseline.
   #
-  # Isolated as its own job so the token that can write repo variables lives
-  # nowhere else in the pipeline. The built-in GITHUB_TOKEN cannot manage Actions
-  # variables under any `permissions:` setting, so a PAT/App token with
-  # `variables: write` is required (EAS_BASELINE_VARIABLE_TOKEN).
+  # The persistent artifact replaces the old actions/cache marker without
+  # requiring a PAT or mutable repository variable. Each successful deploy adds
+  # an immutable marker; the next run reads the newest non-expired one using the
+  # built-in GITHUB_TOKEN.
   recordBaseline:
     name: Record fingerprint baseline
     runs-on: ubuntu-latest
     needs: [bundleDeploy, buildIfNecessaryIOS, buildIfNecessaryAndroid]
-    if: ${{ (inputs.channel || 'testflight') == 'testflight' &&
-      needs.buildIfNecessaryIOS.result == 'success' &&
-      needs.buildIfNecessaryAndroid.result == 'success' &&
+    if: ${{ always() &&
+      (inputs.channel || 'testflight') == 'testflight' &&
+      needs.bundleDeploy.result == 'success' &&
+      (needs.bundleDeploy.outputs.changes-detected != 'true' ||
+      (needs.buildIfNecessaryIOS.result == 'success' &&
+      needs.buildIfNecessaryAndroid.result == 'success')) &&
       github.repository == 'bluesky-social/social-app' }}
-    # Only actions:read (to download the intra-run artifact) is needed from the
-    # built-in token; the repo-variable write uses the PAT, not GITHUB_TOKEN.
     permissions:
       actions: read
     steps:
-      - name: ⬇️ Download native hash
+      - name: ⬇️ Download native fingerprint
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: native-hash-${{ github.run_id }}
+          name: native-fingerprint-${{ github.run_id }}
 
-      - name: ✏️ Advance baseline repo variable
-        env:
-          # PAT/App token with `variables: write`; see the job comment above
-          GH_TOKEN: ${{ secrets.EAS_BASELINE_VARIABLE_TOKEN }}
-          REPO: ${{ github.repository }}
-        run: |
-          NATIVE_HASH="$(cat native-hash.txt)"
-          # Fail loudly rather than writing an empty baseline. A blank value here
-          # would make the next run's fast-path comparison always mismatch and
-          # force perpetual native builds - the exact silent failure we're fixing.
-          if [ -z "$NATIVE_HASH" ]; then
-            echo "::error::native hash artifact was empty; refusing to write an empty baseline."
-            exit 1
-          fi
-          echo "Advancing MOST_RECENT_TESTFLIGHT_NATIVE_HASH to $NATIVE_HASH"
-          gh variable set MOST_RECENT_TESTFLIGHT_NATIVE_HASH \
-            --repo "$REPO" \
-            --body "$NATIVE_HASH"
+      - name: 🧐 Validate native fingerprint
+        run: >
+          jq -e '.sources | type == "array"' native-fingerprint.json >/dev/null ||
+          (echo "::error::native fingerprint artifact was invalid; refusing to record it as the baseline." && exit 1)
+
+      - name: 🚀 Record fingerprint baseline
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: testflight-native-fingerprint
+          path: native-fingerprint.json
+          retention-days: 90
+          if-no-files-found: error

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: 📷 Check fingerprint and install dependencies
         id: fingerprint
-        uses: bluesky-social/github-actions/fingerprint-native@21761a2827a7f9f0c9cb31ce973ac55ccab3b74f # v0.3.0
+        uses: bluesky-social/github-actions/fingerprint-native@594f8b014440e76aa4e12cc0110d602fe3b5c348 # v0.3.0
         with:
           profile: ${{ inputs.channel || 'testflight' }}
           previous-commit-tag: ${{ inputs.runtimeVersion }}

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: 📷 Check fingerprint and install dependencies
         id: fingerprint
-        uses: bluesky-social/github-actions/fingerprint-native@dbb7ac9d2fed7cafc8488ba707d315b3fb3ea431 # v0.3.0
+        uses: bluesky-social/github-actions/fingerprint-native@8d9bd6ef54f21d219d1b4c1e547f010a80cc3f19 # v0.3.0
         with:
           profile: ${{ inputs.channel || 'testflight' }}
           previous-commit-tag: ${{ inputs.runtimeVersion }}

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: 📷 Check fingerprint and install dependencies
         id: fingerprint
-        uses: bluesky-social/github-actions/fingerprint-native@8d9bd6ef54f21d219d1b4c1e547f010a80cc3f19 # v0.3.0
+        uses: bluesky-social/github-actions/fingerprint-native@abc6a46eb4badf243f55bfd7d6cec42722456300 # v0.3.0
         with:
           profile: ${{ inputs.channel || 'testflight' }}
           previous-commit-tag: ${{ inputs.runtimeVersion }}


### PR DESCRIPTION
## The bug

The "Bundle and Deploy EAS Update" push-to-`main` pipeline stopped shipping OTA updates around **June 15 2026**. Every push since has skipped the OTA deploy and run full native builds instead.

**Root cause:** the pipeline decided OTA-vs-native-rebuild by diffing the current fingerprint against a baseline commit whose SHA lived in an `actions/cache` entry keyed `most-recent-testflight-commit`. But `actions/cache` only saves on a miss, while the fingerprint action restored that entry on every run and kept it alive. Once cache eviction stopped, the baseline froze, every fingerprint showed native changes, and OTA deploys silently stopped.

## The fix

Persist the last successfully deployed **full Expo fingerprint** as a GitHub Actions artifact instead of relying on cache replacement or a mutable repository variable.

- `fingerprint-native` v0.3.0 accepts a `baseline-fingerprint-path` and writes the current fingerprint to `current-fingerprint-path`. It diffs the current fingerprint directly against the artifact and skips checking out and reinstalling the baseline commit.
- `bundleDeploy` loads the newest non-expired `testflight-native-fingerprint` artifact produced by this repository's `main` branch, using the built-in `GITHUB_TOKEN` with `actions: read`.
- The current fingerprint crosses jobs through a short-lived run-specific artifact. `recordBaseline` promotes it to a 90-day persistent marker after a successful OTA deploy, or after **both** native builds succeed.
- Successful OTA deploys refresh the marker's retention. If the marker is missing, expired, invalid, or temporarily unavailable, the action fails safe by forcing native builds; their successful completion seeds a new marker.
- The dead cache write steps are removed from the reusable iOS and Android build workflows.

This needs no PAT, repository secret, repository variable, or manual seed. The first run without an artifact performs native builds and establishes the baseline automatically.

## Required before merge

Merge bluesky-social/github-actions#18 first, then re-pin this workflow's fingerprint step from the PR-head SHA to the squashed merge SHA.
