### PR TITLE
Fix legacy ota1 OTA upload broken by the denis cutover

### DIFF
--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -204,20 +204,19 @@ jobs:
           SENTRY_DIST=${{ steps.env.outputs.bundle-identifier }}
           pnpm export
 
-      - name: 📦 Package Bundle and 🚀 Deploy
-        if: ${{ !steps.fingerprint.outputs.includes-changes &&
-          !steps.version.outputs.version-changed }}
-        run: pnpm use-build-number bash scripts/bundleUpdate.sh
-        env:
-          DENIS_API_KEY: ${{ secrets.DENIS_API_KEY }}
-          RUNTIME_VERSION: ${{ inputs.runtimeVersion }}
-          CHANNEL_NAME: ${{ inputs.channel || 'testflight' }}
-
-      # The three steps below dual-write the same exported bundle to the new
-      # denis/S3 service alongside the legacy ota1 upload above. This is a
-      # deliberate temporary dual-write during the ota1 -> denis migration:
-      # both paths run and both must succeed. The legacy step above and this
-      # block are removed together once denis is the sole origin (Phase 5).
+      # denis on EKS has been the sole origin for updates.bsky.app since
+      # 2026-07-26, so it publishes FIRST: it is the path that actually serves
+      # clients. The legacy ota1 upload runs after it, and exists only so that
+      # rolling the Bunny origin back to ota1 would find current bundles there.
+      #
+      # The ordering is load-bearing, not cosmetic. While the legacy step ran
+      # first, its failure skipped these steps and nothing reached EITHER origin
+      # -- the dual-write took down the working path with it. Both steps are
+      # still required to pass, so a stale ota1 remains a loud failure, but the
+      # publish that serves users has already landed before the legacy one can
+      # fail.
+      #
+      # Both halves are removed together when ota1 is decommissioned (Phase 5).
       - name: ☁️ Configure AWS credentials (denis)
         if: ${{ !steps.fingerprint.outputs.includes-changes &&
           !steps.version.outputs.version-changed }}
@@ -240,6 +239,15 @@ jobs:
           !steps.version.outputs.version-changed }}
         run: pnpm use-build-number bash scripts/denisPublish.sh
         env:
+          RUNTIME_VERSION: ${{ inputs.runtimeVersion }}
+          CHANNEL_NAME: ${{ inputs.channel || 'testflight' }}
+
+      - name: 📦 Package Bundle and 🚀 Deploy (legacy ota1)
+        if: ${{ !steps.fingerprint.outputs.includes-changes &&
+          !steps.version.outputs.version-changed }}
+        run: pnpm use-build-number bash scripts/bundleUpdate.sh
+        env:
+          DENIS_API_KEY: ${{ secrets.DENIS_API_KEY }}
           RUNTIME_VERSION: ${{ inputs.runtimeVersion }}
           CHANNEL_NAME: ${{ inputs.channel || 'testflight' }}
 

--- a/scripts/bundleUpdate.sh
+++ b/scripts/bundleUpdate.sh
@@ -15,7 +15,21 @@ fi
 
 cd bundleTempDir || exit
 BUNDLE_VERSION=$(date +%s)
