### PR TITLE
Add author autocomplete to from: searches

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -1767,13 +1767,5 @@
     "typescript/no-unsafe-call": {
       "count": 1
     }
-  },
-  "src/view/shell/desktop/Search.tsx": {
-    "typescript/no-unsafe-call": {
-      "count": 3
-    },
-    "typescript/no-unsafe-member-access": {
-      "count": 3
-    }
   }
 }

--- a/src/screens/Search/Shell.tsx
+++ b/src/screens/Search/Shell.tsx
@@ -35,6 +35,10 @@ import {
 import {extractFromMe} from '#/state/queries/search-posts-params'
 import {useSession} from '#/state/session'
 import {
+  completeActorSearchOperator,
+  getActorAutocompleteState,
+} from '#/screens/Search/actorAutocomplete'
+import {
   countActiveFilters,
   definedFilterParams,
   filtersToRouteParams,
@@ -142,16 +146,22 @@ export function SearchScreenShell({
     setSearchText(text)
   }, [])
 
+  /*
+   * On web the dropdown (SearchAutocompleteInput) owns its own autocomplete
+   * query; only the native inline list consumes this one, so pass an empty
+   * query on web to keep the hook a no-op instead of doing wasted work.
+   */
+  const profileAutocompleteQuery = IS_NATIVE
+    ? getActorAutocompleteState(searchText).query
+    : ''
   const {items: autocompleteItems, isFetching: isAutocompleteFetching} =
     useAutocomplete({
       type: 'profile',
-      /*
-       * On web the dropdown (SearchAutocompleteInput) owns its own autocomplete
-       * query; only the native inline list consumes this one, so pass an empty
-       * query on web to keep the hook a no-op instead of doing wasted work.
-       */
-      query: IS_NATIVE ? searchText : '',
+      query: profileAutocompleteQuery,
     })
+  const visibleAutocompleteItems = profileAutocompleteQuery
+    ? autocompleteItems
+    : []
 
   const [showAutocomplete, setShowAutocomplete] = useState(false)
 
@@ -425,6 +435,25 @@ export function SearchScreenShell({
     [ax, handleProfileClick, navigation],
   )
 
+  const onSelectSearchOperator = useCallback(
+    (profile: bsky.profile.AnyProfileView, position: number) => {
+      const currentValue = searchTextRef.current
+      const context = getActorAutocompleteState(currentValue).context
+      if (!context) return
+
+      ax.metric('search:autocomplete:press', {
+        profileDid: profile.did,
+        position,
+      })
+      updateSearchText(
+        completeActorSearchOperator(currentValue, context, profile.handle),
+      )
+      setShowAutocomplete(false)
+      requestAnimationFrame(() => textInput.current?.focus())
+    },
+    [ax, updateSearchText],
+  )
+
   /**
    * Web only. Selecting the "Search for X" row from the anchored autocomplete
    * dropdown. This runs the typed query as-is (not a suggested profile), so it
@@ -614,6 +643,7 @@ export function SearchScreenShell({
                       hotkey={true}
                       fixedParams={Boolean(fixedParams)}
                       onSelectProfile={onSelectProfile}
+                      onSelectSearchOperator={onSelectSearchOperator}
                       onSelectSearch={onSelectSearch}
                     />
                   </View>
@@ -670,12 +700,15 @@ export function SearchScreenShell({
             accessibilityRole="list">
             {searchText.length > 0 && IS_NATIVE ? (
               <AutocompleteResults
-                items={autocompleteItems}
-                isFetching={isAutocompleteFetching}
+                items={visibleAutocompleteItems}
+                isFetching={
+                  Boolean(profileAutocompleteQuery) && isAutocompleteFetching
+                }
                 searchText={searchText}
                 onSubmit={onSubmit('autocomplete')}
                 onResultPress={onAutocompleteResultPress}
                 onProfileClick={handleProfileClick}
+                onSelectSearchOperator={onSelectSearchOperator}
               />
             ) : (
               <SearchHistory

--- a/src/screens/Search/__tests__/actorAutocomplete.test.ts
+++ b/src/screens/Search/__tests__/actorAutocomplete.test.ts
@@ -1,0 +1,73 @@
+import {describe, expect, it} from '@jest/globals'
+
+import {
+  completeActorSearchOperator,
+  getActorAutocompleteState,
+} from '#/screens/Search/actorAutocomplete'
+
+describe('search operator autocomplete', () => {
+  it.each([
+    ['from:ali', 'ali', 0],
+    ['cats from:ali', 'ali', 5],
+    ['cats  from:@ali', 'ali', 6],
+    ['cats\nfrom:ali', 'ali', 5],
+  ])('extracts an active from operator from %s', (value, query, tokenStart) => {
+    expect(getActorAutocompleteState(value).context).toEqual({
+      operator: 'from',
+      query,
+      tokenStart,
+    })
+  })
+
+  it.each([
+    'cats',
+    'cats from:alice.bsky.social more',
+    'from:me',
+    '"from:alice"',
+    'cats "words from:alice"',
+    'notfrom:alice',
+    'from:ali!ce',
+  ])('does not expose a replacement context for %s', value => {
+    expect(getActorAutocompleteState(value).context).toBeNull()
+  })
+
+  it.each([
+    ['from:ali', 'ali', true],
+    ['cats from:@ali', 'ali', true],
+    ['from:', '', false],
+    ['from:me', '', true],
+    ['from:me ad', '', true],
+    ['cats from:alice.bsky.social more', '', true],
+    ['ordinary search', 'ordinary search', false],
+    ['cats "words from:alice"', 'cats "words from:alice"', false],
+  ])(
+    'derives autocomplete state from %j',
+    (value, query, showFullSearchFallback) => {
+      expect(getActorAutocompleteState(value)).toMatchObject({
+        query,
+        showFullSearchFallback,
+      })
+    },
+  )
+
+  it('does not treat differently-cased Me as the reserved value', () => {
+    expect(getActorAutocompleteState('from:Me')).toMatchObject({
+      context: {
+        operator: 'from',
+        query: 'Me',
+        tokenStart: 0,
+      },
+      query: 'Me',
+      showFullSearchFallback: true,
+    })
+  })
+
+  it('completes the operator and preserves preceding terms', () => {
+    const value = 'cats from:ali'
+    const context = getActorAutocompleteState(value).context
+    expect(context).not.toBeNull()
+    expect(
+      completeActorSearchOperator(value, context!, 'alice.bsky.social'),
+    ).toBe('cats from:alice.bsky.social ')
+  })
+})

--- a/src/screens/Search/actorAutocomplete.ts
+++ b/src/screens/Search/actorAutocomplete.ts
@@ -1,0 +1,89 @@
+import {tokenizeQuery} from '#/state/queries/search-posts-params'
+
+export type ActorSearchOperatorContext = {
+  operator: 'from'
+  query: string
+  tokenStart: number
+}
+
+export type ActorAutocompleteState = {
+  context: ActorSearchOperatorContext | null
+  query: string
+  showFullSearchFallback: boolean
+}
+
+/**
+ * Returns the actor-valued search operator currently being typed. Operators
+ * are only completed at the end of the input so editing ordinary query text
+ * doesn't unexpectedly open an actor typeahead.
+ */
+function getActorSearchOperatorContext(
+  value: string,
+): ActorSearchOperatorContext | null {
+  if (!value || /\s$/u.test(value)) return null
+
+  const token = tokenizeQuery(value).at(-1)
+  if (!token) return null
+
+  /*
+   * The fragment must be handle-shaped, so junk after `from:` doesn't fire
+   * typeahead requests.
+   */
+  const match = /^from:@?([a-zA-Z0-9.-]*)$/iu.exec(token)
+  if (!match) return null
+  /*
+   * `me` is a reserved backend value meaning the current viewer, not an actor
+   * prefix to resolve through typeahead.
+   */
+  if (match[1] === 'me') return null
+
+  return {
+    operator: 'from',
+    query: match[1],
+    tokenStart: value.length - token.length,
+  }
+}
+
+function hasActorSearchOperator(value: string): boolean {
+  return tokenizeQuery(value).some(token => /^from:@?[^"\s]+$/iu.test(token))
+}
+
+/**
+ * Derives actor typeahead behavior from the full search input.
+ *
+ * An in-progress `from:` operator searches by only its handle fragment. A
+ * completed operator suppresses profile autocomplete while preserving the
+ * fallback that submits the full search. A bare `from:` is incomplete, so it
+ * shows neither profiles nor a submit fallback.
+ */
+export function getActorAutocompleteState(
+  value: string,
+): ActorAutocompleteState {
+  const context = getActorSearchOperatorContext(value)
+  if (context) {
+    return {
+      context,
+      query: context.query,
+      showFullSearchFallback: context.query.length > 0,
+    }
+  }
+
+  const hasCompletedOperator = hasActorSearchOperator(value)
+  return {
+    context: null,
+    query: hasCompletedOperator ? '' : value,
+    showFullSearchFallback: hasCompletedOperator,
+  }
+}
+
+/**
+ * Replaces the in-progress operator with the selected handle. The trailing
+ * space closes the typeahead and leaves the input ready for another term.
+ */
+export function completeActorSearchOperator(
+  value: string,
+  context: ActorSearchOperatorContext,
+  handle: string,
+): string {
+  return `${value.slice(0, context.tokenStart)}${context.operator}:${handle} `
+}

--- a/src/screens/Search/components/AutocompleteResults.tsx
+++ b/src/screens/Search/components/AutocompleteResults.tsx
@@ -3,6 +3,7 @@ import {TouchableOpacity, View, type ViewStyle} from 'react-native'
 import {useLingui} from '@lingui/react/macro'
 
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
+import {getActorAutocompleteState} from '#/screens/Search/actorAutocomplete'
 import {SearchProfileCard} from '#/screens/Search/components/SearchProfileCard'
 import {atoms as a, native, useTheme} from '#/alf'
 import {type AutocompleteItem} from '#/components/Autocomplete'
@@ -21,6 +22,7 @@ let AutocompleteResults = ({
   onSubmit,
   onResultPress,
   onProfileClick,
+  onSelectSearchOperator,
 }: {
   items: AutocompleteItem[]
   isFetching: boolean
@@ -28,10 +30,16 @@ let AutocompleteResults = ({
   onSubmit: () => void
   onResultPress: () => void
   onProfileClick: (profile: bsky.profile.AnyProfileView) => void
+  onSelectSearchOperator: (
+    profile: bsky.profile.AnyProfileView,
+    position: number,
+  ) => void
 }): React.ReactNode => {
   const ax = useAnalytics()
   const {t: l} = useLingui()
   const moderationOpts = useModerationOpts()
+  const operatorContext = getActorAutocompleteState(searchText).context
+  const isIncompleteOperator = operatorContext?.query === ''
 
   return (
     <>
@@ -45,16 +53,18 @@ let AutocompleteResults = ({
         <Layout.Content
           keyboardShouldPersistTaps="handled"
           keyboardDismissMode="on-drag">
-          <SearchLinkCard
-            label={l`Search for “${searchText}”`}
-            onPress={native(onSubmit)}
-            to={
-              IS_NATIVE
-                ? undefined
-                : `/search?q=${encodeURIComponent(searchText)}`
-            }
-            style={a.border_b}
-          />
+          {!isIncompleteOperator && (
+            <SearchLinkCard
+              label={l`Search for “${searchText}”`}
+              onPress={native(onSubmit)}
+              to={
+                IS_NATIVE
+                  ? undefined
+                  : `/search?q=${encodeURIComponent(searchText)}`
+              }
+              style={a.border_b}
+            />
+          )}
           {items.map((item, index) => {
             if (item.type !== 'profile') return null
             return (
@@ -62,7 +72,22 @@ let AutocompleteResults = ({
                 key={item.key}
                 profile={item.profile}
                 moderationOpts={moderationOpts}
-                onPress={() => {
+                accessibilityLabel={
+                  operatorContext
+                    ? l`Use ${item.profile.handle} as the search author`
+                    : undefined
+                }
+                accessibilityHint={
+                  operatorContext
+                    ? l`Completes the from search filter`
+                    : undefined
+                }
+                onPress={event => {
+                  if (operatorContext) {
+                    event.preventDefault()
+                    onSelectSearchOperator(item.profile, index)
+                    return false
+                  }
                   ax.metric('search:autocomplete:press', {
                     profileDid: item.profile.did,
                     position: index,

--- a/src/screens/Search/components/SearchAutocompleteInput/index.native.tsx
+++ b/src/screens/Search/components/SearchAutocompleteInput/index.native.tsx
@@ -10,6 +10,7 @@ export function SearchAutocompleteInput({
   // web-only props are ignored on native
   fixedParams: _fixedParams,
   onSelectProfile: _onSelectProfile,
+  onSelectSearchOperator: _onSelectSearchOperator,
   onSelectSearch: _onSelectSearch,
   ...rest
 }: SearchAutocompleteInputProps) {

--- a/src/screens/Search/components/SearchAutocompleteInput/index.tsx
+++ b/src/screens/Search/components/SearchAutocompleteInput/index.tsx
@@ -3,6 +3,7 @@ import {type TextInput, View} from 'react-native'
 import {useSift} from '@bsky.app/sift'
 
 import {mergeRefs} from '#/lib/merge-refs'
+import {getActorAutocompleteState} from '#/screens/Search/actorAutocomplete'
 import {atoms as a} from '#/alf'
 import {
   Autocomplete,
@@ -21,6 +22,7 @@ import {type SearchAutocompleteInputProps} from './shared'
 export function SearchAutocompleteInput({
   fixedParams,
   onSelectProfile,
+  onSelectSearchOperator,
   onSelectSearch,
   value = '',
   onFocus,
@@ -45,15 +47,31 @@ export function SearchAutocompleteInput({
   })
 
   const active = focused && !dismissed
+  const autocompleteState = getActorAutocompleteState(value)
+  const operatorContext = autocompleteState.context
 
-  const {items} = useAutocomplete({
+  const {items: autocompleteItems} = useAutocomplete({
     type: 'profile',
     // The dropdown only shows while active, so don't fetch otherwise. This
     // avoids a typeahead request on mount when arriving with text already
     // present (e.g. /search?q=foo).
-    query: active ? value : '',
-    showSearchFallback: true,
+    query: active ? autocompleteState.query : '',
+    showSearchFallback: !autocompleteState.showFullSearchFallback,
   })
+  /*
+   * `useAutocomplete` keeps the preceding query's results while the next query
+   * resolves. Do not let those stale profiles survive when an operator has no
+   * actor fragment (or has already been completed).
+   */
+  const actorItems = autocompleteState.query ? autocompleteItems : []
+  /*
+   * The actor lookup only receives the handle fragment, but the search row
+   * must still submit the full expression rather than searching for that
+   * fragment by itself.
+   */
+  const items: AutocompleteItem[] = autocompleteState.showFullSearchFallback
+    ? [{key: `search-${value}`, type: 'search', value}, ...actorItems]
+    : actorItems
 
   const showDropdown =
     active && !fixedParams && value.length > 0 && items.length > 0
@@ -61,7 +79,14 @@ export function SearchAutocompleteInput({
   function onSelect(item: AutocompleteItem) {
     if (item.type === 'profile') {
       const position = items.filter(i => i.type === 'profile').indexOf(item)
-      onSelectProfile?.(item.profile, position)
+      if (operatorContext) {
+        onSelectSearchOperator(item.profile, position)
+        setDismissed(true)
+        inputRef.current?.focus()
+        return
+      } else {
+        onSelectProfile?.(item.profile, position)
+      }
     } else if (item.type === 'search') {
       onSelectSearch?.(item.value)
     }

--- a/src/screens/Search/components/SearchAutocompleteInput/shared.ts
+++ b/src/screens/Search/components/SearchAutocompleteInput/shared.ts
@@ -17,6 +17,13 @@ export type SearchAutocompleteInputProps = SearchInputProps & {
     position: number,
   ) => void
   /**
+   * Called when a profile completes an actor-valued search operator.
+   */
+  onSelectSearchOperator: (
+    profile: bsky.profile.AnyProfileView,
+    position: number,
+  ) => void
+  /**
    * Web only. Called when the "Search for X" row in the dropdown is selected.
    */
   onSelectSearch?: (value: string) => void

--- a/src/screens/Search/components/SearchProfileCard.tsx
+++ b/src/screens/Search/components/SearchProfileCard.tsx
@@ -1,5 +1,5 @@
 import {useCallback} from 'react'
-import {View} from 'react-native'
+import {type GestureResponderEvent, View} from 'react-native'
 import {type ModerationOpts} from '@bsky/sdk/moderation'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
@@ -16,25 +16,35 @@ export function SearchProfileCard({
   profile,
   moderationOpts,
   onPress: onPressInner,
+  accessibilityLabel,
+  accessibilityHint,
 }: {
   profile: bsky.profile.AnyProfileView
   moderationOpts: ModerationOpts
-  onPress?: () => void
+  onPress?: (event: GestureResponderEvent) => void | false
+  accessibilityLabel?: string
+  accessibilityHint?: string
 }) {
   const t = useTheme()
   const {_} = useLingui()
   const qc = useQueryClient()
 
-  const onPress = useCallback(() => {
-    unstableCacheProfileView(qc, profile)
-    onPressInner?.()
-  }, [qc, profile, onPressInner])
+  const onPress = useCallback(
+    (event: GestureResponderEvent): void | false => {
+      unstableCacheProfileView(qc, profile)
+      return onPressInner?.(event)
+    },
+    [qc, profile, onPressInner],
+  )
+
+  const label = accessibilityLabel ?? _(msg`View ${profile.handle}'s profile`)
 
   return (
     <Link
       testID={`searchAutoCompleteResult-${profile.handle}`}
       to={makeProfileLink(profile)}
-      label={_(msg`View ${profile.handle}'s profile`)}
+      label={label}
+      accessibilityHint={accessibilityHint}
       onPress={onPress}>
       {({hovered, pressed}) => (
         <View

--- a/src/view/shell/desktop/Search.tsx
+++ b/src/view/shell/desktop/Search.tsx
@@ -1,9 +1,14 @@
-import {useState} from 'react'
-import {View} from 'react-native'
+import {useRef, useState} from 'react'
+import {type TextInput, View} from 'react-native'
 import {useSift} from '@bsky.app/sift'
 import {StackActions, useNavigation} from '@react-navigation/native'
 
+import {mergeRefs} from '#/lib/merge-refs'
 import {type NavigationProp} from '#/lib/routes/types'
+import {
+  completeActorSearchOperator,
+  getActorAutocompleteState,
+} from '#/screens/Search/actorAutocomplete'
 import {atoms as a} from '#/alf'
 import {
   Autocomplete as AutocompleteBase,
@@ -16,7 +21,9 @@ export function DesktopSearch() {
   const navigation = useNavigation<NavigationProp>()
   const [active, setActive] = useState(false)
   const [query, setQuery] = useState<string>('')
+  const operatorContext = getActorAutocompleteState(query).context
   const showResults = active && !!query.length
+  const inputRef = useRef<TextInput>(null)
 
   const sift = useSift({
     offset: a.p_sm.padding,
@@ -46,21 +53,35 @@ export function DesktopSearch() {
   const onSubmit = () => {
     if (!query.length) return
     onClearText()
-    sift.elements.input.blur()
+    inputRef.current?.blur()
     navigation.dispatch(StackActions.push('Search', {q: query}))
   }
 
   const onSelect = (item: AutocompleteItem) => {
     if (item.type === 'profile') {
+      if (operatorContext) {
+        setQuery(
+          completeActorSearchOperator(
+            query,
+            operatorContext,
+            item.profile.handle,
+          ),
+        )
+        setActive(false)
+        inputRef.current?.focus()
+        return
+      }
       onClearText()
-      sift.elements.input.blur()
+      inputRef.current?.blur()
       navigation.navigate('Profile', {name: item.profile.handle})
     } else if (item.type === 'search') {
       onClearText()
-      sift.elements.input.blur()
+      inputRef.current?.blur()
       navigation.navigate('Search', {q: item.value})
     }
   }
+
+  const {ref: siftInputRef, ...siftTargetProps} = sift.targetProps
 
   return (
     <View collapsable={false} ref={sift.refs.setAnchor}>
@@ -72,7 +93,8 @@ export function DesktopSearch() {
         onChangeText={onChangeText}
         onClearText={onClearText}
         onSubmitEditing={onSubmit}
-        {...sift.targetProps}
+        ref={mergeRefs([inputRef, siftInputRef])}
+        {...siftTargetProps}
       />
       {showResults && (
         <Inner
@@ -97,11 +119,16 @@ function Inner({
   onSelect: (item: AutocompleteItem) => void
   onDismiss: () => void
 }) {
-  const {items} = useAutocomplete({
+  const autocompleteState = getActorAutocompleteState(query)
+  const {items: autocompleteItems} = useAutocomplete({
     type: 'profile',
-    query,
-    showSearchFallback: true,
+    query: autocompleteState.query,
+    showSearchFallback: !autocompleteState.showFullSearchFallback,
   })
+  const actorItems = autocompleteState.query ? autocompleteItems : []
+  const items: AutocompleteItem[] = autocompleteState.showFullSearchFallback
+    ? [{key: `search-${query}`, type: 'search', value: query}, ...actorItems]
+    : actorItems
 
   return items && items.length ? (
     <AutocompleteBase


### PR DESCRIPTION
## Summary

- add actor typeahead while typing the final `from:` search operator
- support the dedicated search screen, the desktop shell search, and the native autocomplete surface
- preserve the existing search action while keeping incomplete and special operator states out of actor lookup

## Screenshots

### Actor suggestions for `from:zzs`

![Actor suggestions for `from:zzs`](https://raw.githubusercontent.com/zzstoatzz/social-app/codex/pr-assets-from-typeahead/.github/pr-assets/from-typeahead.png)

### No stale suggestions for bare `from:`

![No suggestions for bare `from:`](https://raw.githubusercontent.com/zzstoatzz/social-app/codex/pr-assets-from-typeahead/.github/pr-assets/from-empty.png)

### Preserve the special `from:me` operator

![Only the search action for `from:me ad`](https://raw.githubusercontent.com/zzstoatzz/social-app/codex/pr-assets-from-typeahead/.github/pr-assets/from-me.png)

<details>
<summary>Autocomplete behavior</summary>

The full text remains the value submitted to post search, while only the active `from:` value is sent to actor typeahead. Selecting a profile replaces that token with the actor's handle and appends a space so the user can continue composing the query.

Actor typeahead is suppressed for:

- bare `from:`, which is not yet a valid post search
- exact `from:me`, which the search backend resolves to the signed-in account
- completed `from:handle` filters followed by other terms

The ordinary profile autocomplete behavior is unchanged for searches without an active `from:` token.
</details>

<details>
<summary>Parsing details</summary>

This reuses the existing search tokenizer instead of scanning the raw string. That keeps quoted text such as `cats "words from:alice"` from being treated as an operator.

The helper returns the actor query and token range together so desktop, web search, and native search share the same rules.
</details>

<details>
<summary>UI and platform details</summary>

Both web search entry points need explicit wiring because the persistent desktop search and the dedicated search screen are separate implementations. Native receives the same state through the shared autocomplete results.

Profile rows keep the project's existing Link behavior. Operator completion prevents navigation and returns `false`, while ordinary profile suggestions continue to navigate normally.

The desktop input now uses a typed merged ref for focus and selection restoration; this also removes the related unsafe-call suppressions.
</details>

## Test plan

- [x] `pnpm test src/screens/Search src/state/queries/__tests__/search-posts-params.test.ts --runInBand`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm prettier`
- [x] manually verified `from:zzs`, bare `from:`, and `from:me ad` in the local web app


<details>
<summary>Prior art and possible further steps</summary>

[aglais](https://github.com/mary-ext/aglais) (mary-ext's client) has an equivalent feature (`src/components/search/search-suggestions-view.tsx`); this PR follows the same core mechanic (tokenize, detect the in-progress operator, feed the fragment to `searchActorsTypeahead`, splice `from:handle ` back with a trailing space). The handle-shaped fragment gate here is adopted from it. Deliberately left out to keep this diff reviewable, plausible follow-ups:

- cursor-position awareness: complete the token under the caret rather than only at the end of the input
- more operators sharing the actor view (`to:`, `mentions:`), plus date pickers for `since:`/`until:` and suggesting the operators themselves
- offering the signed-in account as the first suggestion for a bare `from:`, completing to `from:me` (this PR just suppresses typeahead there)
- filtering `handle.invalid` actors out of operator suggestions (needs wiring in both the native list and web dropdown render paths)
</details>
