### PR TITLE
Fix tooltip layout measurement loop

### DIFF
--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -425,9 +425,10 @@ function Bubble({
             },
           ]}
           onLayout={e => {
-            setBubbleMeasurements({
-              width: e.nativeEvent.layout.width,
-              height: e.nativeEvent.layout.height,
+            const {width, height} = e.nativeEvent.layout
+            setBubbleMeasurements(prev => {
+              if (prev?.width === width && prev.height === height) return prev
+              return {width, height}
             })
           }}>
           {children}


### PR DESCRIPTION
## Summary

- skip redundant tooltip measurement state updates when layout dimensions are unchanged
- preserve repositioning when tooltip content genuinely changes size
- fix the Android Fabric update loop reported in Sentry APP-T273

Sentry: https://blueskyweb.sentry.io/issues/APP-T273

## Test plan

- ./node_modules/.bin/prettier --check src/components/Tooltip/index.tsx
- ./node_modules/.bin/oxlint --quiet src/components/Tooltip/index.tsx
- ./node_modules/.bin/tsc --project tsconfig.check.android.json --pretty false
- roast review (no findings)