### PR TITLE
[SDK] Migrate discovery and post-thread queries to the appview client

### DIFF
--- a/src/state/queries/search-posts-v2.ts
+++ b/src/state/queries/search-posts-v2.ts
@@ -1,10 +1,5 @@
 import {useCallback, useMemo, useRef} from 'react'
-import {
-  type AppBskyFeedDefs,
-  type AppBskyFeedSearchPostsV2,
-  AtUri,
-  moderatePost,
-} from '@atproto/api'
+import {type AppBskyFeedDefs, AtUri, moderatePost} from '@atproto/api'
 import {
   type InfiniteData,
   type QueryClient,
@@ -13,8 +8,9 @@ import {
 } from '@tanstack/react-query'
 
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
-import {useAgent} from '#/state/session'
+import {useAppviewClient} from '#/state/session'
 import {type SearchFilters} from '#/screens/Search/searchParams'
+import {app} from '#/lexicons'
 import {
   appendFromMe,
   buildSearchPostsV2Filters,
@@ -48,7 +44,7 @@ export function useSearchPostsV2Query({
   enabled?: boolean
   filters?: SearchFilters
 }) {
-  const agent = useAgent()
+  const client = useAppviewClient()
   const moderationOpts = useModerationOpts()
   const selectArgs = useMemo(
     () => ({
@@ -59,15 +55,15 @@ export function useSearchPostsV2Query({
     [query, filters?.author, filters?.from, moderationOpts],
   )
   const lastRun = useRef<{
-    data: InfiniteData<AppBskyFeedSearchPostsV2.OutputSchema>
+    data: InfiniteData<app.bsky.feed.searchPostsV2.$OutputBody>
     args: typeof selectArgs
-    result: InfiniteData<AppBskyFeedSearchPostsV2.OutputSchema>
+    result: InfiniteData<app.bsky.feed.searchPostsV2.$OutputBody>
   } | null>(null)
 
   return useInfiniteQuery<
-    AppBskyFeedSearchPostsV2.OutputSchema,
+    app.bsky.feed.searchPostsV2.$OutputBody,
     Error,
-    InfiniteData<AppBskyFeedSearchPostsV2.OutputSchema>,
+    InfiniteData<app.bsky.feed.searchPostsV2.$OutputBody>,
     QueryKey,
     string | undefined
   >({
@@ -79,9 +75,18 @@ export function useSearchPostsV2Query({
        * dialog; see buildSearchPostsV2Filters for how the two sources combine.
        */
       const {q, ...embedded} = extractSearchPostsParams(query)
-      const builtFilters = buildSearchPostsV2Filters(embedded, filters)
+      /*
+       * The generated params brand format-constrained strings (uri,
+       * at-identifier, language) as template-literal types. The builder emits
+       * plain strings parsed from user input, which are runtime-identical, so
+       * the brand is asserted rather than re-validated here.
+       */
+      const builtFilters = buildSearchPostsV2Filters(
+        embedded,
+        filters,
+      ) as app.bsky.feed.searchPostsV2.$Params
       const finalQuery = appendFromMe(q, filters?.from === 'me')
-      const res = await agent.app.bsky.feed.searchPostsV2({
+      return await client.call(app.bsky.feed.searchPostsV2, {
         ...builtFilters,
         query: finalQuery,
         limit: 25,
@@ -93,13 +98,12 @@ export function useSearchPostsV2Query({
         sort: sort === 'latest' ? 'recent' : sort,
         allTime: true,
       })
-      return res.data
     },
     initialPageParam: undefined,
     getNextPageParam: lastPage => lastPage.cursor,
     enabled: enabled ?? !!moderationOpts,
     select: useCallback(
-      (data: InfiniteData<AppBskyFeedSearchPostsV2.OutputSchema>) => {
+      (data: InfiniteData<app.bsky.feed.searchPostsV2.$OutputBody>) => {
         const {moderationOpts, isSearchingSpecificUser} = selectArgs
 
         /*
@@ -177,7 +181,7 @@ export function* findAllPostsInQueryData(
   uri: string,
 ): Generator<AppBskyFeedDefs.PostView, undefined> {
   const queryDatas = queryClient.getQueriesData<
-    InfiniteData<AppBskyFeedSearchPostsV2.OutputSchema>
+    InfiniteData<app.bsky.feed.searchPostsV2.$OutputBody>
   >({
     queryKey: [searchPostsQueryKeyRoot],
   })

--- a/src/state/queries/service-config.ts
+++ b/src/state/queries/service-config.ts
@@ -1,7 +1,8 @@
 import {useQuery} from '@tanstack/react-query'
 
 import {STALE} from '#/state/queries'
-import {useAgent} from '#/state/session'
+import {useAppviewClient} from '#/state/session'
+import {app} from '#/lexicons'
 
 type ServiceConfig = {
   checkEmailConfirmed: boolean
@@ -13,17 +14,17 @@ type ServiceConfig = {
 }
 
 export function useServiceConfigQuery() {
-  const agent = useAgent()
+  const client = useAppviewClient()
   return useQuery<ServiceConfig>({
     refetchOnWindowFocus: true,
     staleTime: STALE.MINUTES.FIVE,
     queryKey: ['service-config'],
     queryFn: async () => {
       try {
-        const {data} = await agent.api.app.bsky.unspecced.getConfig()
+        const data = await client.call(app.bsky.unspecced.getConfig)
         return {
           checkEmailConfirmed: Boolean(data.checkEmailConfirmed),
-          // @ts-expect-error not included in types atm
+          // @ts-expect-error not included in the lexicon atm
           topicsEnabled: Boolean(data.topicsEnabled),
           liveNow: data.liveNow ?? [],
         }

--- a/src/state/queries/starter-pack-search.ts
+++ b/src/state/queries/starter-pack-search.ts
@@ -1,4 +1,3 @@
-import {type AppBskyGraphSearchStarterPacksV2} from '@atproto/api'
 import {
   type InfiniteData,
   keepPreviousData,
@@ -7,7 +6,8 @@ import {
 } from '@tanstack/react-query'
 
 import {STALE} from '#/state/queries'
-import {useAgent} from '#/state/session'
+import {useAppviewClient} from '#/state/session'
+import {app} from '#/lexicons'
 
 export const RQKEY_ROOT = 'starter-pack-search'
 export const RQKEY = (query: string, limit?: number) => [
@@ -27,23 +27,22 @@ export function useStarterPackSearch({
   maintainData?: boolean
   limit?: number
 }) {
-  const agent = useAgent()
+  const client = useAppviewClient()
   return useInfiniteQuery<
-    AppBskyGraphSearchStarterPacksV2.OutputSchema,
+    app.bsky.graph.searchStarterPacksV2.$OutputBody,
     Error,
-    InfiniteData<AppBskyGraphSearchStarterPacksV2.OutputSchema>,
+    InfiniteData<app.bsky.graph.searchStarterPacksV2.$OutputBody>,
     QueryKey,
     string | undefined
   >({
     staleTime: STALE.MINUTES.FIVE,
     queryKey: RQKEY(query, limit),
     queryFn: async ({pageParam}) => {
-      const res = await agent.app.bsky.graph.searchStarterPacksV2({
+      return await client.call(app.bsky.graph.searchStarterPacksV2, {
         q: query,
         limit,
         cursor: pageParam,
       })
-      return res.data
     },
     enabled: enabled && !!query,
     initialPageParam: undefined,
@@ -54,7 +53,7 @@ export function useStarterPackSearch({
 }
 
 function select(
-  data: InfiniteData<AppBskyGraphSearchStarterPacksV2.OutputSchema>,
+  data: InfiniteData<app.bsky.graph.searchStarterPacksV2.$OutputBody>,
 ) {
   // enforce uniqueness
   const uris = new Set()

--- a/src/state/queries/trending/useGetSuggestedFeedsQuery.ts
+++ b/src/state/queries/trending/useGetSuggestedFeedsQuery.ts
@@ -7,14 +7,15 @@ import {
 import {getContentLanguages} from '#/state/preferences/languages'
 import {STALE} from '#/state/queries'
 import {usePreferencesQuery} from '#/state/queries/preferences'
-import {useAgent} from '#/state/session'
+import {useAppviewClient} from '#/state/session'
+import {app} from '#/lexicons'
 
 export const DEFAULT_LIMIT = 15
 
 export const createGetSuggestedFeedsQueryKey = () => ['suggested-feeds']
 
 export function useGetSuggestedFeedsQuery({enabled}: {enabled?: boolean}) {
-  const agent = useAgent()
+  const client = useAppviewClient()
   const {data: preferences} = usePreferencesQuery()
   const savedFeeds = preferences?.savedFeeds
 
@@ -24,7 +25,8 @@ export function useGetSuggestedFeedsQuery({enabled}: {enabled?: boolean}) {
     queryKey: createGetSuggestedFeedsQueryKey(),
     queryFn: async () => {
       const contentLangs = getContentLanguages().join(',')
-      const {data} = await agent.app.bsky.unspecced.getSuggestedFeeds(
+      const data = await client.call(
+        app.bsky.unspecced.getSuggestedFeeds,
         {
           limit: DEFAULT_LIMIT,
         },

--- a/src/state/queries/trending/useGetSuggestedOnboardingUsersQuery.ts
+++ b/src/state/queries/trending/useGetSuggestedOnboardingUsersQuery.ts
@@ -1,7 +1,3 @@
-import {
-  type AppBskyActorDefs,
-  type AppBskyUnspeccedGetSuggestedOnboardingUsers,
-} from '@atproto/api'
 import {type QueryClient, useQuery} from '@tanstack/react-query'
 
 import {createBskyTopicsHeader} from '#/lib/api/feed/utils'
@@ -9,7 +5,8 @@ import {logger} from '#/logger'
 import {getContentLanguages} from '#/state/preferences/languages'
 import {STALE} from '#/state/queries'
 import {usePreferencesQuery} from '#/state/queries/preferences'
-import {useAgent} from '#/state/session'
+import {useAppviewClient} from '#/state/session'
+import {app} from '#/lexicons'
 
 export type QueryProps = {
   category?: string | null
@@ -30,7 +27,7 @@ export const createGetSuggestedOnboardingUsersQueryKey = (
 ]
 
 export function useGetSuggestedOnboardingUsersQuery(props: QueryProps) {
-  const agent = useAgent()
+  const client = useAppviewClient()
   const {data: preferences} = usePreferencesQuery()
 
   return useQuery({
@@ -42,7 +39,8 @@ export function useGetSuggestedOnboardingUsersQuery(props: QueryProps) {
 
       const overrideInterests = props.overrideInterests.join(',')
 
-      const {data} = await agent.app.bsky.unspecced.getSuggestedOnboardingUsers(
+      const data = await client.call(
+        app.bsky.unspecced.getSuggestedOnboardingUsers,
         {
           category: props.category ?? undefined,
           limit: props.limit || 10,
@@ -66,9 +64,9 @@ export function useGetSuggestedOnboardingUsersQuery(props: QueryProps) {
 export function* findAllProfilesInQueryData(
   queryClient: QueryClient,
   did: string,
-): Generator<AppBskyActorDefs.ProfileView, void> {
+): Generator<app.bsky.actor.defs.ProfileView, void> {
   const responses =
-    queryClient.getQueriesData<AppBskyUnspeccedGetSuggestedOnboardingUsers.OutputSchema>(
+    queryClient.getQueriesData<app.bsky.unspecced.getSuggestedOnboardingUsers.$OutputBody>(
       {
         queryKey: [getSuggestedOnboardingUsersQueryKeyRoot],
       },

--- a/src/state/queries/trending/useGetSuggestedUsersForDiscoverQuery.ts
+++ b/src/state/queries/trending/useGetSuggestedUsersForDiscoverQuery.ts
@@ -1,7 +1,3 @@
-import {
-  type AppBskyActorDefs,
-  type AppBskyUnspeccedGetSuggestedUsersForDiscover,
-} from '@atproto/api'
 import {type QueryClient, useQuery} from '@tanstack/react-query'
 
 import {
@@ -12,7 +8,8 @@ import {logger} from '#/logger'
 import {getContentLanguages} from '#/state/preferences/languages'
 import {STALE} from '#/state/queries'
 import {usePreferencesQuery} from '#/state/queries/preferences'
-import {useAgent} from '#/state/session'
+import {useAppviewClient} from '#/state/session'
+import {app} from '#/lexicons'
 
 export type QueryProps = {
   limit?: number
@@ -25,7 +22,7 @@ export const createGetSuggestedUsersForDiscoverQueryKey = (props: {
 }) => [getSuggestedUsersForDiscoverQueryKeyRoot, props.limit]
 
 export function useGetSuggestedUsersForDiscoverQuery(props: QueryProps = {}) {
-  const agent = useAgent()
+  const client = useAppviewClient()
   const {data: preferences} = usePreferencesQuery()
 
   return useQuery({
@@ -35,18 +32,18 @@ export function useGetSuggestedUsersForDiscoverQuery(props: QueryProps = {}) {
       const contentLangs = getContentLanguages().join(',')
       const userInterests = aggregateUserInterests(preferences)
 
-      const {data} =
-        await agent.app.bsky.unspecced.getSuggestedUsersForDiscover(
-          {
-            limit: props.limit || 10,
+      const data = await client.call(
+        app.bsky.unspecced.getSuggestedUsersForDiscover,
+        {
+          limit: props.limit || 10,
+        },
+        {
+          headers: {
+            ...createBskyTopicsHeader(userInterests),
+            'Accept-Language': contentLangs,
           },
-          {
-            headers: {
-              ...createBskyTopicsHeader(userInterests),
-              'Accept-Language': contentLangs,
-            },
-          },
-        )
+        },
+      )
       if (!data.recIdStr) {
         logger.debug('getSuggestedUsersForDiscover response missing recIdStr')
       }
@@ -58,9 +55,9 @@ export function useGetSuggestedUsersForDiscoverQuery(props: QueryProps = {}) {
 export function* findAllProfilesInQueryData(
   queryClient: QueryClient,
   did: string,
-): Generator<AppBskyActorDefs.ProfileView, void> {
+): Generator<app.bsky.actor.defs.ProfileView, void> {
   const responses =
-    queryClient.getQueriesData<AppBskyUnspeccedGetSuggestedUsersForDiscover.OutputSchema>(
+    queryClient.getQueriesData<app.bsky.unspecced.getSuggestedUsersForDiscover.$OutputBody>(
       {
         queryKey: [getSuggestedUsersForDiscoverQueryKeyRoot],
       },

--- a/src/state/queries/trending/useGetSuggestedUsersForExploreQuery.ts
+++ b/src/state/queries/trending/useGetSuggestedUsersForExploreQuery.ts
@@ -1,7 +1,3 @@
-import {
-  type AppBskyActorDefs,
-  type AppBskyUnspeccedGetSuggestedUsersForExplore,
-} from '@atproto/api'
 import {type QueryClient, useQuery} from '@tanstack/react-query'
 
 import {
@@ -12,7 +8,8 @@ import {logger} from '#/logger'
 import {getContentLanguages} from '#/state/preferences/languages'
 import {STALE} from '#/state/queries'
 import {usePreferencesQuery} from '#/state/queries/preferences'
-import {useAgent} from '#/state/session'
+import {useAppviewClient} from '#/state/session'
+import {app} from '#/lexicons'
 
 export type QueryProps = {
   category?: string | null
@@ -26,7 +23,7 @@ export const createGetSuggestedUsersForExploreQueryKey = (
 ) => [getSuggestedUsersForExploreQueryKeyRoot, props.category, props.limit]
 
 export function useGetSuggestedUsersForExploreQuery(props: QueryProps = {}) {
-  const agent = useAgent()
+  const client = useAppviewClient()
   const {data: preferences} = usePreferencesQuery()
 
   return useQuery({
@@ -36,7 +33,8 @@ export function useGetSuggestedUsersForExploreQuery(props: QueryProps = {}) {
       const contentLangs = getContentLanguages().join(',')
       const userInterests = aggregateUserInterests(preferences)
 
-      const {data} = await agent.app.bsky.unspecced.getSuggestedUsersForExplore(
+      const data = await client.call(
+        app.bsky.unspecced.getSuggestedUsersForExplore,
         {
           category: props.category ?? undefined,
           limit: props.limit || 10,
@@ -60,9 +58,9 @@ export function useGetSuggestedUsersForExploreQuery(props: QueryProps = {}) {
 export function* findAllProfilesInQueryData(
   queryClient: QueryClient,
   did: string,
-): Generator<AppBskyActorDefs.ProfileView, void> {
+): Generator<app.bsky.actor.defs.ProfileView, void> {
   const responses =
-    queryClient.getQueriesData<AppBskyUnspeccedGetSuggestedUsersForExplore.OutputSchema>(
+    queryClient.getQueriesData<app.bsky.unspecced.getSuggestedUsersForExplore.$OutputBody>(
       {
         queryKey: [getSuggestedUsersForExploreQueryKeyRoot],
       },

--- a/src/state/queries/trending/useGetSuggestedUsersForSeeMoreQuery.ts
+++ b/src/state/queries/trending/useGetSuggestedUsersForSeeMoreQuery.ts
@@ -1,7 +1,3 @@
-import {
-  type AppBskyActorDefs,
-  type AppBskyUnspeccedGetSuggestedUsersForSeeMore,
-} from '@atproto/api'
 import {type QueryClient, useQuery} from '@tanstack/react-query'
 
 import {
@@ -12,7 +8,8 @@ import {logger} from '#/logger'
 import {getContentLanguages} from '#/state/preferences/languages'
 import {STALE} from '#/state/queries'
 import {usePreferencesQuery} from '#/state/queries/preferences'
-import {useAgent} from '#/state/session'
+import {useAppviewClient} from '#/state/session'
+import {app} from '#/lexicons'
 
 export type QueryProps = {
   category?: string | null
@@ -28,7 +25,7 @@ export const createGetSuggestedUsersForSeeMoreQueryKey = (props: {
 }) => [getSuggestedUsersForSeeMoreQueryKeyRoot, props.category, props.limit]
 
 export function useGetSuggestedUsersForSeeMoreQuery(props: QueryProps = {}) {
-  const agent = useAgent()
+  const client = useAppviewClient()
   const {data: preferences} = usePreferencesQuery()
 
   return useQuery({
@@ -42,7 +39,8 @@ export function useGetSuggestedUsersForSeeMoreQuery(props: QueryProps = {}) {
       const contentLangs = getContentLanguages().join(',')
       const userInterests = aggregateUserInterests(preferences)
 
-      const {data} = await agent.app.bsky.unspecced.getSuggestedUsersForSeeMore(
+      const data = await client.call(
+        app.bsky.unspecced.getSuggestedUsersForSeeMore,
         {
           category: props.category ?? undefined,
           limit: props.limit || 50,
@@ -66,9 +64,9 @@ export function useGetSuggestedUsersForSeeMoreQuery(props: QueryProps = {}) {
 export function* findAllProfilesInQueryData(
   queryClient: QueryClient,
   did: string,
-): Generator<AppBskyActorDefs.ProfileView, void> {
+): Generator<app.bsky.actor.defs.ProfileView, void> {
   const responses =
-    queryClient.getQueriesData<AppBskyUnspeccedGetSuggestedUsersForSeeMore.OutputSchema>(
+    queryClient.getQueriesData<app.bsky.unspecced.getSuggestedUsersForSeeMore.$OutputBody>(
       {
         queryKey: [getSuggestedUsersForSeeMoreQueryKeyRoot],
       },

--- a/src/state/queries/useOnboardingSuggestedStarterPacksQuery.ts
+++ b/src/state/queries/useOnboardingSuggestedStarterPacksQuery.ts
@@ -7,7 +7,8 @@ import {
 import {getContentLanguages} from '#/state/preferences/languages'
 import {STALE} from '#/state/queries'
 import {usePreferencesQuery} from '#/state/queries/preferences'
-import {useAgent} from '#/state/session'
+import {useAppviewClient} from '#/state/session'
+import {app} from '#/lexicons'
 
 export const createOnboardingSuggestedStarterPacksQueryKey = (
   interests?: string[],
@@ -20,7 +21,7 @@ export function useOnboardingSuggestedStarterPacksQuery({
   enabled?: boolean
   overrideInterests?: string[]
 }) {
-  const agent = useAgent()
+  const client = useAppviewClient()
   const {data: preferences} = usePreferencesQuery()
   const contentLangs = getContentLanguages().join(',')
 
@@ -29,21 +30,20 @@ export function useOnboardingSuggestedStarterPacksQuery({
     staleTime: STALE.MINUTES.THREE,
     queryKey: createOnboardingSuggestedStarterPacksQueryKey(overrideInterests),
     queryFn: async () => {
-      const {data} =
-        await agent.app.bsky.unspecced.getOnboardingSuggestedStarterPacks(
-          {limit: 6},
-          {
-            headers: {
-              ...createBskyTopicsHeader(
-                overrideInterests
-                  ? overrideInterests.join(',')
-                  : aggregateUserInterests(preferences),
-              ),
-              'Accept-Language': contentLangs,
-            },
+      return await client.call(
+        app.bsky.unspecced.getOnboardingSuggestedStarterPacks,
+        {limit: 6},
+        {
+          headers: {
+            ...createBskyTopicsHeader(
+              overrideInterests
+                ? overrideInterests.join(',')
+                : aggregateUserInterests(preferences),
+            ),
+            'Accept-Language': contentLangs,
           },
-        )
-      return data
+        },
+      )
     },
   })
 }

--- a/src/state/queries/usePostThread/index.ts
+++ b/src/state/queries/usePostThread/index.ts
@@ -1,4 +1,5 @@
 import {useCallback, useMemo, useState} from 'react'
+import {type AtUriString} from '@atproto/syntax'
 import {useQuery, useQueryClient} from '@tanstack/react-query'
 
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
@@ -73,7 +74,7 @@ export function usePostThread({anchor}: {anchor?: string}) {
     queryKey: postThreadQueryKey,
     async queryFn(ctx) {
       const data = await client.call(app.bsky.unspecced.getPostThreadV2, {
-        anchor: anchor! as app.bsky.unspecced.getPostThreadV2.$Params['anchor'],
+        anchor: anchor! as AtUriString,
         branchingFactor: view === 'linear' ? LINEAR_VIEW_BF : TREE_VIEW_BF,
         below,
         sort: sort,
@@ -169,8 +170,7 @@ export function usePostThread({anchor}: {anchor?: string}) {
     queryKey: postThreadOtherQueryKey,
     async queryFn() {
       return await client.call(app.bsky.unspecced.getPostThreadOtherV2, {
-        anchor:
-          anchor! as app.bsky.unspecced.getPostThreadOtherV2.$Params['anchor'],
+        anchor: anchor! as AtUriString,
       })
     },
   })

--- a/src/state/queries/usePostThread/index.ts
+++ b/src/state/queries/usePostThread/index.ts
@@ -27,10 +27,11 @@ import {
 } from '#/state/queries/usePostThread/types'
 import {getThreadgateRecord} from '#/state/queries/usePostThread/utils'
 import * as views from '#/state/queries/usePostThread/views'
-import {useAgent, useSession} from '#/state/session'
+import {useAppviewClient, useSession} from '#/state/session'
 import {useMergeThreadgateHiddenReplies} from '#/state/threadgate-hidden-replies'
 import {useBreakpoints} from '#/alf'
 import {IS_WEB} from '#/env'
+import {app} from '#/lexicons'
 
 export * from '#/state/queries/usePostThread/context'
 export {useUpdatePostThreadThreadgateQueryCache} from '#/state/queries/usePostThread/queryCache'
@@ -38,7 +39,7 @@ export * from '#/state/queries/usePostThread/types'
 
 export function usePostThread({anchor}: {anchor?: string}) {
   const qc = useQueryClient()
-  const agent = useAgent()
+  const client = useAppviewClient()
   const {hasSession} = useSession()
   const {gtPhone} = useBreakpoints()
   const moderationOpts = useModerationOpts()
@@ -71,8 +72,8 @@ export function usePostThread({anchor}: {anchor?: string}) {
     enabled: isThreadPreferencesLoaded && !!anchor && !!moderationOpts,
     queryKey: postThreadQueryKey,
     async queryFn(ctx) {
-      const {data} = await agent.app.bsky.unspecced.getPostThreadV2({
-        anchor: anchor!,
+      const data = await client.call(app.bsky.unspecced.getPostThreadV2, {
+        anchor: anchor! as app.bsky.unspecced.getPostThreadV2.$Params['anchor'],
         branchingFactor: view === 'linear' ? LINEAR_VIEW_BF : TREE_VIEW_BF,
         below,
         sort: sort,
@@ -93,18 +94,24 @@ export function usePostThread({anchor}: {anchor?: string}) {
         ctx.meta.hasOtherReplies = true
       }
 
+      /*
+       * The generated views type `threadgate.record` as an opaque lex map and
+       * brand at-uris, so the response is asserted to the exported result type
+       * here; the record swap-in below and every downstream consumer of the
+       * thread read that narrower contract.
+       */
       const result = {
         thread: data.thread || [],
         threadgate: data.threadgate,
         hasOtherReplies: !!ctx.meta.hasOtherReplies,
-      }
+      } as UsePostThreadQueryResult
 
       const record = getThreadgateRecord(result.threadgate)
       if (result.threadgate && record) {
         result.threadgate.record = record
       }
 
-      return result as UsePostThreadQueryResult
+      return result
     },
     placeholderData() {
       if (!anchor) return
@@ -161,10 +168,10 @@ export function usePostThread({anchor}: {anchor?: string}) {
     enabled: additionalQueryEnabled,
     queryKey: postThreadOtherQueryKey,
     async queryFn() {
-      const {data} = await agent.app.bsky.unspecced.getPostThreadOtherV2({
-        anchor: anchor!,
+      return await client.call(app.bsky.unspecced.getPostThreadOtherV2, {
+        anchor:
+          anchor! as app.bsky.unspecced.getPostThreadOtherV2.$Params['anchor'],
       })
-      return data
     },
   })
   const serverOtherThreadItems: ThreadItem[] = useMemo(() => {

--- a/src/state/queries/useSuggestedStarterPacksQuery.ts
+++ b/src/state/queries/useSuggestedStarterPacksQuery.ts
@@ -7,7 +7,8 @@ import {
 import {getContentLanguages} from '#/state/preferences/languages'
 import {STALE} from '#/state/queries'
 import {usePreferencesQuery} from '#/state/queries/preferences'
-import {useAgent} from '#/state/session'
+import {useAppviewClient} from '#/state/session'
+import {app} from '#/lexicons'
 
 export const createSuggestedStarterPacksQueryKey = (interests?: string[]) => [
   'suggested-starter-packs',
@@ -21,7 +22,7 @@ export function useSuggestedStarterPacksQuery({
   enabled?: boolean
   overrideInterests?: string[]
 }) {
-  const agent = useAgent()
+  const client = useAppviewClient()
   const {data: preferences} = usePreferencesQuery()
   const contentLangs = getContentLanguages().join(',')
 
@@ -30,8 +31,9 @@ export function useSuggestedStarterPacksQuery({
     staleTime: STALE.MINUTES.THREE,
     queryKey: createSuggestedStarterPacksQueryKey(overrideInterests),
     queryFn: async () => {
-      const {data} = await agent.app.bsky.unspecced.getSuggestedStarterPacks(
-        undefined,
+      return await client.call(
+        app.bsky.unspecced.getSuggestedStarterPacks,
+        {},
         {
           headers: {
             ...createBskyTopicsHeader(
@@ -43,7 +45,6 @@ export function useSuggestedStarterPacksQuery({
           },
         },
       )
-      return data
     },
   })
 }

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -47,12 +47,11 @@ import {type ImagePickerAsset} from 'expo-image-picker'
 import {
   AppBskyDraftCreateDraft,
   AppBskyUnspeccedDefs,
-  type AppBskyUnspeccedGetPostThreadV2,
-  type AtpAgent,
   AtUri,
   ChatBskyGroupDefs,
   type RichText,
 } from '@atproto/api'
+import {type Client} from '@atproto/lex'
 import {plural} from '@lingui/core/macro'
 import {Trans, useLingui} from '@lingui/react/macro'
 import {useNavigation} from '@react-navigation/native'
@@ -96,7 +95,7 @@ import {
 import {usePreferencesQuery} from '#/state/queries/preferences'
 import {useProfileQuery} from '#/state/queries/profile'
 import {resolveLinkQueryOptions} from '#/state/queries/resolve-link'
-import {useAgent, useSession} from '#/state/session'
+import {useAgent, useAppviewClient, useSession} from '#/state/session'
 import {useComposerControls} from '#/state/shell/composer'
 import {type ComposerOpts, type OnPostSuccessData} from '#/state/shell/composer'
 import {CharProgress} from '#/view/com/composer/char-progress/CharProgress'
@@ -144,6 +143,7 @@ import {
   IS_WEB_SAFARI,
 } from '#/env'
 import {type Gif} from '#/features/gifPicker/types'
+import {app} from '#/lexicons'
 import {BottomSheetPortalProvider} from '../../../../modules/bottom-sheet'
 import {
   draftToComposerPosts,
@@ -275,6 +275,7 @@ export const ComposePost = ({
     ? VIDEO_10_MINUTE_MAX_DURATION_MS
     : VIDEO_MAX_DURATION_MS
   const agent = useAgent()
+  const client = useAppviewClient()
   const queryClient = useQueryClient()
   const currentDid = currentAccount!.did
   const {closeComposer} = useComposerControls()
@@ -1105,23 +1106,27 @@ export const ComposePost = ({
             5,
             _e => true,
             async () => {
-              const res = await agent.app.bsky.unspecced.getPostThreadV2({
-                anchor: postUri!,
-                above: false,
-                below: filteredThread.posts.length - 1,
-                branchingFactor: 1,
-              })
-              if (res.data.thread.length !== filteredThread.posts.length) {
+              const res = await client.call(
+                app.bsky.unspecced.getPostThreadV2,
+                {
+                  anchor:
+                    postUri! as app.bsky.unspecced.getPostThreadV2.$Params['anchor'],
+                  above: false,
+                  below: filteredThread.posts.length - 1,
+                  branchingFactor: 1,
+                },
+              )
+              if (res.thread.length !== filteredThread.posts.length) {
                 throw new Error(`composer: app view is not ready`)
               }
               if (
-                !res.data.thread.every(p =>
+                !res.thread.every(p =>
                   AppBskyUnspeccedDefs.isThreadItemPost(p.value),
                 )
               ) {
                 throw new Error(`composer: app view returned non-post items`)
               }
-              return res.data.thread
+              return res.thread
             },
             1e3,
           )
@@ -1224,8 +1229,8 @@ export const ComposePost = ({
     setLangPrefs.savePostLanguageToHistory()
     if (initQuote) {
       // We want to wait for the quote count to update before we call `onPost`, which will refetch data
-      void whenAppViewReady(agent, initQuote.uri, res => {
-        const anchor = res.data.thread.at(0)
+      void whenAppViewReady(client, initQuote.uri, res => {
+        const anchor = res.thread.at(0)
         if (
           AppBskyUnspeccedDefs.isThreadItemPost(anchor?.value) &&
           anchor.value.post.quoteCount !== initQuote.quoteCount
@@ -1272,6 +1277,7 @@ export const ComposePost = ({
     l,
     ax,
     agent,
+    client,
     canPost,
     isPublishing,
     currentLanguages,
@@ -2486,17 +2492,17 @@ function useKeyboardVerticalOffset() {
 }
 
 async function whenAppViewReady(
-  agent: AtpAgent,
+  client: Client,
   uri: string,
-  fn: (res: AppBskyUnspeccedGetPostThreadV2.Response) => boolean,
+  fn: (res: app.bsky.unspecced.getPostThreadV2.$OutputBody) => boolean,
 ) {
   await until(
     5, // 5 tries
     1e3, // 1s delay between tries
     fn,
     () =>
-      agent.app.bsky.unspecced.getPostThreadV2({
-        anchor: uri,
+      client.call(app.bsky.unspecced.getPostThreadV2, {
+        anchor: uri as app.bsky.unspecced.getPostThreadV2.$Params['anchor'],
         above: false,
         below: 0,
         branchingFactor: 0,

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -52,6 +52,7 @@ import {
   type RichText,
 } from '@atproto/api'
 import {type Client} from '@atproto/lex'
+import {type AtUriString} from '@atproto/syntax'
 import {plural} from '@lingui/core/macro'
 import {Trans, useLingui} from '@lingui/react/macro'
 import {useNavigation} from '@react-navigation/native'
@@ -1109,8 +1110,7 @@ export const ComposePost = ({
               const res = await client.call(
                 app.bsky.unspecced.getPostThreadV2,
                 {
-                  anchor:
-                    postUri! as app.bsky.unspecced.getPostThreadV2.$Params['anchor'],
+                  anchor: postUri! as AtUriString,
                   above: false,
                   below: filteredThread.posts.length - 1,
                   branchingFactor: 1,
@@ -2502,7 +2502,7 @@ async function whenAppViewReady(
     fn,
     () =>
       client.call(app.bsky.unspecced.getPostThreadV2, {
-        anchor: uri as app.bsky.unspecced.getPostThreadV2.$Params['anchor'],
+        anchor: uri as AtUriString,
         above: false,
         below: 0,
         branchingFactor: 0,


### PR DESCRIPTION
Seventh slice of #11182 (stacked on #11353). First consumer-migration wave: the unspecced/trending/discovery query cluster moves from `useAgent()`/`agent.*` to `useAppviewClient()`/`client.call()` with generated schemas from `#/lexicons`, mirroring the trends-query precedent from #11348. 12 files; query keys unchanged; zero consumer edits.

## What changed

**Trending discovery queries** - the five `useGetSuggested*Query` files in `src/state/queries/trending/`, plus `useOnboardingSuggestedStarterPacksQuery` and `useSuggestedStarterPacksQuery`.

**Search + starter packs** - `search-posts-v2.ts`, `starter-pack-search.ts`. The generated `$Params` brand format-constrained strings (at-uris, identifiers, languages) as template-literal types; user-input-derived plain strings pass through one documented assertion at the call site. `findAllPostsInQueryData` keeps its old-world yield type so `post-shadow.ts` compiles untouched (generated views are structurally assignable in).

**Post thread** - `usePostThread/index.ts` transport flipped; the existing result-shaped assertion absorbs the generated views' branded uris and opaque threadgate record, and the response flows into `sortAndAnnotateThreadItems` unchanged - no sibling file in the directory needed edits.

**Service config + composer** - `service-config.ts` drops the `agent.api` self-getter noise; `Composer.tsx` migrates both of its `getPostThreadV2` reads (the post-publish appview-ready poll and `whenAppViewReady`, now typed over `Client`). Composer keeps `useAgent()` alongside the client for its out-of-cluster uses (video upload, link resolution, `apilib.post`) - those are PDS writes belonging to later waves.

## Notes

- No error-handling changes were needed: nothing in this cluster classifies errors by code string, and the lex client throws for the same failure conditions the old agent did.
- Remaining `@atproto/api` imports in the cluster are justified and enumerated in the diff: moderation helpers (`moderatePost`, `hasMutedWord`), `AtUri`, and old-world view types that downstream consumers still declare (dual-world compatible either way).

## Verification
- `pnpm typecheck` 0 errors (ios + android + web), `pnpm test` 53/53 suites (773 passed + 28 todo), `pnpm lint` + `pnpm prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
