### PR TITLE
Restore PR OTA QR comment

### DIFF
--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -15,7 +15,7 @@ concurrency:
 
 # Permissions are granted per-job below; anything unlisted defaults to none.
 # pull-requests: write is needed by sticky-pull-request-comment to post the
-# bundle-size and fingerprint diffs
+# bundle-size and fingerprint diffs and the PR OTA install link
 permissions: {}
 
 # denis release tag in bluesky-social/tango whose linux-amd64 binary the PR OTA
@@ -325,3 +325,21 @@ jobs:
         env:
           RUNTIME_VERSION: ''
           CHANNEL_NAME: pull-request-${{ github.event.pull_request.number }}
+
+  comment-pr-ota:
+    name: Comment PR OTA install link
+    needs: publish-pr-ota
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: 💬 Drop OTA install comment
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: pull-request-ota
+          message: |
+            The OTA deployment for this PR was successful! You may now apply it by either scanning the QR code or opening the deep link below in your browser:
+
+            <img src="https://bsky-qr.vercel.app?channel=pull-request-${{ github.event.pull_request.number }}" width="300" height="300" alt="QR code for the PR OTA deployment">
+
+            `bluesky://intent/apply-ota?channel=pull-request-${{ github.event.pull_request.number }}`


### PR DESCRIPTION
## Summary

- restore the sticky QR-code and deep-link comment after successful PR OTA publishes
- update one stable comment per PR on subsequent publishes
- isolate pull-request write permission in a small dependent job

## Validation

- actionlint workflow syntax
- Prettier
- adversarial review