### PR TITLE
filter timed out network errors from sentry

### DIFF
--- a/src/lib/hooks/useCleanError.ts
+++ b/src/lib/hooks/useCleanError.ts
@@ -1,6 +1,8 @@
 import {useCallback} from 'react'
 import {useLingui} from '@lingui/react/macro'
 
+import {NETWORK_ERRORS} from '#/lib/strings/errors'
+
 type CleanedError = {
   raw: string | undefined
   clean: string | undefined
@@ -81,14 +83,6 @@ export function useCleanError() {
     [l],
   )
 }
-
-const NETWORK_ERRORS = [
-  'Abort',
-  'Network request failed',
-  'Failed to fetch',
-  'Load failed',
-  'Upstream service unreachable',
-]
 
 export function isNetworkError(e: unknown) {
   const str = String(e)

--- a/src/lib/strings/errors.ts
+++ b/src/lib/strings/errors.ts
@@ -79,7 +79,7 @@ export function cleanError(e: unknown): string {
   return toDisplayString(e, str)
 }
 
-const NETWORK_ERRORS = [
+export const NETWORK_ERRORS = [
   'Abort',
   'Network request failed',
   'Network request timed out',

--- a/src/lib/strings/errors.ts
+++ b/src/lib/strings/errors.ts
@@ -82,6 +82,7 @@ export function cleanError(e: unknown): string {
 const NETWORK_ERRORS = [
   'Abort',
   'Network request failed',
+  'Network request timed out',
   'Failed to fetch',
   'Load failed',
   'Upstream service unreachable',

--- a/src/logger/__tests__/logger.test.ts
+++ b/src/logger/__tests__/logger.test.ts
@@ -292,6 +292,14 @@ describe('general functionality', () => {
       timestamp,
     )
 
+    sentryTransport(
+      LogLevel.Error,
+      Logger.Context.Default,
+      'Network request timed out',
+      {},
+      timestamp,
+    )
+
     // network error in metadata, message is something else
     sentryTransport(
       LogLevel.Error,

--- a/src/logger/sentry/setup/index.ts
+++ b/src/logger/sentry/setup/index.ts
@@ -20,6 +20,7 @@ init({
      * Un-useful errors
      */
     `Network request failed`,
+    `Network request timed out`,
   ],
   /**
    * Does not affect traces of error events or other logs, just disables


### PR DESCRIPTION
## Summary

- ignore the whatwg-fetch Network request timed out exception in Sentry SDK configuration
- classify the same message as a network error in application logging
- cover the logger transport behavior with a test

Sentry issue: https://blueskyweb.sentry.io/issues/7512863665/

## Test plan

- pnpm test src/logger/__tests__/logger.test.ts --runInBand --no-watchman