### PR TITLE
Get number of trending topics for Explore from GrowthBook

### DIFF
--- a/src/analytics/features/types.ts
+++ b/src/analytics/features/types.ts
@@ -25,6 +25,7 @@ export enum Features {
 
   // values
   TrendingDiscoverValues = 'trending_discover:values',
+  TrendingExploreTopicsCountValue = 'trending_explore_topics_count:value',
 
   AATest = 'aa-test',
 }

--- a/src/screens/Search/modules/ExploreTrendingTopics.tsx
+++ b/src/screens/Search/modules/ExploreTrendingTopics.tsx
@@ -13,7 +13,10 @@ import {
   useTrendingSettings,
   useTrendingSettingsApi,
 } from '#/state/preferences/trending'
-import {useGetTrendsQuery} from '#/state/queries/trending/useGetTrendsQuery'
+import {
+  DEFAULT_LIMIT,
+  useGetTrendsQuery,
+} from '#/state/queries/trending/useGetTrendsQuery'
 import {useTrendingConfig} from '#/state/service-config'
 import {LoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
 import {formatCount} from '#/view/com/util/numeric/format'
@@ -29,8 +32,6 @@ import {Text} from '#/components/Typography'
 import {useAnalytics} from '#/analytics'
 import * as ModuleHeader from '../components/ModuleHeader'
 
-const TOPIC_COUNT = 10
-
 const IMAGE_SIZE = 56
 
 export function ExploreTrendingTopics() {
@@ -42,6 +43,12 @@ export function ExploreTrendingTopics() {
 function Inner() {
   const ax = useAnalytics()
   const {t: l} = useLingui()
+
+  const topicCount = ax.features.getValue(
+    ax.features.TrendingDiscoverValues,
+    DEFAULT_LIMIT,
+  )
+
   const trendingPrompt = Prompt.usePromptControl()
   const {setTrendingDisabled} = useTrendingSettingsApi()
   const {
@@ -49,7 +56,7 @@ function Inner() {
     error,
     isLoading,
     isRefetching,
-  } = useGetTrendsQuery({limit: TOPIC_COUNT})
+  } = useGetTrendsQuery({limit: topicCount})
   const noTopics = !isLoading && !error && !trending?.trends?.length
   const showLoading = isLoading || isRefetching
 
@@ -69,7 +76,7 @@ function Inner() {
           />
         </ModuleHeader.Container>
         {showLoading
-          ? Array.from({length: TOPIC_COUNT}).map((__, i) => (
+          ? Array.from({length: topicCount}).map((__, i) => (
               <TrendingTopicRowSkeleton key={i} />
             ))
           : trending?.trends.map((trend, index) => (

--- a/src/screens/Search/modules/ExploreTrendingTopics.tsx
+++ b/src/screens/Search/modules/ExploreTrendingTopics.tsx
@@ -29,7 +29,7 @@ import {Text} from '#/components/Typography'
 import {useAnalytics} from '#/analytics'
 import * as ModuleHeader from '../components/ModuleHeader'
 
-const TOPIC_COUNT = 5
+const TOPIC_COUNT = 10
 
 const IMAGE_SIZE = 56
 
@@ -44,7 +44,12 @@ function Inner() {
   const {t: l} = useLingui()
   const trendingPrompt = Prompt.usePromptControl()
   const {setTrendingDisabled} = useTrendingSettingsApi()
-  const {data: trending, error, isLoading, isRefetching} = useGetTrendsQuery()
+  const {
+    data: trending,
+    error,
+    isLoading,
+    isRefetching,
+  } = useGetTrendsQuery({limit: TOPIC_COUNT})
   const noTopics = !isLoading && !error && !trending?.trends?.length
   const showLoading = isLoading || isRefetching
 
@@ -143,7 +148,6 @@ export function TrendRow({
               style={[
                 a.text_md,
                 a.font_medium,
-
                 t.atoms.text_contrast_low,
                 {
                   fontVariant: ['tabular-nums'],

--- a/src/screens/Search/modules/ExploreTrendingTopics.tsx
+++ b/src/screens/Search/modules/ExploreTrendingTopics.tsx
@@ -45,7 +45,7 @@ function Inner() {
   const {t: l} = useLingui()
 
   const topicCount = ax.features.getValue(
-    ax.features.TrendingDiscoverValues,
+    ax.features.TrendingExploreTopicsCountValue,
     DEFAULT_LIMIT,
   )
 

--- a/src/view/shell/desktop/SidebarTrendingTopics.tsx
+++ b/src/view/shell/desktop/SidebarTrendingTopics.tsx
@@ -11,6 +11,7 @@ import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonIcon} from '#/components/Button'
 import {DotGrid3x1_Stroke2_Corner0_Rounded as EllipsisIcon} from '#/components/icons/DotGrid'
 import {Trending3_Stroke2_Corner1_Rounded as TrendingIcon} from '#/components/icons/Trending'
+import {Link} from '#/components/Link'
 import * as Prompt from '#/components/Prompt'
 import {TrendingTopicLink} from '#/components/TrendingTopics'
 import {Text} from '#/components/Typography'
@@ -35,6 +36,7 @@ function Inner() {
     error,
     isLoading,
   } = useGetTrendsQuery({
+    limit: TRENDING_LIMIT,
     refetchOnWindowFocus: true,
   })
   const noTopics = !isLoading && !error && !trending?.trends?.length
@@ -53,6 +55,24 @@ function Inner() {
           <Text style={[a.flex_1, a.text_md, a.font_semi_bold]}>
             <Trans>Trending</Trans>
           </Text>
+          <Link label={l`See more trending topics`} to="/search">
+            {({hovered, pressed}) => (
+              <Text
+                style={[
+                  a.text_sm,
+                  a.font_medium,
+                  {
+                    color:
+                      hovered || pressed
+                        ? t.palette.contrast_800
+                        : t.palette.contrast_500,
+                  },
+                ]}
+                numberOfLines={1}>
+                <Trans>See more</Trans>
+              </Text>
+            )}
+          </Link>
           <Button
             variant="ghost"
             size="tiny"

--- a/src/view/shell/desktop/SidebarTrendingTopics.tsx
+++ b/src/view/shell/desktop/SidebarTrendingTopics.tsx
@@ -5,7 +5,10 @@ import {
   useTrendingSettings,
   useTrendingSettingsApi,
 } from '#/state/preferences/trending'
-import {useGetTrendsQuery} from '#/state/queries/trending/useGetTrendsQuery'
+import {
+  DEFAULT_LIMIT,
+  useGetTrendsQuery,
+} from '#/state/queries/trending/useGetTrendsQuery'
 import {useTrendingConfig} from '#/state/service-config'
 import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonIcon} from '#/components/Button'
@@ -17,8 +20,6 @@ import {TrendingTopicLink} from '#/components/TrendingTopics'
 import {Text} from '#/components/Typography'
 import {useAnalytics} from '#/analytics'
 
-const TRENDING_LIMIT = 5
-
 export function SidebarTrendingTopics() {
   const {enabled} = useTrendingConfig()
   const {trendingDisabled} = useTrendingSettings()
@@ -29,6 +30,12 @@ function Inner() {
   const t = useTheme()
   const {t: l} = useLingui()
   const ax = useAnalytics()
+
+  const exploreTopicCount = ax.features.getValue(
+    ax.features.TrendingDiscoverValues,
+    DEFAULT_LIMIT,
+  )
+
   const trendingPrompt = Prompt.usePromptControl()
   const {setTrendingDisabled} = useTrendingSettingsApi()
   const {
@@ -36,7 +43,7 @@ function Inner() {
     error,
     isLoading,
   } = useGetTrendsQuery({
-    limit: TRENDING_LIMIT,
+    limit: DEFAULT_LIMIT,
     refetchOnWindowFocus: true,
   })
   const noTopics = !isLoading && !error && !trending?.trends?.length
@@ -55,24 +62,26 @@ function Inner() {
           <Text style={[a.flex_1, a.text_md, a.font_semi_bold]}>
             <Trans>Trending</Trans>
           </Text>
-          <Link label={l`See more trending topics`} to="/search">
-            {({hovered, pressed}) => (
-              <Text
-                style={[
-                  a.text_sm,
-                  a.font_medium,
-                  {
-                    color:
-                      hovered || pressed
-                        ? t.palette.contrast_800
-                        : t.palette.contrast_500,
-                  },
-                ]}
-                numberOfLines={1}>
-                <Trans>See more</Trans>
-              </Text>
-            )}
-          </Link>
+          {exploreTopicCount > DEFAULT_LIMIT ? (
+            <Link label={l`See more trending topics`} to="/search">
+              {({hovered, pressed}) => (
+                <Text
+                  style={[
+                    a.text_sm,
+                    a.font_medium,
+                    {
+                      color:
+                        hovered || pressed
+                          ? t.palette.contrast_800
+                          : t.palette.contrast_500,
+                    },
+                  ]}
+                  numberOfLines={1}>
+                  <Trans>See more</Trans>
+                </Text>
+              )}
+            </Link>
+          ) : null}
           <Button
             variant="ghost"
             size="tiny"
@@ -87,7 +96,7 @@ function Inner() {
 
         <View style={[a.gap_xs]}>
           {isLoading ? (
-            Array(TRENDING_LIMIT)
+            Array(DEFAULT_LIMIT)
               .fill(0)
               .map((_n, i) => (
                 <View key={i} style={[a.flex_row, a.align_center, a.gap_sm]}>
@@ -110,7 +119,7 @@ function Inner() {
               ))
           ) : !trending?.trends ? null : (
             <>
-              {trending.trends.slice(0, TRENDING_LIMIT).map((topic, i) => (
+              {trending.trends.slice(0, DEFAULT_LIMIT).map((topic, i) => (
                 <TrendingTopicLink
                   key={topic.link}
                   topic={topic}

--- a/src/view/shell/desktop/SidebarTrendingTopics.tsx
+++ b/src/view/shell/desktop/SidebarTrendingTopics.tsx
@@ -32,7 +32,7 @@ function Inner() {
   const ax = useAnalytics()
 
   const exploreTopicCount = ax.features.getValue(
-    ax.features.TrendingDiscoverValues,
+    ax.features.TrendingExploreTopicsCountValue,
     DEFAULT_LIMIT,
   )
 


### PR DESCRIPTION
For example, with the count set to 10:

| Explore | Sidebar |
| - | - |
| <img width="610" height="827" alt="explore" src="https://github.com/user-attachments/assets/fd101347-6e49-4201-a64f-17b6643d6708" /> | <img width="312" height="183" alt="sidebar" src="https://github.com/user-attachments/assets/0ff78b24-b6eb-4d00-a888-36c38861ae23" /> |