### PR TITLE
Invert password reveal eye icon

### DIFF
--- a/src/screens/Login/LoginForm.tsx
+++ b/src/screens/Login/LoginForm.tsx
@@ -601,7 +601,12 @@ function RevealPasswordButton({
   const {t: l} = useLingui()
   const context = TextField.useTextFieldContext()
 
-  const Icon = !active ? EyeSlashIcon : EyeIcon
+  /*
+   * The icon shows the action the button performs, not the current state: an
+   * open eye when the password is hidden (tap to reveal), a crossed-out eye
+   * when it is visible (tap to hide).
+   */
+  const Icon = active ? EyeSlashIcon : EyeIcon
 
   if (!hasPassword && !context.focused) return null
 


### PR DESCRIPTION
The icon now shows the action the button performs rather than the current
state: an open eye while the password is hidden (tap to reveal) and a
crossed-out eye while it is visible (tap to hide). This matches the button
label, which already used action semantics.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NwPDpir8XPecFyXvQuvE1q