### PR TITLE
Fix profile badge sometimes displayed below on Android

### DIFF
--- a/src/screens/Profile/Header/DisplayName.tsx
+++ b/src/screens/Profile/Header/DisplayName.tsx
@@ -37,6 +37,11 @@ export function ProfileHeaderDisplayName({
         <View style={[a.pl_xs, {marginTop: platform({ios: 2})}]}>
           <ProfileBadges profile={profile} size="lg" interactive />
         </View>
+        {/*
+         * TODO: Workaround for a rounding bug in Android RN.
+         * Fixed upstream in RN main (facebook/react-native#56651); remove this
+         *  once we are on a release that contains it (0.86.0 should be good).
+         */}{' '}
       </Text>
     </View>
   )


### PR DESCRIPTION



https://linear.app/blueskyweb/issue/APP-2731/androidnew-arch-verified-checkmark-appears-improperly-sometimes


The bug:
<img width="406" height="933" alt="Screenshot 2026-07-30 at 17 24 40" src="https://github.com/user-attachments/assets/33b1bc87-d02b-4072-94c3-5d3e2c0328bf" />
