### PR TITLE
fix: stop grouping all signup failures into one sentry issue

### DIFF
--- a/src/analytics/metrics/types.ts
+++ b/src/analytics/metrics/types.ts
@@ -103,6 +103,10 @@ export type Events = {
   }
   'signup:captchaSuccess': {}
   'signup:captchaFailure': {}
+  'signup:captchaBackPress': {}
+  'signup:createAccountFailure': {
+    reason: string
+  }
   'signup:fieldError': {
     field: string
     errorCount: number

--- a/src/screens/Signup/StepCaptcha/index.tsx
+++ b/src/screens/Signup/StepCaptcha/index.tsx
@@ -127,23 +127,17 @@ function StepCaptchaInner({
         value: _(msg`Error receiving captcha response.`),
       })
       ax.metric('signup:captchaFailure', {})
-      logger.error('Signup Flow Error', {
-        registrationHandle: state.handle,
-        error,
+      logger.error('Signup: captcha response error', {
+        safeMessage: error,
       })
     },
-    [_, ax, dispatch, state.handle],
+    [_, ax, dispatch],
   )
 
   const onBackPress = useCallback(() => {
-    logger.error('Signup Flow Error', {
-      errorMessage:
-        'User went back from captcha step. Possibly encountered an error.',
-      registrationHandle: state.handle,
-    })
-
+    ax.metric('signup:captchaBackPress', {})
     dispatch({type: 'prev'})
-  }, [dispatch, state.handle])
+  }, [ax, dispatch])
 
   return (
     <>

--- a/src/screens/Signup/state.ts
+++ b/src/screens/Signup/state.ts
@@ -8,7 +8,7 @@ import {useLingui} from '@lingui/react/macro'
 import * as EmailValidator from 'email-validator'
 
 import {DEFAULT_SERVICE} from '#/lib/constants'
-import {cleanError} from '#/lib/strings/errors'
+import {cleanError, isNetworkError} from '#/lib/strings/errors'
 import {createFullHandle} from '#/lib/strings/handles'
 import {getAge} from '#/lib/strings/time'
 import {useSessionApi} from '#/state/session'
@@ -255,6 +255,25 @@ export const SignupContext = createContext<IContext>({} as IContext)
 SignupContext.displayName = 'SignupContext'
 export const useSignupContext = () => useContext(SignupContext)
 
+/**
+ * Returns a PII-free name for expected signup failures, or undefined if the
+ * failure is unexpected and should be reported to Sentry.
+ */
+function classifyExpectedSignupError(e: unknown): string | undefined {
+  if (e instanceof ComAtprotoServerCreateAccount.InvalidHandleError)
+    return 'InvalidHandle'
+  if (e instanceof ComAtprotoServerCreateAccount.HandleNotAvailableError)
+    return 'HandleNotAvailable'
+  if (e instanceof ComAtprotoServerCreateAccount.InvalidPasswordError)
+    return 'InvalidPassword'
+  if (e instanceof ComAtprotoServerCreateAccount.UnsupportedDomainError)
+    return 'UnsupportedDomain'
+  /* the server sends no typed error for this case */
+  if (String(e).includes('Email already taken')) return 'EmailTaken'
+  if (isNetworkError(e)) return 'NetworkError'
+  return undefined
+}
+
 export function useSubmitSignup() {
   const ax = useAnalytics()
   const {t: l} = useLingui()
@@ -300,10 +319,7 @@ export function useSubmitSignup() {
         !state.pendingSubmit?.verificationCode
       ) {
         dispatch({type: 'setStep', value: SignupStep.CAPTCHA})
-        ax.logger.error('Signup Flow Error', {
-          errorMessage: 'Verification captcha code was not set.',
-          registrationHandle: state.handle,
-        })
+        ax.logger.error('Signup: captcha code missing at submit', {})
         return dispatch({
           type: 'setError',
           value: l`Please complete the verification captcha.`,
@@ -362,14 +378,18 @@ export function useSubmitSignup() {
         })
         dispatch({type: 'setStep', value: isHandleError ? 2 : 1})
 
-        ax.logger.error('Signup Flow Error', {
-          errorMessage: error,
-          registrationHandle: state.handle,
-        })
+        const expected = classifyExpectedSignupError(e)
+        if (expected) {
+          ax.metric('signup:createAccountFailure', {reason: expected})
+        } else {
+          ax.logger.error('Signup: unexpected createAccount failure', {
+            safeMessage: e,
+          })
+        }
       } finally {
         dispatch({type: 'setIsLoading', value: false})
       }
     },
-    [l, ax.logger, createAccount, onboardingDispatch],
+    [l, ax, createAccount, onboardingDispatch],
   )
 }


### PR DESCRIPTION
Fixes APP-S3WR

[APP-S3WR](https://blueskyweb.sentry.io/issues/6706737577/) ("Signup Flow Error") has 511k events / 100k users because four call sites log the same constant string at error level, so Sentry groups every possible signup failure – expected user errors, user behavior, and genuine bugs – into one unactionable issue. It also sends PII (the raw server error containing the user's email, plus the registration handle) to Sentry.

## Changes

**`useSubmitSignup` catch block** (`src/screens/Signup/state.ts`)
- Expected failures (invalid/taken handle, invalid password, unsupported domain, email already taken, network errors) are now counted via a new `signup:createAccountFailure` metric with a PII-free `reason`, instead of being reported to Sentry.
- Unexpected failures go to Sentry as `Signup: unexpected createAccount failure` with `safeMessage`.
- Classification runs on the **raw** error (typed `ComAtprotoServerCreateAccount` errors + string match for email-taken, which has no typed error). `cleanError` output can't be used for this since it's localized; it's still used for the user-facing error display, which is unchanged.

**Captcha step** (`src/screens/Signup/StepCaptcha/index.tsx`)
- Webview error → own Sentry issue: `Signup: captcha response error`.
- Back-press on the captcha step is user behavior, not an error – replaced `logger.error` with a `signup:captchaBackPress` metric, matching the neighboring captcha metrics.

**Other**
- The captcha-code-missing invariant in `state.ts` keeps error level but gets its own message.
- No more `errorMessage`/`registrationHandle` attached to any of these events.
- New metric events registered in `src/analytics/metrics/types.ts`.

## Test plan

- `pnpm typecheck`, `pnpm lint`, `pnpm prettier` all pass. No existing tests cover these files.
- User-facing behavior is intentionally unchanged: all `setError`/`setStep`/`isLoading` dispatches, including the `isHandleError` routing, are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)