### PR TITLE
fix: prevent blank flash on mentions tab when there are no mentions

### DIFF
--- a/src/view/com/notifications/NotificationFeed.tsx
+++ b/src/view/com/notifications/NotificationFeed.tsx
@@ -62,13 +62,7 @@ export function NotificationFeed({
     enabled: enabled && !!moderationOpts,
     filter,
   })
-  // previously, this was `!isFetching && !data?.pages[0]?.items.length`
-  // however, if the first page had no items (can happen in the mentions tab!)
-  // it would flicker the empty state whenever it was loading.
-  // therefore, we need to find if *any* page has items. in 99.9% of cases,
-  // the `.find()` won't need to go any further than the first page -sfn
-  const isEmpty =
-    !isFetching && !data?.pages.find(page => page.items.length > 0)
+  const isEmpty = !data?.pages.find(page => page.items.length > 0)
 
   const items = useMemo(() => {
     let arr: any[] = []
@@ -78,12 +72,6 @@ export function NotificationFeed({
       } else if (data) {
         for (const page of data?.pages) {
           arr = arr.concat(page.items)
-        }
-        // fixed zero-data edge case: when isFetching=true isEmpty stays false,
-        // so we fall into this branch even with no items (e.g. mentions tab with
-        // no mentions). without this check arr would be [] causing a blank flash.
-        if (arr.length === 0) {
-          arr = arr.concat([EMPTY_FEED_ITEM])
         }
       }
       if (isError && !isEmpty) {

--- a/src/view/com/notifications/NotificationFeed.tsx
+++ b/src/view/com/notifications/NotificationFeed.tsx
@@ -79,6 +79,12 @@ export function NotificationFeed({
         for (const page of data?.pages) {
           arr = arr.concat(page.items)
         }
+        // fixed zero-data edge case: when isFetching=true isEmpty stays false,
+        // so we fall into this branch even with no items (e.g. mentions tab with
+        // no mentions). without this check arr would be [] causing a blank flash.
+        if (arr.length === 0) {
+          arr = arr.concat([EMPTY_FEED_ITEM])
+        }
       }
       if (isError && !isEmpty) {
         arr = arr.concat([LOAD_MORE_ERROR_ITEM])


### PR DESCRIPTION

Noticed the mentions tab flickers with a blank screen when you have no mentions.
Happens every time you switch to the tab.

Traced it back to the `else if (data)` branch — when `isFetching` is true,
`isEmpty` stays false so we fall into that branch and loop through the pages.
But if you have zero mentions every page comes back empty, so `arr` ends up as
`[]` and we're passing an empty array to List which causes the flash.

Simple fix — if `arr` is still empty after the loop just show the empty state
instead. Doesn't affect anyone who actually has mentions since their `arr` would
have items and never hit that check.