### PR TITLE
Stub RN codegen native component on web

### DIFF
--- a/src/lib/web-shims/codegenNativeComponent.js
+++ b/src/lib/web-shims/codegenNativeComponent.js
@@ -1,0 +1,17 @@
+/*
+ * Web stub for `react-native/Libraries/Utilities/codegenNativeComponent`.
+ *
+ * Deep `react-native/*` imports bypass the `react-native$ -> react-native-web`
+ * alias and drag RN core into the web bundle, where its platform-extension
+ * modules (e.g. Libraries/Utilities/Platform.js) resolve to themselves and
+ * throw a TDZ error at startup. Packages that import codegen specs
+ * unconditionally (react-native-uitextview) guard the native component behind
+ * a `Platform.OS === 'ios'` check, so nothing ever renders this on web.
+ */
+module.exports = function codegenNativeComponent(componentName) {
+  return function UnimplementedNativeComponent() {
+    throw new Error(
+      `Native component "${componentName}" was rendered on web. It has no web implementation.`,
+    )
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,6 +62,16 @@ module.exports = async function (env, argv) {
   }
   config = withAlias(config, {
     'react-native$': 'react-native-web',
+    /*
+     * Codegen specs import this via a deep `react-native/*` path, which skips
+     * the exact-match alias above and pulls RN core into the web bundle. RN
+     * core's platform-extension modules have no `.web` variant, so they
+     * resolve to themselves and blow up with a TDZ error on startup.
+     */
+    'react-native/Libraries/Utilities/codegenNativeComponent$': path.join(
+      __dirname,
+      'src/lib/web-shims/codegenNativeComponent.js',
+    ),
     'react-native-webview': 'react-native-web-webview',
     'react-native-gesture-handler': false, // RNGH should not be used on web, so let's cause a build error if it sneaks in
     '@sentry-internal/replay': false, // not used, ~300kb of dead weight


### PR DESCRIPTION
Web is broken on prod: the app hangs on the splash screen and the console shows
`Uncaught ReferenceError: Cannot access 'r' before initialization`. Dev fails to
compile entirely, trying to resolve `react-devtools-core` from RN's
`setUpReactDevTools`.

## Cause

`react-native-uitextview` 2.2.0 (bumped from 1.4.0 in #10980) imports its codegen
specs via a deep path:

```js
import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent'
```

Deep `react-native/*` requests skip the `'react-native$': 'react-native-web'`
alias, which is exact-match only, so RN core lands in the web bundle. RN core's
`Libraries/Utilities/Platform.js` is a back-compat shim that does
`import Platform from './Platform'` and relies on platform-extension resolution.
There is no `.web` variant, so it resolves to itself, and the circular default
export throws at module init before the app boots.

Version 1.4.0 imported `requireNativeComponent` from `'react-native'`, which the
alias caught and pointed at react-native-web, which is why this only started now.

Instrumenting the webpack module graph shows these are the only two edges from
app dependencies into RN core:

```
react-native-uitextview/lib/module/RNUITextViewChildNativeComponent.ts -> react-native/Libraries/Utilities/codegenNativeComponent.js
react-native-uitextview/lib/module/RNUITextViewNativeComponent.ts      -> react-native/Libraries/Utilities/codegenNativeComponent.js
```

## Fix

Alias `react-native/Libraries/Utilities/codegenNativeComponent` to a web stub.
The packages that import codegen specs unconditionally already guard the native
component behind `Platform.OS === 'ios'`, so nothing renders it on web; the stub
throws if anything ever does.

This also covers any other dependency that reaches RN core the same way.

## Follow-up

The durable fix belongs in `react-native-uitextview`: ship `.web` variants of the
native component modules, or import `codegenNativeComponent` from `'react-native'`.
Once that is published and bumped here, this alias can be dropped.

## Test plan

- [ ] `pnpm web` compiles and the app boots past the splash screen
- [ ] `pnpm build-web` output loads with no console errors
- [ ] Text rendering unchanged on iOS/Android (no native code paths touched)
