### PR TITLE
Fix scroll forwarder web entrypoint

### DIFF
--- a/modules/react-native-scroll-forwarder/src/index.web.tsx
+++ b/modules/react-native-scroll-forwarder/src/index.web.tsx
@@ -1,0 +1,1 @@
+export {ScrollForwarderView} from './ScrollForwarderView'

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {StyleSheet} from 'react-native'
 import {SafeAreaView} from 'react-native-safe-area-context'
-import {ScrollForwarderView} from 'react-native-scroll-forwarder/src'
+import {ScrollForwarderView} from 'react-native-scroll-forwarder'
 import {
   type AppBskyActorDefs,
   moderateProfile,


### PR DESCRIPTION
## Summary

- add a web entrypoint for react-native-scroll-forwarder that avoids exporting the native codegen spec
- import the package through its public entrypoint so web platform resolution applies

## Test plan

- pnpm run typecheck:web
- pnpm exec oxlint --quiet modules/react-native-scroll-forwarder/src
- pnpm run build-web