### PR TITLE
Simplify inline badge presentation, fix alignment

### DIFF
--- a/src/view/com/notifications/NotificationFeedItem.tsx
+++ b/src/view/com/notifications/NotificationFeedItem.tsx
@@ -250,7 +250,6 @@ let NotificationFeedItem = ({
           t.atoms.text,
           a.font_semi_bold,
           a.text_md,
-          a.leading_tight,
           web({direction: 'ltr', unicodeBidi: 'isolate'}),
         ]}
         to={firstAuthor.href}
@@ -260,18 +259,8 @@ let NotificationFeedItem = ({
         {forceLTR(firstAuthorName)}
         <ProfileBadges
           profile={firstAuthor.profile}
-          size="md"
-          style={[
-            a.relative,
-            {
-              // weird stuff here
-              paddingTop: platform({android: 2}),
-              marginBottom: platform({ios: -6}),
-              top: platform({web: 2}),
-              paddingLeft: 3,
-              paddingRight: 2,
-            },
-          ]}
+          size="sm"
+          style={[a.px_2xs, {transform: [{translateY: 1}]}]}
         />
       </InlineLinkText>
     </ProfileHoverCard>
@@ -315,7 +304,7 @@ let NotificationFeedItem = ({
     notificationContent = hasMultipleAuthors ? (
       <Trans>
         {firstAuthorLink} and{' '}
-        <Text style={[a.text_md, a.font_semi_bold, a.leading_snug]}>
+        <Text style={[a.text_md, a.font_semi_bold]}>
           <Plural
             value={additionalAuthorsCount}
             one={`${formattedAuthorsCount} other`}
@@ -337,7 +326,7 @@ let NotificationFeedItem = ({
     notificationContent = hasMultipleAuthors ? (
       <Trans>
         {firstAuthorLink} and{' '}
-        <Text style={[a.text_md, a.font_semi_bold, a.leading_snug]}>
+        <Text style={[a.text_md, a.font_semi_bold]}>
           <Plural
             value={additionalAuthorsCount}
             one={`${formattedAuthorsCount} other`}
@@ -377,7 +366,7 @@ let NotificationFeedItem = ({
       notificationContent = hasMultipleAuthors ? (
         <Trans>
           {firstAuthorLink} and{' '}
-          <Text style={[a.text_md, a.font_semi_bold, a.leading_snug]}>
+          <Text style={[a.text_md, a.font_semi_bold]}>
             <Plural
               value={additionalAuthorsCount}
               one={`${formattedAuthorsCount} other`}
@@ -409,7 +398,7 @@ let NotificationFeedItem = ({
     notificationContent = hasMultipleAuthors ? (
       <Trans>
         {firstAuthorLink} and{' '}
-        <Text style={[a.text_md, a.font_semi_bold, a.leading_snug]}>
+        <Text style={[a.text_md, a.font_semi_bold]}>
           <Plural
             value={additionalAuthorsCount}
             one={`${formattedAuthorsCount} other`}
@@ -431,7 +420,7 @@ let NotificationFeedItem = ({
     notificationContent = hasMultipleAuthors ? (
       <Trans>
         {firstAuthorLink} and{' '}
-        <Text style={[a.text_md, a.font_semi_bold, a.leading_snug]}>
+        <Text style={[a.text_md, a.font_semi_bold]}>
           <Plural
             value={additionalAuthorsCount}
             one={`${formattedAuthorsCount} other`}
@@ -458,7 +447,7 @@ let NotificationFeedItem = ({
     notificationContent = hasMultipleAuthors ? (
       <Trans>
         {firstAuthorLink} and{' '}
-        <Text style={[a.text_md, a.font_semi_bold, a.leading_snug]}>
+        <Text style={[a.text_md, a.font_semi_bold]}>
           <Plural
             value={additionalAuthorsCount}
             one={`${formattedAuthorsCount} other`}
@@ -481,7 +470,7 @@ let NotificationFeedItem = ({
     notificationContent = hasMultipleAuthors ? (
       <Trans>
         {firstAuthorLink} and{' '}
-        <Text style={[a.text_md, a.font_semi_bold, a.leading_snug]}>
+        <Text style={[a.text_md, a.font_semi_bold]}>
           <Plural
             value={additionalAuthorsCount}
             one={`${formattedAuthorsCount} other`}
@@ -506,7 +495,7 @@ let NotificationFeedItem = ({
     notificationContent = hasMultipleAuthors ? (
       <Trans>
         {firstAuthorLink} and{' '}
-        <Text style={[a.text_md, a.font_semi_bold, a.leading_snug]}>
+        <Text style={[a.text_md, a.font_semi_bold]}>
           <Plural
             value={additionalAuthorsCount}
             one={`${formattedAuthorsCount} other`}
@@ -528,7 +517,7 @@ let NotificationFeedItem = ({
     notificationContent = hasMultipleAuthors ? (
       <Trans>
         {firstAuthorLink} and{' '}
-        <Text style={[a.text_md, a.font_semi_bold, a.leading_snug]}>
+        <Text style={[a.text_md, a.font_semi_bold]}>
           <Plural
             value={additionalAuthorsCount}
             one={`${formattedAuthorsCount} other`}
@@ -558,7 +547,7 @@ let NotificationFeedItem = ({
     notificationContent = hasMultipleAuthors ? (
       <Trans>
         New posts from {firstAuthorLink} and{' '}
-        <Text style={[a.text_md, a.font_semi_bold, a.leading_snug]}>
+        <Text style={[a.text_md, a.font_semi_bold]}>
           <Plural
             value={additionalAuthorsCount}
             one={`${formattedAuthorsCount} other`}
@@ -662,7 +651,6 @@ let NotificationFeedItem = ({
                   {paddingTop: 6},
                   a.self_start,
                   a.text_md,
-                  a.leading_snug,
                 ]}
                 accessibilityHint=""
                 accessibilityLabel={a11yLabel}>
@@ -1171,7 +1159,7 @@ function AdditionalPostText({post}: {post?: AppBskyFeedDefs.PostView}) {
         {text?.length > 0 && (
           <Text
             emoji
-            style={[a.text_sm, a.leading_snug, t.atoms.text_contrast_medium]}
+            style={[a.text_sm, t.atoms.text_contrast_medium]}
             numberOfLines={MAX_POST_LINES}>
             {text}
           </Text>


### PR DESCRIPTION
After new arch, the alignment of the inline badges in the notification item were all over the place.

<img width="1367" height="417" alt="Screenshot 2026-08-03 at 14 11 53" src="https://github.com/user-attachments/assets/68448624-bb40-4132-af53-de3bc9b46471" />

Seems like we had very bespoke and fragile custom alignment for each platform. Seems like we can get rid of this, predicated on a couple other changes:

- Make sure all the text is using the same lineHeight (default which is `leading_snug`) - it was mismatched
- Use the `sm` badge size (matches `PostMeta` which has `text_md` + `sm`)
- Get rid of the custom padding/margin, just translate the badge down by 1px. This seems to align it the same on every platform now.

<img width="1378" height="327" alt="Screenshot 2026-08-03 at 14 11 07" src="https://github.com/user-attachments/assets/9049771e-ad66-4b26-a81d-46fe949dddc8" />
