### PR TITLE
Publish one bundle version to both OTA origins, not two

### DIFF
--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -204,6 +204,18 @@ jobs:
           SENTRY_DIST=${{ steps.env.outputs.bundle-identifier }}
           pnpm export
 
+      # Pin ONE bundle version for both publishes below. Each script used to call
+      # `date +%s` itself, so the same bytes reached denis and ota1 under versions
+      # seconds apart (observed: 1785102575 vs 1785102614). The version is part of
+      # the asset URL path, so each origin then served a manifest referencing a
+      # path only it had -- meaning a manifest fetched from one origin and assets
+      # fetched from the other 404. Both scripts fall back to `date +%s` when this
+      # is unset, so single-publisher callers are unaffected.
+      - name: 🔢 Pin bundle version
+        if: ${{ !steps.fingerprint.outputs.includes-changes &&
+          !steps.version.outputs.version-changed }}
+        run: echo "BUNDLE_VERSION=$(date +%s)" >> "$GITHUB_ENV"
+
       # denis on EKS has been the sole origin for updates.bsky.app since
       # 2026-07-26, so it publishes FIRST: it is the path that actually serves
       # clients. The legacy ota1 upload runs after it, and exists only so that

--- a/scripts/bundleUpdate.sh
+++ b/scripts/bundleUpdate.sh
@@ -14,7 +14,11 @@ if [ -z "$RUNTIME_VERSION" ]; then
 fi
 
 cd bundleTempDir || exit
-BUNDLE_VERSION=$(date +%s)
+
+# Shared with denisPublish.sh when both run in one job -- see the note there.
+# Both origins must receive the same bundle version for the same bytes, because
+# the version is part of the asset URL path.
+BUNDLE_VERSION="${BUNDLE_VERSION:-$(date +%s)}"
 
 # This MUST address ota1's own origin hostname, never updates.bsky.app.
 #

--- a/scripts/denisPublish.sh
+++ b/scripts/denisPublish.sh
@@ -19,7 +19,16 @@ if [ -z "$RUNTIME_VERSION" ]; then
   RUNTIME_VERSION=$(cat package.json | jq '.version' -r)
 fi
 
-BUNDLE_VERSION=$(date +%s)
+# Accept a caller-supplied bundle version so that a dual-write publishes the SAME
+# version to every origin. When this script and bundleUpdate.sh each called
+# `date +%s` independently they produced versions seconds apart for identical
+# bytes -- observed 1785102575 (denis) vs 1785102614 (ota1) for one commit. Since
+# the version is part of the asset URL path, the two origins then served
+# manifests pointing at paths only one of them had, so the manifest and its
+# assets had to come from the same origin or the fetch 404s. Falling back to
+# `date +%s` keeps standalone callers (PR previews, `pnpm make-deploy-bundle`)
+# working unchanged.
+BUNDLE_VERSION="${BUNDLE_VERSION:-$(date +%s)}"
 DENIS_CDN_DOMAIN="${DENIS_CDN_DOMAIN:-updates.bsky.app}"
 DENIS_S3_BUCKET="${DENIS_S3_BUCKET:-bsky-denis-ota-prod}"
 


### PR DESCRIPTION
A single dual-write publish gave the same bytes two different bundle versions,
because `bundleUpdate.sh` and `denisPublish.sh` each called `date +%s`.

Observed on the first post-cutover publish (commit b662cd43b, 1.130.0 testflight):

| Origin | bundle version | launch bundle hash |
| --- | --- | --- |
| denis | `1785102575` | `9abd402a964f349ba369969356e69afa` |
| ota1 | `1785102614` | `9abd402a964f349ba369969356e69afa` |

39 seconds apart. Identical content.

## Why this matters

The bundle version is a path segment in every asset URL the manifest hands the
client:

```
https://updates.bsky.app/file/1.130.0/<bundle-version>/bundles/<hash>
```

Both origins mint those URLs against `updates.bsky.app`, which resolves to
whichever origin Bunny currently points at. So each origin was serving a manifest
whose assets **only it has**. denis has no `1785102614`; ota1 has no `1785102575`.

A manifest fetched from one origin with assets fetched from the other 404s. That
is precisely what a rollback of the Bunny origin does if it lands between a
client's manifest fetch and its asset fetch. The dual-write exists to make
rollback safe, and it was quietly making it unsafe.

## Fix

Pin the version once per job and let both publishers inherit it:

```yaml
- name: 🔢 Pin bundle version
  run: echo "BUNDLE_VERSION=$(date +%s)" >> "$GITHUB_ENV"
```

Both scripts become `BUNDLE_VERSION="${BUNDLE_VERSION:-$(date +%s)}"`, so the
single-publisher callers keep working unchanged — `pull-request-commit.yml:324`
(denis only, no dual-write) and `pnpm make-deploy-bundle` in `package.json:92`.

The fallback uses `:-` rather than `-` so an empty value also falls back.
`denis publish` validates the bundle version as numeric, so an empty one must
never propagate.

## Verified

- Both scripts resolve to the same value when `BUNDLE_VERSION` is set
- Clean fallback when unset, no `set -o nounset` failure
- Empty string falls back rather than propagating
- Step order: `Create Bundle → Pin bundle version → Publish OTA to denis → Package Bundle (legacy ota1)`
- Workflow YAML parses (23 steps); `shellcheck` clean on both scripts

## What this does NOT fix

The manifests still are not byte-identical. `createdAt` differs — `21:49:35Z`
(denis) vs `21:50:18Z` (ota1) for the commit above — because ota1's legacy
uploader stamps it server-side on receipt. The client posts a tarball, not a
timestamp, so nothing on this side can align it. It disappears with the dual-write
in Phase 5.

That residual is inert in a way the bundle version was not. The manifest `id` is
content-addressed on `metadata.json` and is **identical** across both origins
(`cb66e5eb-03cb-e085…`), so denis's `currentUpdateID == entry.Manifest.ID` check
makes a client that switches origins see the same update rather than a newer one.
No re-download, no ordering confusion.

Practical note: `scripts/denis-parity.sh` in bsky-infra byte-compares manifests
between origins, so it will still report 2 mismatches per dual-written publish —
now on `createdAt` alone rather than on asset URLs. That is the script measuring
bytes where what matters is the update ID, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
