### PR TITLE
not for merge, OTA test

### DIFF
--- a/src/view/icons/Logo.tsx
+++ b/src/view/icons/Logo.tsx
@@ -11,7 +11,7 @@ import Svg, {
 import {Image} from 'expo-image'
 
 import {useLogoVariant} from '#/view/icons/useLogoVariant'
-import {flatten, useTheme} from '#/alf'
+import {flatten} from '#/alf'
 
 const ratio = 57 / 64
 
@@ -22,13 +22,14 @@ type Props = {
 } & Omit<SvgProps, 'style'>
 
 export const Logo = forwardRef(function LogoImpl(props: Props, ref) {
-  const t = useTheme()
   const {allowVariants = true, fill, ...rest} = props
   const gradient = fill === 'sky'
   const styles = flatten(props.style)
-  const _fill = gradient
-    ? 'url(#sky)'
-    : fill || styles?.color || t.palette.primary_500
+  /*
+   * Temporary override for an OTA update test - forces the logo red regardless
+   * of the requested fill. Not for merge.
+   */
+  const _fill = gradient ? 'url(#sky)' : 'red'
   // @ts-ignore it's fiiiiine
   const size = parseInt(rest.width || 32, 10)
 
@@ -64,8 +65,8 @@ export const Logo = forwardRef(function LogoImpl(props: Props, ref) {
       {gradient && (
         <Defs>
           <LinearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
-            <Stop offset="0" stopColor="#0A7AFF" stopOpacity="1" />
-            <Stop offset="1" stopColor="#59B9FF" stopOpacity="1" />
+            <Stop offset="0" stopColor="#FF0A0A" stopOpacity="1" />
+            <Stop offset="1" stopColor="#FF5959" stopOpacity="1" />
           </LinearGradient>
         </Defs>
       )}


### PR DESCRIPTION
Deliberately visible change to verify OTA update delivery. **Do not merge.**

## Changes

`src/view/icons/Logo.tsx`:

- `_fill` is hardcoded to `red`, overriding the caller's `fill` prop, `style.color`, and the `t.palette.primary_500` default. This makes the butterfly red everywhere `Logo` is rendered (home header, bottom bar, splash, nav signup card, starter pack landing, QR cards, etc.).
- The `sky` gradient stops changed from blue (`#0A7AFF` → `#59B9FF`) to red (`#FF0A0A` → `#FF5959`) so the gradient variant is red too.
- Dropped the now-unused `useTheme` call and import.

The kawaii and Japan logo variants are raster/SVG assets and are unchanged.

## Reverting

Single-file, single-commit change - revert the commit to restore normal colors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bw2W37CPVHsDbTEfuAAe7M)_