### PR TITLE
Add emoji to GitHub Actions step names for consistency

### DIFF
--- a/.github/workflows/build-and-push-bskyweb-aws.yaml
+++ b/.github/workflows/build-and-push-bskyweb-aws.yaml
@@ -21,20 +21,20 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout repository
+      - name: ⬇️ Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Docker buildx
+      - name: 🔧 Setup Docker buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Log into registry ${{ env.REGISTRY }}
+      - name: 🔑 Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.USERNAME}}
           password: ${{ env.PASSWORD }}
 
-      - name: Extract Docker metadata
+      - name: 🏷️ Extract Docker metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
@@ -43,13 +43,13 @@ jobs:
           tags: |
             type=sha,enable=true,priority=100,prefix=,suffix=,format=long
 
-      - name: Env
+      - name: 📝 Env
         id: env
         run: |
           echo "EXPO_PUBLIC_RELEASE_VERSION=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
           echo "EXPO_PUBLIC_BUNDLE_IDENTIFIER=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Build and push Docker image
+      - name: 🚀 Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:

--- a/.github/workflows/build-and-push-bskyweb-ghcr.yaml
+++ b/.github/workflows/build-and-push-bskyweb-ghcr.yaml
@@ -22,20 +22,20 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout repository
+      - name: ⬇️ Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Docker buildx
+      - name: 🔧 Setup Docker buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Log into registry ${{ env.REGISTRY }}
+      - name: 🔑 Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.USERNAME }}
           password: ${{ env.PASSWORD }}
 
-      - name: Extract Docker metadata
+      - name: 🏷️ Extract Docker metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
@@ -44,7 +44,7 @@ jobs:
           tags: |
             type=sha,enable=true,priority=100,prefix=bskyweb:,suffix=,format=long
 
-      - name: Build and push Docker image
+      - name: 🚀 Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:

--- a/.github/workflows/build-and-push-embedr-aws.yaml
+++ b/.github/workflows/build-and-push-embedr-aws.yaml
@@ -21,20 +21,20 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout repository
+      - name: ⬇️ Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Docker buildx
+      - name: 🔧 Setup Docker buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Log into registry ${{ env.REGISTRY }}
+      - name: 🔑 Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.USERNAME}}
           password: ${{ env.PASSWORD }}
 
-      - name: Extract Docker metadata
+      - name: 🏷️ Extract Docker metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
@@ -43,7 +43,7 @@ jobs:
           tags: |
             type=sha,enable=true,priority=100,prefix=,suffix=,format=long
 
-      - name: Build and push Docker image
+      - name: 🚀 Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:

--- a/.github/workflows/build-and-push-link-aws.yaml
+++ b/.github/workflows/build-and-push-link-aws.yaml
@@ -21,20 +21,20 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout repository
+      - name: ⬇️ Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Docker buildx
+      - name: 🔧 Setup Docker buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Log into registry ${{ env.REGISTRY }}
+      - name: 🔑 Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.USERNAME}}
           password: ${{ env.PASSWORD }}
 
-      - name: Extract Docker metadata
+      - name: 🏷️ Extract Docker metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
@@ -43,7 +43,7 @@ jobs:
           tags: |
             type=sha,enable=true,priority=100,prefix=,suffix=,format=long
 
-      - name: Build and push Docker image
+      - name: 🚀 Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:

--- a/.github/workflows/build-and-push-ogcard-aws.yaml
+++ b/.github/workflows/build-and-push-ogcard-aws.yaml
@@ -21,20 +21,20 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout repository
+      - name: ⬇️ Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Docker buildx
+      - name: 🔧 Setup Docker buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Log into registry ${{ env.REGISTRY }}
+      - name: 🔑 Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.USERNAME}}
           password: ${{ env.PASSWORD }}
 
-      - name: Extract Docker metadata
+      - name: 🏷️ Extract Docker metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
@@ -43,7 +43,7 @@ jobs:
           tags: |
             type=sha,enable=true,priority=100,prefix=,suffix=,format=long
 
