### PR TITLE
Show app build numbers in CI summaries

### DIFF
--- a/.github/workflows/build-submit-android.yml
+++ b/.github/workflows/build-submit-android.yml
@@ -132,6 +132,16 @@ jobs:
           if-no-files-found: error
           path: build.aab
 
+      - name: 📝 Write build summary
+        env:
+          REMOTE_VERSION_CODE: ${{ steps.get-build-info.outputs.BSKY_ANDROID_VERSION_CODE }}
+        run: |
+          {
+            echo "### Android build number"
+            echo
+            echo "\`$REMOTE_VERSION_CODE\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   submit:
     name: Submit to Google Play
     runs-on: ubuntu-latest

--- a/.github/workflows/build-submit-ios.yml
+++ b/.github/workflows/build-submit-ios.yml
@@ -211,6 +211,16 @@ jobs:
             ${{ env.BUILD_DIR }}/Bluesky.ipa
             ${{ env.BUILD_DIR }}/Bluesky.app.dSYM.zip
 
+      - name: 📝 Write build summary
+        env:
+          REMOTE_BUILD_NUMBER: ${{ steps.get-build-info.outputs.BSKY_IOS_BUILD_NUMBER }}
+        run: |
+          {
+            echo "### iOS build number"
+            echo
+            echo "\`$REMOTE_BUILD_NUMBER\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   submit:
     name: Submit iOS
     # Submission and dSYM upload are I/O bound and don't need the xlarge builder.


### PR DESCRIPTION
Adds GitHub Actions job summaries for the iOS and Android build jobs, showing the remote EAS build counter fetched during the build.\n\n## Test plan\n\n- Confirmed both workflow files pass Prettier\n- Confirmed the diff passes git diff --check