### PR TITLE
Fix caret misplaced upon pressing Return when using Japanese symbols …

### DIFF
--- a/.github/workflows/build-submit-ios.yml
+++ b/.github/workflows/build-submit-ios.yml
@@ -18,6 +18,11 @@ on:
           - QA Team
           - Software Mansion
         default: none
+      changelog:
+        type: string
+        description: TestFlight "What to Test" notes (only applied when a group is selected)
+        required: false
+        default: ''
   workflow_call:
     inputs:
       profile:
@@ -270,6 +275,7 @@ jobs:
       - name: 🧪 Assign build to TestFlight group
         env:
           TESTFLIGHT_GROUP: ${{ inputs.testFlightGroup }}
+          CHANGELOG: ${{ inputs.changelog }}
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
           ASC_KEY_P8_BASE64: ${{ secrets.ASC_KEY_P8_BASE64 }}
@@ -288,6 +294,12 @@ jobs:
             --arg key "$key_content" \
             '{key_id: $key_id, issuer_id: $issuer_id, key: $key, in_house: false}' \
             > asc_api_key.json
+          # changelog is optional, and passing it empty would blank out whatever "What to
+          # Test" notes the build already has, so only include the flag when it is set.
+          changelog_arg=()
+          if [ -n "$CHANGELOG" ]; then
+            changelog_arg=(changelog:"$CHANGELOG")
+          fi
           # app_platform is required in non-interactive mode: distribute_only otherwise
           # calls fetch_app_platform, which prompts for input and crashes without a TTY.
           fastlane run upload_to_testflight \
@@ -298,4 +310,5 @@ jobs:
             app_version:"$APP_VERSION" \
             build_number:"$BUILD_NUMBER" \
             groups:"$TESTFLIGHT_GROUP" \
-            notify_external_testers:true
+            notify_external_testers:true \
+            "${changelog_arg[@]}"

--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -26,7 +26,7 @@ import {
 } from '#/view/com/composer/text-input/text-input-util'
 import {atoms as a, useAlf} from '#/alf'
 import {normalizeTextStyles} from '#/alf/typography'
-import {IS_ANDROID, IS_NATIVE} from '#/env'
+import {IS_ANDROID} from '#/env'
 import {Autocomplete} from './mobile/Autocomplete'
 import {type TextInputProps} from './TextInput.types'
 
@@ -170,13 +170,6 @@ export function TextInput({
         flags: {},
       },
     )
-
-    /**
-     * PasteInput doesn't like `lineHeight`, results in jumpiness
-     */
-    if (IS_NATIVE) {
-      style.lineHeight = undefined
-    }
 
     /*
      * Android impl of `PasteInput` doesn't support the array syntax for `fontVariant`


### PR DESCRIPTION
…only


https://github.com/bluesky-social/social-app/pull/11316#issue-4999834170

https://linear.app/blueskyweb/issue/APP-2762/new-arch-ios-composer-caret-is-drawn-in-the-wrong-place-after-return
https://linear.app/blueskyweb/issue/APP-2763/new-arch-ios-composer-bottom-line-of-a-long-japanese-post-gets-clipped