### PR TITLE
Fix native signup captcha interactions

### DIFF
--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useReducer, useState} from 'react'
+import {type PropsWithChildren, useEffect, useReducer, useState} from 'react'
 import {AppState, type AppStateStatus, View} from 'react-native'
 import ReactNativeDeviceAttest from 'react-native-device-attest'
 import {KeyboardAvoidingView} from 'react-native-keyboard-controller'
@@ -132,10 +132,8 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
   return (
     <Animated.View exiting={native(FadeIn.duration(90))} style={a.flex_1}>
       <SignupContext.Provider value={{state, dispatch}}>
-        <KeyboardAvoidingView
-          behavior="padding"
-          style={a.flex_1}
-          automaticOffset>
+        <SignupKeyboardAvoidingView
+          enabled={state.activeStep !== SignupStep.CAPTCHA}>
           <LoggedOutLayout
             leadin=""
             title={l`Create account`}
@@ -260,8 +258,23 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
               </LayoutAnimationConfig>
             </View>
           </LoggedOutLayout>
-        </KeyboardAvoidingView>
+        </SignupKeyboardAvoidingView>
       </SignupContext.Provider>
     </Animated.View>
+  )
+}
+
+function SignupKeyboardAvoidingView({
+  children,
+  enabled,
+}: PropsWithChildren<{enabled: boolean}>) {
+  if (!enabled) {
+    return <View style={a.flex_1}>{children}</View>
+  }
+
+  return (
+    <KeyboardAvoidingView behavior="padding" style={a.flex_1} automaticOffset>
+      {children}
+    </KeyboardAvoidingView>
   )
 }


### PR DESCRIPTION
The signup flow was recently wrapped in `KeyboardAvoidingView` from `react-native-keyboard-controller`. On the captcha step, that animated native wrapper prevents the embedded WebView and the surrounding controls from receiving touches on iOS and Android.

Use a plain `View` for the captcha step while retaining keyboard avoidance for the account and handle form steps.