### PR TITLE
Reenable wake-from-background Android OTA

### DIFF
--- a/src/lib/hooks/useOTAUpdates.ts
+++ b/src/lib/hooks/useOTAUpdates.ts
@@ -12,7 +12,7 @@ import {
 
 import {isNetworkError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
-import {IS_ANDROID, IS_IOS, IS_TESTFLIGHT} from '#/env'
+import {IS_IOS, IS_TESTFLIGHT} from '#/env'
 
 const MINIMUM_MINIMIZE_TIME = 15 * 60e3
 
@@ -191,13 +191,6 @@ export function useOTAUpdates() {
     if (!isEnabled || currentChannel?.startsWith('pull-request')) {
       return
     }
-
-    // TEMP: disable wake-from-background OTA loading on Android.
-    // This is causing a crash when the thread view is open due to
-    // `maintainVisibleContentPosition`. See repro repo for more details:
-    // https://github.com/mozzius/ota-crash-repro
-    // Old Arch only - re-enable once we're on the New Archictecture! -sfn
-    if (IS_ANDROID) return
 
     const subscription = AppState.addEventListener(
       'change',


### PR DESCRIPTION
No longer crashes (confirmed when originally reproduced)