-      - name: Build and push Docker image
+      - name: 🚀 Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -48,7 +48,7 @@ jobs:
         steps.version.outputs.version-changed }}
 
     steps:
-      - name: Check for EXPO_TOKEN
+      - name: 🔑 Check for EXPO_TOKEN
         run: >
           if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then
             echo "You must provide an EXPO_TOKEN secret linked to this project's Expo account in this repo's secrets. Learn more: https://docs.expo.dev/eas-update/github-actions"
@@ -159,13 +159,13 @@ jobs:
       - name: 🔤 Compile translations
         uses: ./.github/actions/compile-i18n
 
-      - name: Lint check
+      - name: 🧹 Lint check
         run: pnpm lint
 
-      - name: Prettier check
+      - name: 💅 Prettier check
         run: pnpm prettier --check .
 
-      - name: Type check
+      - name: 🔎 Type check
         run: pnpm typecheck
 
       - name: 🔨 Setup EAS

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -53,18 +53,18 @@ jobs:
       cancel-in-progress: false
 
     steps:
-      - name: Checkout repository
+      - name: ⬇️ Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
 
-      - name: Configure AWS credentials (OIDC)
+      - name: ☁️ Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: ${{ secrets.AWS_BEDROCK_REVIEW_ROLE_ARN }}
           aws-region: us-east-2
 
-      - name: Claude
+      - name: 🤖 Claude
         uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1.0.171
         with:
           use_bedrock: 'true'

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -39,18 +39,18 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - name: Checkout repository
+      - name: ⬇️ Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
 
-      - name: Configure AWS credentials (OIDC)
+      - name: ☁️ Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: ${{ secrets.AWS_BEDROCK_REVIEW_ROLE_ARN }}
           aws-region: us-east-2
 
-      - name: Claude review
+      - name: 🤖 Claude review
         uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1.0.171
         with:
           use_bedrock: 'true'

--- a/.github/workflows/golang-test-lint.yml
+++ b/.github/workflows/golang-test-lint.yml
@@ -17,32 +17,32 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Git Checkout
+      - name: ⬇️ Git Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Set up Go tooling
+      - name: 🔧 Set up Go tooling
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: bskyweb/go.mod
           cache-dependency-path: bskyweb/go.sum
-      - name: Dummy Static Files
+      - name: 📄 Dummy Static Files
         run: touch bskyweb/static/js/blah.js && touch bskyweb/static/css/blah.txt && touch bskyweb/static/media/blah.txt
-      - name: Check
+      - name: 🔍 Check
         run: cd bskyweb/ && make check
-      - name: Build (binary)
+      - name: 🏗️ Build (binary)
         run: cd bskyweb/ && make build
-      - name: Test
+      - name: 🧪 Test
         run: cd bskyweb/ && make test
   lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Git Checkout
+      - name: ⬇️ Git Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Set up Go tooling
+      - name: 🔧 Set up Go tooling
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: bskyweb/go.mod
           cache-dependency-path: bskyweb/go.sum
-      - name: Dummy Static Files
+      - name: 📄 Dummy Static Files
         run: touch bskyweb/static/js/blah.js && touch bskyweb/static/css/blah.txt && touch bskyweb/static/media/blah.txt
-      - name: Lint
+      - name: 🧹 Lint
         run: cd bskyweb/ &&  make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,9 +24,9 @@ jobs:
         job:
           [lint, prettier, 'typecheck:ios', 'typecheck:android', 'typecheck:web']
     steps:
-      - name: Check out Git repository
+      - name: ⬇️ Check out Git repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Verify Node version pins match package.json
+      - name: 🔍 Verify Node version pins match package.json
         run: |
           set -euo pipefail
           expected=$(node -p "require('./package.json').engines.node.replace(/[^0-9.]/g, '')")
@@ -52,16 +52,16 @@ jobs:
           check "eas.json" "$v"
           exit $rc
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - name: Install node
+      - name: 🔧 Install node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: package.json
           cache: pnpm
