### PR TITLE
Add unique context to ‘People I follow’ in FromDropdown.tsx

### DIFF
--- a/src/screens/Search/components/AdvancedSearchDialog/FromDropdown.tsx
+++ b/src/screens/Search/components/AdvancedSearchDialog/FromDropdown.tsx
@@ -20,7 +20,10 @@ export function FromDropdown({
 
   const options: {value: FromFilter; label: string}[] = [
     {value: 'anyone', label: l`No author filter`},
-    {value: 'following', label: l({context: 'display posts made by', message: `People I follow`})},
+    {
+      value: 'following',
+      label: l({context: 'display posts made by', message: 'People I follow'}),
+    },
     {value: 'me', label: l`Me`},
   ]
   const currentLabel =

--- a/src/screens/Search/components/AdvancedSearchDialog/FromDropdown.tsx
+++ b/src/screens/Search/components/AdvancedSearchDialog/FromDropdown.tsx
@@ -20,7 +20,7 @@ export function FromDropdown({
 
   const options: {value: FromFilter; label: string}[] = [
     {value: 'anyone', label: l`No author filter`},
-    {value: 'following', label: l`People I follow`},
+    {value: 'following', label: l({context: 'display posts made by', message: `People I follow`})},
     {value: 'me', label: l`Me`},
   ]
   const currentLabel =


### PR DESCRIPTION
Unlinks an instance of ‘People I follow’ in the advanced search dialog due to different grammatical contexts.

These two contexts are currently using the same string:
- receive notifications **from** people I follow
- display posts made **by** people I follow

This PR unlinks them.