### PR TITLE
fix: prevent boot crash when transition_animation_scale setting is malformed

### DIFF
--- a/modules/expo-bluesky-swiss-army/android/src/main/java/expo/modules/blueskyswissarmy/platforminfo/ExpoPlatformInfoModule.kt
+++ b/modules/expo-bluesky-swiss-army/android/src/main/java/expo/modules/blueskyswissarmy/platforminfo/ExpoPlatformInfoModule.kt
@@ -13,12 +13,7 @@ class ExpoPlatformInfoModule : Module() {
       Function("getIsReducedMotionEnabled") {
         val resolver = appContext.reactContext?.contentResolver ?: return@Function false
         val scale = Settings.Global.getString(resolver, Settings.Global.TRANSITION_ANIMATION_SCALE) ?: return@Function false
-
-        try {
-          return@Function scale.toFloat() == 0f
-        } catch (_: Error) {
-          return@Function false
-        }
+        return@Function scale.toFloatOrNull() == 0f
       }
     }
 }

--- a/modules/expo-bluesky-swiss-army/src/PlatformInfo/index.native.ts
+++ b/modules/expo-bluesky-swiss-army/src/PlatformInfo/index.native.ts
@@ -5,8 +5,20 @@ import {type AudioCategory} from './types'
 
 const NativeModule = requireNativeModule('ExpoPlatformInfo')
 
+/**
+ * Whether the user has enabled reduced motion at the OS level.
+ *
+ * This is called at module scope during boot via src/state/persisted/schema.ts,
+ * so a rejected native call would crash the app on startup. We catch any native
+ * failure and fall back to false to keep boot safe. See Sentry issue APP-T2EW,
+ * where a malformed TRANSITION_ANIMATION_SCALE setting threw at startup.
+ */
 export function getIsReducedMotionEnabled(): boolean {
-  return NativeModule.getIsReducedMotionEnabled()
+  try {
+    return NativeModule.getIsReducedMotionEnabled()
+  } catch {
+    return false
+  }
 }
 
 export function setAudioActive(active: boolean): void {


### PR DESCRIPTION
## Why

Fixes a fatal Android boot crash ([APP-T2EW](https://blueskyweb.sentry.io/issues/APP-T2EW)):

```
Error: Call to function 'ExpoPlatformInfo.getIsReducedMotionEnabled' has been rejected.
Caused by: java.lang.NumberFormatException: For input string: "STRING_FROM_SETTINGS_GLOBAL_WITH_KEY_transition_animation_scale"
```

On devices with a broken settings provider (seen on Waydroid; possible on odd OEM ROMs), `Settings.Global.TRANSITION_ANIMATION_SCALE` returns a non-numeric string. The existing Kotlin guard was `catch (_: Error)`, but `NumberFormatException` is an `Exception`, so it escaped and rejected the sync module call. Since `src/state/persisted/schema.ts` calls `getIsReducedMotionEnabled()` at module scope during boot, the rejection is an unhandled fatal and the app cannot start on affected devices.

## How

Two layers of hardening:

1. **Kotlin**: replace `toFloat()` + broken catch with `toFloatOrNull() == 0f`, which never throws.
2. **JS wrapper** (`PlatformInfo/index.native.ts`): wrap the native call in try/catch returning `false`, so any future native failure of this call degrades gracefully instead of crashing boot.

Note: reanimated's built-in `useReducedMotion` has the identical unguarded `Float.parseFloat` on Android (`NativeProxy.java:520` in v4.3.2), so migrating to it was not an option here - worth an upstream PR separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)