-      - name: pnpm install
+      - name: 📦 pnpm install
         run: pnpm install --frozen-lockfile
-      - name: Check & compile i18n
+      - name: 🔤 Check & compile i18n
         run: pnpm intl:build
-      - name: Lint checks
+      - name: 🧹 Lint checks
         run: pnpm ${{ matrix.job }}
   # Aggregates the matrix results into a single stable check name so branch
   # protection can require "Run linters" regardless of how many matrix jobs run.
@@ -73,7 +73,7 @@ jobs:
     needs: [linting]
     runs-on: ubuntu-latest
     steps:
-      - name: Require linting to have succeeded
+      - name: ✅ Require linting to have succeeded
         env:
           RESULT: ${{ needs.linting.result }}
         run: |
@@ -87,19 +87,19 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - name: Check out Git repository
+      - name: ⬇️ Check out Git repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - name: Install node
+      - name: 🔧 Install node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: package.json
           cache: pnpm
-      - name: pnpm install
+      - name: 📦 pnpm install
         run: pnpm install --frozen-lockfile
-      - name: Check & compile i18n
+      - name: 🔤 Check & compile i18n
         run: pnpm intl:build
-      - name: Run tests
+      - name: 🧪 Run tests
         run: |
           NODE_ENV=test pnpm test --forceExit --shard=${{ matrix.shard }}/${{ strategy.job-total }}
   # Aggregates the sharded test results into a single stable check name so branch
@@ -112,7 +112,7 @@ jobs:
     needs: [testing]
     runs-on: ubuntu-latest
     steps:
-      - name: Require testing to have succeeded
+      - name: ✅ Require testing to have succeeded
         env:
           RESULT: ${{ needs.testing.result }}
         run: |

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -28,41 +28,41 @@ jobs:
     runs-on: macos-26-xlarge
     timeout-minutes: 120
     steps:
-      - name: Checkout
+      - name: ⬇️ Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - name: Select Xcode 26.4
+      - name: 🛠️ Select Xcode 26.4
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: "26.4"
 
-      - name: Prepare E2E configuration
+      - name: 🧰 Prepare E2E configuration
         run: |
           mkdir -p artifacts/ios
           echo "Installing dependencies" > artifacts/ios/phase.txt
           cp .env.example .env.development
           cp google-services.json.example google-services.json
 
-      - name: Set up Expo project
+      - name: 🔧 Set up Expo project
         uses: ./.github/actions/setup-expo-project
         with:
           expo-token: ${{ secrets.EXPO_TOKEN }}
 
-      - name: Set up Java 17
+      - name: ☕️ Set up Java 17
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           distribution: temurin
           java-version: "17"
 
-      - name: Install dev-env dependencies
+      - name: 📦 Install dev-env dependencies
         run: pnpm --dir dev-env install --frozen-lockfile 2>&1 | tee artifacts/ios/dependencies.log
 
-      - name: Compile translations
+      - name: 🔤 Compile translations
         uses: ./.github/actions/compile-i18n
 
-      - name: Install Maestro 2.6.1
+      - name: 📥 Install Maestro 2.6.1
         run: |
           echo "Installing Maestro" > artifacts/ios/phase.txt
           curl -fsSL -o "$RUNNER_TEMP/maestro.zip" \
@@ -74,7 +74,7 @@ jobs:
           "$RUNNER_TEMP/maestro/bin/maestro" --version | tee artifacts/ios/maestro-version.log
           test "$("$RUNNER_TEMP/maestro/bin/maestro" --version)" = "$MAESTRO_VERSION"
 
-      - name: Boot one iOS simulator
+      - name: 📱 Boot one iOS simulator
         run: |
           echo "Booting iOS simulator" > artifacts/ios/phase.txt
           device_name="iPhone 17"
@@ -112,10 +112,10 @@ jobs:
           xcrun simctl bootstatus "$udid" -b
           echo "Using $device_name on $runtime_name ($udid)"
 
