### PR TITLE
Tweak appearance of trending topics

### DIFF
--- a/src/components/interstitials/FeedTrendingTopics.tsx
+++ b/src/components/interstitials/FeedTrendingTopics.tsx
@@ -1,6 +1,5 @@
 import {useMemo} from 'react'
 import {Pressable, View} from 'react-native'
-import {LinearGradient} from 'expo-linear-gradient'
 import {type AppBskyUnspeccedDefs, moderateProfile} from '@atproto/api'
 import {plural} from '@lingui/core/macro'
 import {Trans, useLingui} from '@lingui/react/macro'
@@ -51,16 +50,6 @@ function Inner() {
 
   const shadowColor = alpha(t.palette.primary_100, 0.5)
 
-  const gradient = {
-    values: [
-      [0, t.atoms.bg.backgroundColor],
-      [0.1, t.palette.primary_25],
-      [0.9, t.palette.primary_25],
-      [1, t.atoms.bg.backgroundColor],
-    ],
-    hover_value: t.palette.white,
-  }
-
   if (error || noTopics) {
     return null
   }
@@ -75,13 +64,6 @@ function Inner() {
         a.border_t,
         t.atoms.border_contrast_low,
       ]}>
-      <LinearGradient
-        colors={gradient.values.map(c => c[1]) as [string, string, ...string[]]}
-        locations={
-          gradient.values.map(c => c[0]) as [number, number, ...number[]]
-        }
-        style={[a.absolute, a.inset_0]}
-      />
       <View
         style={[
           a.relative,
@@ -94,23 +76,27 @@ function Inner() {
         ]}>
         <View style={[a.flex_row, a.align_center, a.justify_between, a.gap_xs]}>
           <TrendingIcon width={18} />
-          <Text
-            style={[a.text_md, a.font_medium, a.leading_snug]}
-            numberOfLines={1}>
+          <Text style={[a.text_md, a.font_medium]} numberOfLines={1}>
             <Trans>Trending</Trans>
           </Text>
         </View>
         <Link label={l`See more trending topics`} to="/search">
-          <Text
-            style={[
-              a.text_sm,
-              a.font_medium,
-              a.leading_snug,
-              t.atoms.text_contrast_high,
-            ]}
-            numberOfLines={1}>
-            <Trans>See more</Trans>
-          </Text>
+          {({hovered, pressed}) => (
+            <Text
+              style={[
+                a.text_sm,
+                a.font_medium,
+                {
+                  color:
+                    hovered || pressed
+                      ? t.palette.contrast_800
+                      : t.palette.contrast_500,
+                },
+              ]}
+              numberOfLines={1}>
+              <Trans>See more</Trans>
+            </Text>
+          )}
         </Link>
       </View>
       <View


### PR DESCRIPTION
* Removes linear gradient
* Reduces contrast of “See more” link and adds interactive state

<img width="402" height="294" alt="trending" src="https://github.com/user-attachments/assets/2f3188d6-4ad3-4fb7-a329-cd6b36fbe160" />
