### PR TITLE
Migrate `useScrollViewOffset` to `useScrollOffset`

### DIFF
--- a/src/components/DraggableList/index.tsx
+++ b/src/components/DraggableList/index.tsx
@@ -42,7 +42,7 @@ interface SortableListProps<T> {
   itemHeight: number
   /** Ref to the parent Animated.ScrollView for auto-scroll. */
   scrollRef?: AnimatedRef<Animated.ScrollView>
-  /** Scroll offset shared value from useScrollViewOffset. */
+  /** Scroll offset shared value from useScrollOffset. */
   scrollOffset?: SharedValue<number>
 }
 

--- a/src/components/DraggableList/index.web.tsx
+++ b/src/components/DraggableList/index.web.tsx
@@ -22,7 +22,7 @@ interface SortableListProps<T> {
   itemHeight: number
   /** Ref to the parent Animated.ScrollView for auto-scroll. Ignored on web. */
   scrollRef?: AnimatedRef<Animated.ScrollView>
-  /** Scroll offset shared value from useScrollViewOffset. Ignored on web. */
+  /** Scroll offset shared value from useScrollOffset. Ignored on web. */
   scrollOffset?: SharedValue<number>
 }
 

--- a/src/screens/SavedFeeds.tsx
+++ b/src/screens/SavedFeeds.tsx
@@ -1,7 +1,7 @@
 import {useState} from 'react'
 import {View} from 'react-native'
 import type Animated from 'react-native-reanimated'
-import {useAnimatedRef, useScrollViewOffset} from 'react-native-reanimated'
+import {useAnimatedRef, useScrollOffset} from 'react-native-reanimated'
 import {type AppBskyActorDefs} from '@atproto/api'
 import {TID} from '@atproto/common-web'
 import {msg} from '@lingui/core/macro'
@@ -69,7 +69,7 @@ function SavedFeedsInner({
     useOverwriteSavedFeedsMutation()
   const navigation = useNavigation<NavigationProp>()
   const scrollRef = useAnimatedRef<Animated.ScrollView>()
-  const scrollOffset = useScrollViewOffset(scrollRef)
+  const scrollOffset = useScrollOffset(scrollRef)
 
   /*
    * Use optimistic data if exists and no error, otherwise fallback to remote


### PR DESCRIPTION
This PR migrates all usages of `useScrollViewOffset` from `react-native-reanimated` to `useScrollOffset`.

* [Migrating from Reanimated 3.x to 4.x](https://docs.swmansion.com/react-native-reanimated/docs/guides/migration-from-3.x/#renamed-usescrollviewoffset-to-usescrolloffset)