-      - name: Mark iOS development client build phase
+      - name: 🏷️ Mark iOS development client build phase
         run: echo "Building the iOS development client" > artifacts/ios/phase.txt
 
-      - name: Build iOS development client
+      - name: 🏗️ Build iOS development client
         uses: ./.github/actions/eas-local-build
         with:
           platform: ios
@@ -123,7 +123,7 @@ jobs:
           output: ${{ runner.temp }}/nightly-e2e-ios.tar.gz
           log-path: artifacts/ios/build.log
 
-      - name: Install iOS development client
+      - name: 📲 Install iOS development client
         run: |
           build_contents="$RUNNER_TEMP/nightly-e2e-ios-build"
           mkdir -p "$build_contents"
@@ -135,14 +135,14 @@ jobs:
           fi
           xcrun simctl install "$IOS_UDID" "$app_path" 2>&1 | tee -a artifacts/ios/build.log
 
-      - name: Run iOS Maestro suite
+      - name: 🧪 Run iOS Maestro suite
         run: .github/scripts/run-nightly-e2e.sh ios "$IOS_UDID"
 
-      - name: Clean up iOS services and simulator
+      - name: 🧹 Clean up iOS services and simulator
         if: always()
         run: .github/scripts/cleanup-nightly-e2e.sh ios "${IOS_UDID:-}"
 
-      - name: Upload iOS E2E artifacts
+      - name: 🚀 Upload iOS E2E artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -158,36 +158,36 @@ jobs:
     runs-on: Linux-x64-32core
     timeout-minutes: 120
     steps:
-      - name: Checkout
+      - name: ⬇️ Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - name: Prepare E2E configuration
+      - name: 🧰 Prepare E2E configuration
         run: |
           mkdir -p artifacts/android
           echo "Installing dependencies" > artifacts/android/phase.txt
           cp .env.example .env.development
           cp google-services.json.example google-services.json
 
-      - name: Set up Expo project
+      - name: 🔧 Set up Expo project
         uses: ./.github/actions/setup-expo-project
         with:
           expo-token: ${{ secrets.EXPO_TOKEN }}
 
-      - name: Set up Java 17
+      - name: ☕️ Set up Java 17
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           distribution: temurin
           java-version: "17"
 
-      - name: Install dev-env dependencies
+      - name: 📦 Install dev-env dependencies
         run: pnpm --dir dev-env install --frozen-lockfile 2>&1 | tee artifacts/android/dependencies.log
 
-      - name: Compile translations
+      - name: 🔤 Compile translations
         uses: ./.github/actions/compile-i18n
 
-      - name: Install Maestro 2.6.1
+      - name: 📥 Install Maestro 2.6.1
         run: |
           echo "Installing Maestro" > artifacts/android/phase.txt
           curl -fsSL -o "$RUNNER_TEMP/maestro.zip" \
@@ -199,7 +199,7 @@ jobs:
           "$RUNNER_TEMP/maestro/bin/maestro" --version | tee artifacts/android/maestro-version.log
           test "$("$RUNNER_TEMP/maestro/bin/maestro" --version)" = "$MAESTRO_VERSION"
 
-      - name: Install and boot one Android emulator
+      - name: 📱 Install and boot one Android emulator
         run: |
           echo "Booting Android emulator" > artifacts/android/phase.txt
           android_sdk="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-/usr/local/lib/android/sdk}}"
@@ -299,10 +299,10 @@ jobs:
           adb -s emulator-5554 shell settings put global transition_animation_scale 0
           adb -s emulator-5554 shell settings put global animator_duration_scale 0
 
-      - name: Mark Android development client build phase
+      - name: 🏷️ Mark Android development client build phase
         run: echo "Building the Android development client" > artifacts/android/phase.txt
 
-      - name: Build Android development client
+      - name: 🏗️ Build Android development client
         uses: ./.github/actions/eas-local-build
         with:
           platform: android
