### PR TITLE
Add meta tags for AT URIs

### DIFF
--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -765,6 +765,8 @@ func (srv *Server) WebStarterPack(c echo.Context) error {
 		return c.Render(http.StatusOK, "starterpack.html", data)
 	}
 	data["title"] = rec.Name
+	data["starterPackURI"] = spv.StarterPack.Uri;
+	
 	if srv.cfg.ogcardHost != "" {
 		data["imgThumbUrl"] = fmt.Sprintf("%s/start/%s/%s", srv.cfg.ogcardHost, identifier, rkey)
 	}

--- a/bskyweb/templates/feed.html
+++ b/bskyweb/templates/feed.html
@@ -38,7 +38,7 @@
   <meta name="twitter:label1" content="Created by">
   <meta name="twitter:value1" content="@{{ feedView.Creator.Handle }}">
 
-  <link rel="alternate" href="{{ feedView.Uri }}" />
+  <meta name="at:canonical" content="{{ feedView.Uri }}" />
 {% endif -%}
 {%- endblock %}
 

--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -68,7 +68,7 @@
   {% endif -%}
   <meta property="article:published_time" content="{{ postView.IndexedAt }}">
   <link rel="alternate" type="application/json+oembed" href="https://embed.bsky.app/oembed?format=json&url={{ postView.Uri | urlencode }}" />
-  <link rel="alternate" href="{{ postView.Uri }}" />
+  <meta name="at:canonical" content="{{ postView.Uri }}" />
   {%- if postJSONLD %}
   <script type="application/ld+json">{{ postJSONLD|safe }}</script>
   {% endif -%}

--- a/bskyweb/templates/profile.html
+++ b/bskyweb/templates/profile.html
@@ -29,7 +29,7 @@
   <meta property="og:title" content="{{ profileView.Handle }}">
   {% endif -%}
 
-  <link rel="alternate" href="at://{{ profileView.Did }}/app.bsky.actor.profile/self" />
+  <meta name="at:canonical" content="at://{{ profileView.Did }}/app.bsky.actor.profile/self" />
 
   <meta name="twitter:label1" content="Account DID">
   <meta name="twitter:value1" content="{{ profileView.Did }}">

--- a/bskyweb/templates/starterpack.html
+++ b/bskyweb/templates/starterpack.html
@@ -23,4 +23,7 @@
   <meta name="description" content="Join the conversation" />
   <meta name="og:description" content="Join the conversation" />
   <meta name="twitter:description" content="Join the conversation" />
+  {%- if starterPackURI %}
+  <meta name="at:canonical" content="{{ starterPackURI }}" />
+  {% endif -%}
 {%- endblock %}


### PR DESCRIPTION
This PR implements the [community proposal](https://tangled.org/chrisshank.com/at-tags/) for mapping web pages back AT URIs. It overrides #6033, since it's not *technically* valid HTML. If there are worries that this is a breaking change, we can keep `<link>` for the time being.