-DEPLOYMENT_URL="https://updates.bsky.app/v1/upload?runtime-version=$RUNTIME_VERSION&bundle-version=$BUNDLE_VERSION&channel=$CHANNEL_NAME&ios-build-number=$BSKY_IOS_BUILD_NUMBER&android-build-number=$BSKY_ANDROID_VERSION_CODE"
+
+# This MUST address ota1's own origin hostname, never updates.bsky.app.
+#
+# Since the 2026-07-26 cutover updates.bsky.app resolves to denis on EKS, which
+# deliberately has no /v1/upload route -- publishing there is out-of-band via
+# `denis publish` (see denisPublish.sh). Posting to the CDN hostname therefore
+# returns 404, which is what broke this step the first time it ran after the
+# flip. The dual-write was never independent of the cutover precisely because it
+# addressed the hostname being cut over.
+#
+# This upload exists only to keep ota1 carrying current bundles so a rollback of
+# the Bunny origin remains useful. It goes away with this whole script when ota1
+# is decommissioned (Phase 5).
+OTA1_ORIGIN="${OTA1_ORIGIN:-https://ota1.us-east.updates.bsky.network}"
+DEPLOYMENT_URL="$OTA1_ORIGIN/v1/upload?runtime-version=$RUNTIME_VERSION&bundle-version=$BUNDLE_VERSION&channel=$CHANNEL_NAME&ios-build-number=$BSKY_IOS_BUILD_NUMBER&android-build-number=$BSKY_ANDROID_VERSION_CODE"
 
 tar czvf bundle.tar.gz ./*
 


### PR DESCRIPTION
OTA publishing from `main` is currently broken. Fixes it.

## What broke

[Run 30220289826](https://github.com/bluesky-social/social-app/actions/runs/30220289826) —
the `📦 Package Bundle and 🚀 Deploy` step:

```
Deploying to https://updates.bsky.app/v1/upload?runtime-version=1.130.0&...
ERROR: code=404, message=Not Found
curl: (22) The requested URL returned error: 404
```

`bundleUpdate.sh` posted the legacy dual-write to `updates.bsky.app`. Since the
2026-07-26 origin cutover that hostname resolves to denis on EKS, which
deliberately has no `/v1/upload` route — publishing there is out-of-band via
`denis publish`. So the legacy leg 404s.

The dual-write was never independent of the cutover: it wrote to ota1 **through
the hostname being cut over**, so flipping the origin was guaranteed to break it.

Confirmed:

| Endpoint | Status |
| --- | --- |
| `updates.bsky.app/v1/upload` | 404 — route gone |
| `ota1.us-east.updates.bsky.network/v1/upload` | 401 — route present, auth required |

This surfaced only now because the two runs between the cutover and this one had
fingerprint changes, took the native-rebuild path, and skipped the OTA steps
entirely. Run 30220289826 was the first actual OTA publish attempt after the
flip.

## The more serious half

The legacy step ran **before** the three denis steps, so when it 404'd the denis
steps were skipped and the bundle reached **neither** origin. A dual-write that
takes down the working path when its deprecated half fails is worse than no
dual-write.

So this also reorders them: denis publishes first, since it is the sole origin
actually serving clients. The legacy ota1 upload runs after and is still required
to pass, so a stale ota1 stays a loud failure rather than a silent one — but the
publish users depend on has already landed before the legacy one can fail.

The two scripts are independent (each assembles its own `bundleTempDir` via
`scripts/bundleUpdate.js` and cleans up after itself), so the reorder is safe.

## Changes

- `scripts/bundleUpdate.sh` — target ota1's own origin, overridable via
  `OTA1_ORIGIN`, with a comment explaining why it must never be pointed back at
  the CDN hostname.
- `.github/workflows/bundle-deploy-eas-update.yml` — denis publish before legacy
  upload; replace the now-inaccurate dual-write comment (it described denis as
  the addition alongside ota1, which is backwards now, and said the block is
  removed "once denis is the sole origin" — denis has been the sole origin since
  2026-07-26).

Both halves are removed together when ota1 is decommissioned (Phase 5).

## Verification

`shellcheck` clean; workflow YAML parses with step order and `env` blocks intact;
constructed URL checked:

```
https://ota1.us-east.updates.bsky.network/v1/upload?runtime-version=1.130.0&bundle-version=...&channel=testflight&ios-build-number=1976&android-build-number=1471
```

The upload itself could not be exercised locally — it needs `DENIS_API_KEY` and a
real bundle, so the first run on merge is the real test. Note the ordering change
contains that risk: if the key turns out to be stale, the legacy step 401s
*after* the denis publish has already succeeded, rather than blocking it.

## Follow-up, not fixed here

`bundleUpdate.sh` and `denisPublish.sh` each compute their own
`BUNDLE_VERSION=$(date +%s)`, seconds apart, so the two origins receive different
bundle versions for the same commit. Content and update ID still agree (the
manifest ID hashes `metadata.json`), but asset URLs embed the bundle version, so
the served manifests differ between origins. Harmless while denis is sole origin,
and moot once ota1 is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
