### PR TITLE
Tweak loading state for block dialog

### DIFF
--- a/src/components/moderation/BlockDialog.tsx
+++ b/src/components/moderation/BlockDialog.tsx
@@ -181,6 +181,7 @@ function BlockDialogInner({
   const footer = (
     <View style={[a.w_full, a.gap_sm, a.justify_end]}>
       <Button
+        disabled={isLoading}
         color={profile.viewer?.blocking ? undefined : 'negative'}
         size="large"
         label={profile.viewer?.blocking ? l`Unblock` : l`Block`}
@@ -192,6 +193,7 @@ function BlockDialogInner({
             <Trans>Block</Trans>
           )}
         </ButtonText>
+        {isLoading ? <ButtonIcon icon={Loader} /> : null}
       </Button>
       <Button
         color="secondary"
@@ -211,11 +213,6 @@ function BlockDialogInner({
         label={profile.viewer?.blocking ? l`Unblock` : l`Block`}
         style={[web([{maxWidth: 420}])]}>
         {listHeader}
-        {isLoading ? (
-          <View style={[a.pb_2xl, a.align_center, a.justify_center]}>
-            <Loader size="xl" />
-          </View>
-        ) : null}
         {footer}
       </Dialog.ScrollableInner>
     )


### PR DESCRIPTION
Avoids a layout jump after loading shared conversations.

https://github.com/user-attachments/assets/786d6510-d64e-469b-895a-8932bf35d21c