### PR TITLE
Fix scroll forwarder export on web

### DIFF
--- a/modules/react-native-scroll-forwarder/src/ScrollForwarderView.tsx
+++ b/modules/react-native-scroll-forwarder/src/ScrollForwarderView.tsx
@@ -1,4 +1,4 @@
-import {type NativeProps} from './ScrollForwarderViewNativeComponent'
+import {type NativeProps} from './types'
 
 export function ScrollForwarderView({children}: NativeProps) {
   return children

--- a/modules/react-native-scroll-forwarder/src/index.tsx
+++ b/modules/react-native-scroll-forwarder/src/index.tsx
@@ -1,2 +1,2 @@
 export {ScrollForwarderView} from './ScrollForwarderView'
-export * from './ScrollForwarderViewNativeComponent'
+export type {NativeProps} from './types'

--- a/modules/react-native-scroll-forwarder/src/types.ts
+++ b/modules/react-native-scroll-forwarder/src/types.ts
@@ -1,0 +1,9 @@
+import {type CodegenTypes, type ViewProps} from 'react-native'
+
+type OnRefreshEvent = {}
+
+export interface NativeProps extends ViewProps {
+  scrollViewTag: CodegenTypes.Int32 | null
+  refreshing?: boolean
+  onRefresh?: CodegenTypes.BubblingEventHandler<OnRefreshEvent>
+}


### PR DESCRIPTION
## Summary

Stop re-exporting the scroll forwarder's native codegen component from the package entry point. The re-export caused webpack to evaluate React Native's native implementation on web, leading to development compilation failures and an optimized-bundle startup crash in `PixelRatio`.

The platform-specific `ScrollForwarderView.ios.tsx` continues to import and register the native component directly.

## Test plan

- `pnpm exec oxlint --quiet modules/react-native-scroll-forwarder/src/index.tsx`
- `pnpm run typecheck:web`
- `pnpm run build-web` (completes; the `codegenNativeComponent` warning is gone)