### PR TITLE
Update empty state for starter pack search

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -1216,11 +1216,6 @@
       "count": 1
     }
   },
-  "src/screens/StarterPack/Wizard/StepProfiles.tsx": {
-    "typescript/no-misused-promises": {
-      "count": 1
-    }
-  },
   "src/screens/StarterPack/Wizard/index.tsx": {
     "typescript/no-floating-promises": {
       "count": 2

--- a/src/screens/StarterPack/Wizard/StepProfiles.tsx
+++ b/src/screens/StarterPack/Wizard/StepProfiles.tsx
@@ -87,7 +87,9 @@ export function StepProfiles({
         sideBorders={false}
         style={[a.flex_1]}
         onEndReached={
-          !query && !screenReaderEnabled ? () => fetchNextPage() : undefined
+          !query && !screenReaderEnabled
+            ? () => void fetchNextPage()
+            : undefined
         }
         onEndReachedThreshold={IS_NATIVE ? 2 : 0.25}
         keyboardDismissMode="on-drag"
@@ -104,7 +106,11 @@ export function StepProfiles({
                   a.mt_lg,
                   a.leading_snug,
                 ]}>
-                <Trans>Nobody was found. Try searching for someone else.</Trans>
+                {query ? (
+                  <Trans>
+                    Nobody was found. Try searching for someone else.
+                  </Trans>
+                ) : null}
               </Text>
             )}
           </View>


### PR DESCRIPTION
| Empty state | With query |
| - | - |
| <img width="1206" height="2622" alt="empty" src="https://github.com/user-attachments/assets/463f676c-7c7a-467f-b8dc-eadde8c760e9" /> | <img width="1206" height="2622" alt="query" src="https://github.com/user-attachments/assets/bedeabbf-d7b7-4c1b-9aef-198b3a062224" /> |

Note this is just a tweak to the UI since ideally we receive a list of top followers to display for the empty state.