@@ -310,15 +310,15 @@ jobs:
           output: ${{ runner.temp }}/nightly-e2e-android.apk
           log-path: artifacts/android/build.log
 
-      - name: Install Android development client
+      - name: 📲 Install Android development client
         run: |
           adb -s emulator-5554 install -r "$RUNNER_TEMP/nightly-e2e-android.apk" \
             2>&1 | tee -a artifacts/android/build.log
 
-      - name: Run Android Maestro suite
+      - name: 🧪 Run Android Maestro suite
         run: .github/scripts/run-nightly-e2e.sh android emulator-5554
 
-      - name: Capture emulator crash diagnostics
+      - name: 🩺 Capture emulator crash diagnostics
         if: always()
         run: |
           {
@@ -338,11 +338,11 @@ jobs:
             ls -la /tmp/android-runner/emu-crash-*.db 2>/dev/null || echo "No crash database found"
           } > artifacts/android/emulator-diagnostics.log 2>&1
 
-      - name: Clean up Android services and emulator
+      - name: 🧹 Clean up Android services and emulator
         if: always()
         run: .github/scripts/cleanup-nightly-e2e.sh android emulator-5554
 
-      - name: Upload Android E2E artifacts
+      - name: 🚀 Upload Android E2E artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -360,26 +360,26 @@ jobs:
       actions: read
       contents: read
     steps:
-      - name: Checkout
+      - name: ⬇️ Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - name: Download iOS artifacts
+      - name: ⬇️ Download iOS artifacts
         continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nightly-e2e-ios-${{ github.run_id }}
           path: downloaded-artifacts/ios
 
-      - name: Download Android artifacts
+      - name: ⬇️ Download Android artifacts
         continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nightly-e2e-android-${{ github.run_id }}
           path: downloaded-artifacts/android
 
-      - name: Resolve artifact links
+      - name: 🔗 Resolve artifact links
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -395,7 +395,7 @@ jobs:
               }' artifact-response.json > artifact-links.json
           fi
 
-      - name: Summarize platform results
+      - name: 📊 Summarize platform results
         id: summary
         env:
           IOS_STATUS: ${{ needs.ios.result }}
@@ -415,7 +415,7 @@ jobs:
           echo "payload=$(jq -c .payload e2e-summary.json)" >> "$GITHUB_OUTPUT"
           jq -r .githubSummary e2e-summary.json >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Notify Slack of E2E failures
+      - name: 🔔 Notify Slack of E2E failures
         if: steps.summary.outputs.notify == 'true'
         uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
         with:

--- a/.github/workflows/nightly-update-source-languages.yaml
+++ b/.github/workflows/nightly-update-source-languages.yaml
@@ -15,26 +15,26 @@ jobs:
       contents: write
 
     steps:
-      - name: Check out Git repository
+      - name: ⬇️ Check out Git repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ssh-key: ${{secrets.GH_ACTION_DEPLOY_KEY}}
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - name: Install node
+      - name: 🔧 Install node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: package.json
           cache: pnpm
-      - name: pnpm install
+      - name: 📦 pnpm install
         run: pnpm install --frozen-lockfile
-      - name: Extract language strings
+      - name: 🔤 Extract language strings
         run: pnpm intl:extract
-      - name: Create commit
+      - name: 📝 Create commit
         uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: Nightly source-language update
           file_pattern: ./src/locale/locales/en/messages.po
-      - name: Push source lang to Crowdin
+      - name: 🚀 Push source lang to Crowdin
         uses: crowdin/github-action@52aa776766211d83d975df51f3b9c53c2f8ba35f # v2.16.3
         with:
           upload_sources: true

--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -83,7 +83,7 @@ jobs:
           node-version-file: package.json
           cache: pnpm
 
-      - name: Ensure tracking relevant branches and checkout base
+      - name: 🌿 Ensure tracking relevant branches and checkout base
         env:
           HEAD_REF: ${{ github.head_ref }}
           BASE_REF: ${{ github.base_ref }}
