### PR TITLE
ci: skip the per-PR OTA job for bot authors

### DIFF
--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -234,12 +234,19 @@ jobs:
   # This matches the fork-guard gate the other jobs in this workflow use;
   # author_association is deliberately NOT checked (it can't identify a private
   # org member and would skip their PRs).
+  #
+  # Bot authors are excluded: Dependabot pushes in-repo branches, so it passes
+  # the fork guard, but GitHub withholds repo secrets from Dependabot-triggered
+  # runs. EXPO_TOKEN is then empty and the job fails at setup — a red check on
+  # every dependabot PR. There is no OTA preview worth publishing for a
+  # dependency bump anyway.
   publish-pr-ota:
     name: Publish PR OTA to denis
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.type != 'Bot'
     concurrency:
       group: pr-ota-${{ github.event.pull_request.number }}
       cancel-in-progress: true


### PR DESCRIPTION
Follow-up to #11235. The per-PR OTA job currently fails on every Dependabot PR.

## What's happening

Dependabot pushes **in-repo** branches, so its PRs pass the fork guard and
`publish-pr-ota` runs. But GitHub deliberately withholds repo secrets from
Dependabot-triggered runs, so `EXPO_TOKEN` is empty and the job dies at step 3:

```
🛠️ Setup Expo project: failure
  EXPO_TOKEN:            ← empty
  "You must provide an EXPO_TOKEN secret linked to this project's Expo account"
```

Example: [run 30138249137](https://github.com/bluesky-social/social-app/actions/runs/30138249137)
on `dependabot/npm_and_yarn/bskyembed/postcss-8.5.18`.

It fails closed — no secret is exposed, nothing reaches AWS, the job stops before
the OIDC step — but it's a permanent red check on every dependency-bump PR
(2 open today, plus all future ones).

## Fix

Exclude bot authors:

```yaml
github.event.pull_request.user.type != 'Bot'
```

`dependabot[bot]` has `user.type: "Bot"`, so this covers it and generalizes to any
future bot author. There's no OTA preview worth publishing for a dependency bump.

Deliberately **not** reintroducing the `author_association` check that #11235
removed: it reports `CONTRIBUTOR` for private org members, so it wrongly skipped
their PRs (which is why it was dropped). The fork guard remains the trust
boundary; this only filters bots on top of it.
