### PR TITLE
Fix issue where form controls appear above sticky headers

### DIFF
--- a/src/components/forms/TextField.tsx
+++ b/src/components/forms/TextField.tsx
@@ -95,6 +95,8 @@ export function Root({children, isInvalid = false, style}: RootProps) {
           a.relative,
           a.w_full,
           a.px_md,
+          // Contain the input's z-index so it cannot paint over nearby overlays.
+          {zIndex: 0},
           style,
         ]}
         {...web({


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="1206" height="2622" alt="before" src="https://github.com/user-attachments/assets/c435dd43-ee51-4f0a-a5a3-41d39071ed1e" /> | <img width="1206" height="2622" alt="after" src="https://github.com/user-attachments/assets/6825898b-26e5-48ae-923f-dbda432c6e8f" /> |