### PR TITLE
Fix verification flow for new accounts

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -591,11 +591,6 @@
       "count": 2
     }
   },
-  "src/components/intents/VerifyEmailIntentDialog.tsx": {
-    "typescript/no-misused-promises": {
-      "count": 1
-    }
-  },
   "src/components/interstitials/TrendingVideos.tsx": {
     "typescript/no-floating-promises": {
       "count": 1
@@ -689,11 +684,6 @@
     },
     "typescript/no-unsafe-member-access": {
       "count": 1
-    }
-  },
-  "src/lib/hooks/useIntentHandler.ts": {
-    "typescript/no-floating-promises": {
-      "count": 2
     }
   },
   "src/lib/hooks/useNonReactiveCallback.ts": {

--- a/src/components/intents/IntentDialogs.tsx
+++ b/src/components/intents/IntentDialogs.tsx
@@ -11,6 +11,7 @@ import {usePrefetchJoinLinkPreviews} from '#/state/queries/join-links'
 import {useSession} from '#/state/session'
 import {
   useActiveGroupChatJoinRequest,
+  useActiveVerifyEmail,
   useSetActiveLanding,
 } from '#/state/shell/landing'
 import * as Dialog from '#/components/Dialog'
@@ -43,9 +44,17 @@ export function Provider({children}: {children: React.ReactNode}) {
 
   const {hasSession} = useSession()
   const groupChatLanding = useActiveGroupChatJoinRequest()
+  const verifyEmailLanding = useActiveVerifyEmail()
   const setActiveLanding = useSetActiveLanding()
   const prefetchJoinLinkPreviews = usePrefetchJoinLinkPreviews()
   const landingHandledRef = useRef(false)
+
+  useEffect(() => {
+    if (!hasSession || !verifyEmailLanding) return
+    const code = verifyEmailLanding.code
+    setActiveLanding(undefined)
+    setVerifyEmailState({code})
+  }, [hasSession, verifyEmailLanding, setActiveLanding, setVerifyEmailState])
 
   useEffect(() => {
     if (hasSession && groupChatLanding && !landingHandledRef.current) {

--- a/src/components/intents/VerifyEmailIntentDialog.tsx
+++ b/src/components/intents/VerifyEmailIntentDialog.tsx
@@ -1,8 +1,6 @@
-import {useEffect, useState} from 'react'
+import {useEffect, useRef, useState} from 'react'
 import {View} from 'react-native'
-import {msg} from '@lingui/core/macro'
-import {useLingui} from '@lingui/react'
-import {Trans} from '@lingui/react/macro'
+import {Trans, useLingui} from '@lingui/react/macro'
 
 import {useAgent, useSession} from '#/state/session'
 import {atoms as a, useBreakpoints, useTheme} from '#/alf'
@@ -18,10 +16,22 @@ import {Text} from '#/components/Typography'
 import {IS_NATIVE} from '#/env'
 
 export function VerifyEmailIntentDialog() {
-  const {verifyEmailDialogControl: control} = useIntentDialogs()
+  const {
+    verifyEmailDialogControl: control,
+    verifyEmailState: state,
+    setVerifyEmailState,
+  } = useIntentDialogs()
+
+  useEffect(() => {
+    if (state?.code) {
+      control.open()
+    }
+  }, [state?.code, control])
 
   return (
-    <Dialog.Outer control={control}>
+    <Dialog.Outer
+      control={control}
+      onClose={() => setVerifyEmailState(undefined)}>
       <Dialog.Handle />
       <Inner control={control} />
     </Dialog.Outer>
@@ -31,7 +41,7 @@ export function VerifyEmailIntentDialog() {
 function Inner({}: {control: DialogControlProps}) {
   const t = useTheme()
   const {gtMobile} = useBreakpoints()
-  const {_} = useLingui()
+  const {t: l} = useLingui()
   const {verifyEmailState: state} = useIntentDialogs()
   const [status, setStatus] = useState<
     'loading' | 'success' | 'failure' | 'resent'
@@ -39,15 +49,26 @@ function Inner({}: {control: DialogControlProps}) {
   const [sending, setSending] = useState(false)
   const agent = useAgent()
   const {currentAccount} = useSession()
+  const attemptedCode = useRef<string | undefined>(undefined)
   const {mutate: confirmEmail} = useConfirmEmail({
     onSuccess: () => setStatus('success'),
     onError: () => setStatus('failure'),
   })
 
   useEffect(() => {
-    if (state?.code) {
-      confirmEmail({token: state.code})
+    if (!state?.code) {
+      // The queued code was cleared (dialog closed). Reset the guard so that
+      // re-tapping the same verification link re-attempts confirmation instead
+      // of showing the previous result.
+      attemptedCode.current = undefined
+      return
     }
+
+    if (attemptedCode.current === state.code) return
+
+    attemptedCode.current = state.code
+    setStatus('loading')
+    confirmEmail({token: state.code})
   }, [state?.code, confirmEmail])
 
   const onPressResendEmail = async () => {
@@ -59,7 +80,7 @@ function Inner({}: {control: DialogControlProps}) {
 
   return (
     <Dialog.ScrollableInner
-      label={_(msg`Verify email dialog`)}
+      label={l`Verify email dialog`}
       style={[
         gtMobile ? {width: 'auto', maxWidth: 400, minWidth: 200} : a.w_full,
       ]}>
@@ -114,8 +135,8 @@ function Inner({}: {control: DialogControlProps}) {
           <>
             <Divider />
             <Button
-              label={_(msg`Resend Verification Email`)}
-              onPress={onPressResendEmail}
+              label={l`Resend Verification Email`}
+              onPress={() => void onPressResendEmail()}
               color="secondary_inverted"
               size="large"
               disabled={sending}>
@@ -127,7 +148,6 @@ function Inner({}: {control: DialogControlProps}) {
           </>
         )}
       </View>
-
       <Dialog.Close />
     </Dialog.ScrollableInner>
   )

--- a/src/lib/hooks/__tests__/useIntentHandler.test.ts
+++ b/src/lib/hooks/__tests__/useIntentHandler.test.ts
@@ -1,0 +1,108 @@
+import {act, renderHook} from '@testing-library/react-native'
+
+import {useVerifyEmailIntent} from '../useIntentHandler'
+
+const mockCloseAllActiveElements = jest.fn()
+const mockCloseAllActiveElementsAndWait = jest.fn()
+const mockOpen = jest.fn()
+const mockRequestSwitchToAccount = jest.fn()
+const mockSetActiveLanding = jest.fn()
+const mockSetVerifyEmailState = jest.fn()
+
+let mockHasSession = false
+
+jest.mock('expo-linking', () => ({useLinkingURL: jest.fn()}))
+jest.mock('expo-web-browser', () => ({dismissBrowser: jest.fn()}))
+jest.mock('#/lib/hooks/useOpenComposer', () => ({
+  useOpenComposer: () => ({openComposer: jest.fn()}),
+}))
+jest.mock('#/state/queries/join-links', () => ({
+  usePrefetchJoinLinkPreviews: () => jest.fn(),
+}))
+jest.mock('#/state/session', () => ({
+  useSession: () => ({hasSession: mockHasSession}),
+}))
+jest.mock('#/state/shell/landing', () => ({
+  useSetActiveLanding: () => mockSetActiveLanding,
+}))
+jest.mock('#/state/shell/logged-out', () => ({
+  useLoggedOutViewControls: () => ({
+    requestSwitchToAccount: mockRequestSwitchToAccount,
+  }),
+}))
+jest.mock('#/state/util', () => ({
+  useCloseAllActiveElements: () => mockCloseAllActiveElements,
+  useCloseAllActiveElementsAndWait: () => mockCloseAllActiveElementsAndWait,
+}))
+jest.mock('#/components/intents/IntentDialogs', () => ({
+  useIntentDialogs: () => ({
+    verifyEmailDialogControl: {open: mockOpen},
+    setVerifyEmailState: mockSetVerifyEmailState,
+  }),
+}))
+jest.mock('#/analytics', () => ({
+  useAnalytics: () => ({metric: jest.fn()}),
+}))
+jest.mock('#/env', () => ({IS_IOS: false, IS_NATIVE: true}))
+jest.mock('../../../../modules/expo-bluesky-swiss-army', () => ({
+  Referrer: {getReferrerInfo: jest.fn()},
+}))
+jest.mock('../useOTAUpdates', () => ({
+  useApplyPullRequestOTAUpdate: () => ({tryApplyUpdate: jest.fn()}),
+}))
+
+describe('useVerifyEmailIntent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCloseAllActiveElementsAndWait.mockResolvedValue(undefined)
+    mockHasSession = false
+  })
+
+  it('keeps verification pending while the user signs in', () => {
+    const {result} = renderHook(() => useVerifyEmailIntent())
+
+    act(() => result.current('abcde-fghij'))
+
+    expect(mockSetActiveLanding).toHaveBeenCalledWith({
+      type: 'verify-email',
+      code: 'abcde-fghij',
+    })
+    expect(mockRequestSwitchToAccount).toHaveBeenCalledWith({
+      requestedAccount: 'none',
+    })
+    expect(mockSetVerifyEmailState).not.toHaveBeenCalled()
+    expect(mockCloseAllActiveElementsAndWait).not.toHaveBeenCalled()
+  })
+
+  it('queues verification after active dialogs finish dismissing', async () => {
+    let finishDismissal: (() => void) | undefined
+    mockCloseAllActiveElementsAndWait.mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          finishDismissal = resolve
+        }),
+    )
+    mockHasSession = true
+    const {result} = renderHook(() => useVerifyEmailIntent())
+
+    act(() => result.current('abcde-fghij'))
+
+    expect(mockCloseAllActiveElementsAndWait).toHaveBeenCalledTimes(1)
+    expect(mockSetVerifyEmailState).not.toHaveBeenCalled()
+
+    await act(async () => {
+      finishDismissal?.()
+      await Promise.resolve()
+    })
+
+    /*
+     * The hook only queues the code; VerifyEmailIntentDialog opens itself once
+     * the code is set, so the hook does not call open().
+     */
+    expect(mockSetVerifyEmailState).toHaveBeenCalledWith({
+      code: 'abcde-fghij',
+    })
+    expect(mockSetActiveLanding).not.toHaveBeenCalled()
+    expect(mockOpen).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/hooks/useIntentHandler.ts
+++ b/src/lib/hooks/useIntentHandler.ts
@@ -10,7 +10,10 @@ import {usePrefetchJoinLinkPreviews} from '#/state/queries/join-links'
 import {useSession} from '#/state/session'
 import {useSetActiveLanding} from '#/state/shell/landing'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
-import {useCloseAllActiveElements} from '#/state/util'
+import {
+  useCloseAllActiveElements,
+  useCloseAllActiveElementsAndWait,
+} from '#/state/util'
 import {useIntentDialogs} from '#/components/intents/IntentDialogs'
 import {useAnalytics} from '#/analytics'
 import {IS_IOS, IS_NATIVE} from '#/env'
@@ -87,7 +90,7 @@ export function useIntentHandler() {
           if (!channel) {
             Alert.alert('Error', 'No channel provided to look for.')
           } else {
-            tryApplyUpdate(channel)
+            void tryApplyUpdate(channel)
           }
           return
         }
@@ -101,7 +104,7 @@ export function useIntentHandler() {
       if (previousIntentUrl === incomingUrl) {
         return
       }
-      handleIncomingURL(incomingUrl)
+      void handleIncomingURL(incomingUrl)
       previousIntentUrl = incomingUrl
     }
   }, [
@@ -213,20 +216,41 @@ export function useGroupChatJoinIntent() {
   )
 }
 
-function useVerifyEmailIntent() {
+export function useVerifyEmailIntent() {
   const closeAllActiveElements = useCloseAllActiveElements()
-  const {verifyEmailDialogControl: control, setVerifyEmailState: setState} =
-    useIntentDialogs()
+  const closeAllActiveElementsAndWait = useCloseAllActiveElementsAndWait()
+  const {hasSession} = useSession()
+  const {setVerifyEmailState: setState} = useIntentDialogs()
+  const setActiveLanding = useSetActiveLanding()
+  const {requestSwitchToAccount} = useLoggedOutViewControls()
+
+  const openDialog = useCallback(
+    async (code: string) => {
+      await closeAllActiveElementsAndWait()
+      setState({code})
+    },
+    [closeAllActiveElementsAndWait, setState],
+  )
+
   return useCallback(
     (code: string) => {
-      closeAllActiveElements()
-      setState({
-        code,
-      })
-      setTimeout(() => {
-        control.open()
-      }, 1000)
+      if (!hasSession) {
+        closeAllActiveElements()
+        // Landing state lives above the account-keyed app tree, so this code
+        // survives the remount that occurs when login completes.
+        setActiveLanding({type: 'verify-email', code})
+        requestSwitchToAccount({requestedAccount: 'none'})
+        return
+      }
+
+      void openDialog(code)
     },
-    [closeAllActiveElements, control, setState],
+    [
+      hasSession,
+      openDialog,
+      closeAllActiveElements,
+      requestSwitchToAccount,
+      setActiveLanding,
+    ],
   )
 }

--- a/src/state/dialogs/__tests__/dismissal.test.tsx
+++ b/src/state/dialogs/__tests__/dismissal.test.tsx
@@ -1,0 +1,59 @@
+import {act, renderHook} from '@testing-library/react-native'
+
+import {
+  Provider,
+  useDialogStateContext,
+  useDialogStateControlContext,
+} from '../index'
+
+jest.mock('#/lib/hotkeys', () => ({
+  useHotkeysContext: () => ({
+    disableScope: jest.fn(),
+    enableScope: jest.fn(),
+  }),
+}))
+jest.mock('#/components/dialogs/Context', () => ({
+  Provider: ({children}: {children: unknown}) => children,
+}))
+jest.mock('#/env', () => ({IS_WEB: true}))
+jest.mock('../../../../modules/bottom-sheet', () => ({
+  BottomSheetNativeComponent: {dismissAll: jest.fn()},
+}))
+
+describe('dialog dismissal', () => {
+  it('resolves when dialogs open at dismissal time have closed', async () => {
+    const {result} = renderHook(
+      () => ({
+        state: useDialogStateContext(),
+        controls: useDialogStateControlContext(),
+      }),
+      {wrapper: Provider},
+    )
+    const close = jest.fn()
+    result.current.state.activeDialogs.current.set('first', {
+      current: {open: jest.fn(), close},
+    })
+    act(() => result.current.controls.setDialogIsOpen('first', true))
+
+    let didResolve = false
+    let dismissal!: Promise<void>
+    act(() => {
+      dismissal = result.current.controls.closeAllDialogsAndWait()
+      void dismissal.then(() => {
+        didResolve = true
+      })
+    })
+
+    expect(close).toHaveBeenCalledTimes(1)
+    await act(async () => Promise.resolve())
+    expect(didResolve).toBe(false)
+
+    // Dialogs opened after dismissal began are not part of this wait.
+    act(() => result.current.controls.setDialogIsOpen('second', true))
+    act(() => result.current.controls.setDialogIsOpen('first', false))
+    await act(async () => dismissal)
+
+    expect(didResolve).toBe(true)
+    expect(result.current.state.openDialogs.current.has('second')).toBe(true)
+  })
+})

--- a/src/state/dialogs/index.tsx
+++ b/src/state/dialogs/index.tsx
@@ -29,8 +29,14 @@ interface IDialogContext {
 
 interface IDialogControlContext {
   closeAllDialogs(): boolean
+  closeAllDialogsAndWait(): Promise<void>
   setDialogIsOpen(id: string, isOpen: boolean): void
   setFullyExpandedCount: React.Dispatch<React.SetStateAction<number>>
+}
+
+type DialogDismissalWaiter = {
+  dialogIds: Set<string>
+  resolve: () => void
 }
 
 const DialogContext = createContext<IDialogContext>({} as IDialogContext)
@@ -69,6 +75,19 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
     Map<string, React.MutableRefObject<DialogControlRefProps>>
   >(new Map())
   const openDialogs = useRef<Set<string>>(new Set())
+  const dismissalWaiters = useRef<Set<DialogDismissalWaiter>>(new Set())
+
+  const resolveDismissalWaiters = useCallback(() => {
+    dismissalWaiters.current.forEach(waiter => {
+      const allDismissed = [...waiter.dialogIds].every(
+        id => !openDialogs.current.has(id),
+      )
+      if (allDismissed) {
+        dismissalWaiters.current.delete(waiter)
+        waiter.resolve()
+      }
+    })
+  }, [])
 
   const closeAllDialogs = useCallback(() => {
     if (IS_WEB) {
@@ -84,12 +103,31 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
     }
   }, [])
 
+  const closeAllDialogsAndWait = useCallback(() => {
+    const dialogIds = new Set(openDialogs.current)
+    if (dialogIds.size === 0) return Promise.resolve()
+
+    return new Promise<void>(resolve => {
+      dismissalWaiters.current.add({dialogIds, resolve})
+
+      if (IS_WEB) {
+        dialogIds.forEach(id => {
+          const dialog = activeDialogs.current.get(id)
+          if (dialog) dialog.current.close()
+        })
+      } else {
+        void BottomSheetNativeComponent.dismissAll()
+      }
+    })
+  }, [])
+
   const setDialogIsOpen = useCallback(
     (id: string, isOpen: boolean) => {
       if (isOpen) {
         openDialogs.current.add(id)
       } else {
         openDialogs.current.delete(id)
+        resolveDismissalWaiters()
       }
       if (openDialogs.current.size > 0) {
         disableScope('global')
@@ -97,7 +135,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         enableScope('global')
       }
     },
-    [disableScope, enableScope],
+    [disableScope, enableScope, resolveDismissalWaiters],
   )
 
   const context = useMemo<IDialogContext>(
@@ -110,10 +148,16 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   const controls = useMemo(
     () => ({
       closeAllDialogs,
+      closeAllDialogsAndWait,
       setDialogIsOpen,
       setFullyExpandedCount,
     }),
-    [closeAllDialogs, setDialogIsOpen, setFullyExpandedCount],
+    [
+      closeAllDialogs,
+      closeAllDialogsAndWait,
+      setDialogIsOpen,
+      setFullyExpandedCount,
+    ],
   )
 
   return (

--- a/src/state/shell/__tests__/logged-out.test.tsx
+++ b/src/state/shell/__tests__/logged-out.test.tsx
@@ -1,0 +1,46 @@
+import {act, renderHook} from '@testing-library/react-native'
+
+import {
+  Provider,
+  useLoggedOutView,
+  useLoggedOutViewControls,
+} from '../logged-out'
+
+jest.mock('#/state/session', () => ({
+  useSession: () => ({hasSession: false}),
+}))
+jest.mock('#/state/shell/landing', () => ({
+  useActiveLanding: () => undefined,
+}))
+jest.mock('#/env', () => ({IS_WEB: false}))
+
+describe('logged-out view controls', () => {
+  it('identifies repeated account-switch requests', () => {
+    const {result} = renderHook(
+      () => ({
+        state: useLoggedOutView(),
+        controls: useLoggedOutViewControls(),
+      }),
+      {wrapper: Provider},
+    )
+
+    act(() => {
+      result.current.controls.requestSwitchToAccount({
+        requestedAccount: 'none',
+      })
+    })
+
+    expect(result.current.state).toMatchObject({
+      requestedAccountSwitchTo: 'none',
+      requestedAccountSwitchId: 1,
+    })
+
+    act(() => {
+      result.current.controls.requestSwitchToAccount({
+        requestedAccount: 'none',
+      })
+    })
+
+    expect(result.current.state.requestedAccountSwitchId).toBe(2)
+  })
+})

--- a/src/state/shell/landing.tsx
+++ b/src/state/shell/landing.tsx
@@ -20,7 +20,16 @@ type GroupChatJoinRequestLanding = {
   code: string
 }
 
-type LandingType = StarterPackLanding | GroupChatJoinRequestLanding | undefined
+type VerifyEmailLanding = {
+  type: 'verify-email'
+  code: string
+}
+
+type LandingType =
+  | StarterPackLanding
+  | GroupChatJoinRequestLanding
+  | VerifyEmailLanding
+  | undefined
 
 type SetContext = Dispatch<SetStateAction<LandingType>>
 
@@ -70,4 +79,9 @@ export const useSetActiveStarterPack = () => {
 export const useActiveGroupChatJoinRequest = () => {
   const landing = useActiveLanding()
   return landing?.type === 'groupchat' ? landing : undefined
+}
+
+export const useActiveVerifyEmail = () => {
+  const landing = useActiveLanding()
+  return landing?.type === 'verify-email' ? landing : undefined
 }

--- a/src/state/shell/logged-out.tsx
+++ b/src/state/shell/logged-out.tsx
@@ -11,6 +11,11 @@ type State = {
    * shown.
    */
   requestedAccountSwitchTo?: string
+  /**
+   * Incremented for every account-switch request so an already-mounted logged
+   * out view can respond even when the requested account has not changed.
+   */
+  requestedAccountSwitchId: number
 }
 
 type Controls = {
@@ -43,6 +48,7 @@ type Controls = {
 const StateContext = createContext<State>({
   showLoggedOut: false,
   requestedAccountSwitchTo: undefined,
+  requestedAccountSwitchId: 0,
 })
 StateContext.displayName = 'LoggedOutStateContext'
 
@@ -64,6 +70,8 @@ function getRequestedAccountFromLanding(
       return IS_WEB ? 'starterpack' : 'new'
     case 'groupchat':
       return 'groupchat'
+    case 'verify-email':
+      return 'none'
     default:
       return undefined
   }
@@ -81,6 +89,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   const [state, setState] = useState<State>({
     showLoggedOut: Boolean(requestedAccount),
     requestedAccountSwitchTo: requestedAccount,
+    requestedAccountSwitchId: 0,
   })
 
   const controls = useMemo<Controls>(
@@ -96,6 +105,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           ...s,
           showLoggedOut: true,
           requestedAccountSwitchTo: requestedAccount,
+          requestedAccountSwitchId: s.requestedAccountSwitchId + 1,
         }))
       },
       clearRequestedAccount() {

--- a/src/state/util.ts
+++ b/src/state/util.ts
@@ -44,3 +44,20 @@ export function useCloseAllActiveElements() {
     setDrawerOpen(false)
   }, [closeLightbox, closeComposer, closeAlfDialogs, setDrawerOpen])
 }
+
+/**
+ * Close all active elements and resolve once dialogs that were open have
+ * finished dismissing.
+ */
+export function useCloseAllActiveElementsAndWait() {
+  const {closeLightbox} = useLightboxControls()
+  const {closeComposer} = useComposerControls()
+  const {closeAllDialogsAndWait} = useDialogStateControlContext()
+  const setDrawerOpen = useSetDrawerOpen()
+  return useCallback(async () => {
+    closeLightbox()
+    closeComposer()
+    setDrawerOpen(false)
+    await closeAllDialogsAndWait()
+  }, [closeLightbox, closeComposer, closeAllDialogsAndWait, setDrawerOpen])
+}

--- a/src/view/com/auth/LoggedOut.tsx
+++ b/src/view/com/auth/LoggedOut.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useState} from 'react'
+import {useCallback, useEffect, useRef, useState} from 'react'
 import {View} from 'react-native'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {useLingui} from '@lingui/react/macro'
@@ -56,16 +56,25 @@ export function LoggedOut({onDismiss}: {onDismiss?: () => void}) {
   const t = useTheme()
   const insets = useSafeAreaInsets()
   useEnableMinimalShellMode()
-  const {requestedAccountSwitchTo} = useLoggedOutView()
+  const {requestedAccountSwitchTo, requestedAccountSwitchId} =
+    useLoggedOutView()
   const initialScreenState = getInitialScreenState(requestedAccountSwitchTo)
   const [screenState, setScreenState] =
     useState<ScreenState>(initialScreenState)
+  const handledAccountSwitchId = useRef(requestedAccountSwitchId)
   const {clearRequestedAccount} = useLoggedOutViewControls()
   const setActiveLanding = useSetActiveLanding()
 
   const queryClient = useQueryClient()
   const {accounts} = useSession()
   const agent = useAgent()
+  useEffect(() => {
+    if (handledAccountSwitchId.current === requestedAccountSwitchId) return
+
+    handledAccountSwitchId.current = requestedAccountSwitchId
+    setScreenState(getInitialScreenState(requestedAccountSwitchTo))
+  }, [requestedAccountSwitchId, requestedAccountSwitchTo])
+
   useEffect(() => {
     const actors = accounts.map(acc => acc.did)
     if (actors.length === 0) return


### PR DESCRIPTION
Fixes email verification links for signed-out users by preserving the code through login and opening the verification dialog afterward.

As part of that:

- Ensures mounted logged-out views transition directly to login, including repeated requests.
- Replaces the fixed one-second dialog delay with event-driven dismissal tracking.
- Prevents duplicate verification attempts while allowing retries after closing.