@@ -91,13 +91,13 @@ jobs:
           git checkout $HEAD_REF
           git checkout $BASE_REF
 
-      - name: Get the base commit
+      - name: 🔍 Get the base commit
         id: base-commit
         env:
           BASE_REF: ${{ github.base_ref }}
         run: echo base-commit=$(git log -n 1 $BASE_REF --pretty=format:'%H') >> "$GITHUB_OUTPUT"
 
-      - name: Merge PR commit
+      - name: 🔀 Merge PR commit
         env:
           HEAD_REF: ${{ github.head_ref }}
         run: |
@@ -121,7 +121,7 @@ jobs:
           path: stats.json
           key: stats-base-main-${{ steps.base-commit.outputs.base-commit }}
 
-      - name: Restore to base commit
+      - name: ⏪ Restore to base commit
         if: ${{ !steps.get-base-stats.outputs.cache-hit }}
         env:
           BASE_COMMIT: ${{ steps.base-commit.outputs.base-commit }}

--- a/.github/workflows/sync-internal.yaml
+++ b/.github/workflows/sync-internal.yaml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'bluesky-social/social-app'
     steps:
-      - name: Checkout public repo
+      - name: ⬇️ Checkout public repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           # Don't persist the checkout auth header; the push below authenticates
           # with the app token embedded in the remote URL instead
           persist-credentials: false
-      - name: Generate GitHub App Token
+      - name: 🔑 Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -33,7 +33,7 @@ jobs:
           # .github/workflows/, which GitHub refuses to push without it.
           permission-contents: write
           permission-workflows: write
-      - name: Push to internal repo
+      - name: 🚀 Push to internal repo
         env:
           TOKEN: ${{ steps.app-token.outputs.token }}
         run: |

--- a/.github/workflows/verify-pnpm-lock.yml
+++ b/.github/workflows/verify-pnpm-lock.yml
@@ -14,33 +14,33 @@ jobs:
     name: No manual pnpm-lock.yaml edits
     runs-on: ubuntu-latest
     steps:
-      - name: Check out PR HEAD
+      - name: ⬇️ Check out PR HEAD
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
-      - name: Fetch base branch
+      - name: ⬇️ Fetch base branch
         env:
           BASE_REF: ${{ github.base_ref }}
         run: git fetch origin $BASE_REF --depth=1
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
-      - name: Install node
+      - name: 🔧 Install node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: package.json
 
-      - name: Reset pnpm-lock.yaml to base
+      - name: ⏪ Reset pnpm-lock.yaml to base
         env:
           BASE_REF: ${{ github.base_ref }}
         run: git show "origin/$BASE_REF:pnpm-lock.yaml" > pnpm-lock.yaml
 
-      - name: pnpm install
+      - name: 📦 pnpm install
         # Fine to skip scripts since we don't run any code
         run: pnpm clean && pnpm install --ignore-scripts --no-frozen-lockfile
 
-      - name: Verify pnpm-lock.yaml
+      - name: 🔍 Verify pnpm-lock.yaml
         run: |
           git diff --quiet --exit-code || {
             echo '::error::`pnpm-lock.yaml` does not match what pnpm would generate given the base `pnpm-lock.yaml` and the head `package.json`.'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -20,12 +20,12 @@ jobs:
     name: Audit workflows with zizmor
     runs-on: ubuntu-latest
     steps:
-      - name: Check out Git repository
+      - name: ⬇️ Check out Git repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - name: Run zizmor
+      - name: 🛡️ Run zizmor
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:
           # Annotate the PR directly instead of uploading SARIF to the


### PR DESCRIPTION
Several workflows were missing the emoji-prefixed step naming used
elsewhere (e.g. nightly-build.yml, build-submit-ios/android.yml), and
a couple of files that already used emoji had a few gaps. Fills those
in across all workflow files. Job-level `name:` fields are left
untouched since some are pinned as required branch-protection check
names.