### PR TITLE
[SDK] Migrate getAllListMembers to the appview client

### DIFF
--- a/src/components/dialogs/lists/CreateListFromStarterPackDialog.tsx
+++ b/src/components/dialogs/lists/CreateListFromStarterPackDialog.tsx
@@ -20,7 +20,7 @@ import {wait} from '#/lib/async/wait'
 import {type NavigationProp} from '#/lib/routes/types'
 import {logger} from '#/logger'
 import {getAllListMembers} from '#/state/queries/list-members'
-import {useAgent, useSession} from '#/state/session'
+import {useAgent, useAppviewClient, useSession} from '#/state/session'
 import {atoms as a, platform, useTheme, web} from '#/alf'
 import {Admonition} from '#/components/Admonition'
 import {Button, ButtonText} from '#/components/Button'
@@ -41,6 +41,7 @@ export function CreateListFromStarterPackDialog({
   const {_} = useLingui()
   const t = useTheme()
   const agent = useAgent()
+  const appviewClient = useAppviewClient()
   const ax = useAnalytics()
   const {currentAccount} = useSession()
   const navigation = useNavigation<NavigationProp>()
@@ -73,7 +74,10 @@ export function CreateListFromStarterPackDialog({
       const listItems = await wait(
         3000,
         (async () => {
-          const items = await getAllListMembers(agent, starterPack.list!.uri)
+          const items = await getAllListMembers(
+            appviewClient,
+            starterPack.list!.uri,
+          )
 
           if (items.length > 0) {
             const listitemWrites: $Typed<ComAtprotoRepoApplyWrites.Create>[] =

--- a/src/screens/Onboarding/StepFinished/index.tsx
+++ b/src/screens/Onboarding/StepFinished/index.tsx
@@ -26,7 +26,7 @@ import {useSetHasCheckedForStarterPack} from '#/state/preferences/used-starter-p
 import {getAllListMembers} from '#/state/queries/list-members'
 import {preferencesQueryKey} from '#/state/queries/preferences'
 import {RQKEY as profileRQKey} from '#/state/queries/profile'
-import {useAgent} from '#/state/session'
+import {useAgent, useAppviewClient} from '#/state/session'
 import {useOnboardingDispatch} from '#/state/shell'
 import {
   useActiveStarterPack,
@@ -58,6 +58,7 @@ export function StepFinished() {
   const [saving, setSaving] = useState(false)
   const queryClient = useQueryClient()
   const agent = useAgent()
+  const appviewClient = useAppviewClient()
   const requestNotificationsPermission = useRequestNotificationsPermission()
   const activeStarterPack = useActiveStarterPack()
   const setActiveStarterPack = useSetActiveStarterPack()
@@ -82,7 +83,10 @@ export function StepFinished() {
       }
       try {
         if (starterPack?.list) {
-          listItems = await getAllListMembers(agent, starterPack.list.uri)
+          listItems = await getAllListMembers(
+            appviewClient,
+            starterPack.list.uri,
+          )
         }
       } catch (e) {
         logger.error('Failed to fetch starter pack list items', {
@@ -231,6 +235,7 @@ export function StepFinished() {
     ax,
     queryClient,
     agent,
+    appviewClient,
     dispatch,
     onboardDispatch,
     activeStarterPack,

--- a/src/screens/Onboarding/StepSuggestedStarterpacks/StarterPackCard.tsx
+++ b/src/screens/Onboarding/StepSuggestedStarterpacks/StarterPackCard.tsx
@@ -11,7 +11,7 @@ import {isBlockedOrBlocking, isMuted} from '#/lib/moderation/blocked-and-muted'
 import {logger} from '#/logger'
 import {updateProfileShadow} from '#/state/cache/profile-shadow'
 import {getAllListMembers} from '#/state/queries/list-members'
-import {useAgent, useSession} from '#/state/session'
+import {useAgent, useAppviewClient, useSession} from '#/state/session'
 import {bulkWriteFollows} from '#/screens/Onboarding/util'
 import {AvatarStack} from '#/screens/Search/components/StarterPackCard'
 import {atoms as a, useBreakpoints, useTheme, web} from '#/alf'
@@ -36,6 +36,7 @@ export function StarterPackCard({
   const {currentAccount} = useSession()
   const {gtPhone} = useBreakpoints()
   const agent = useAgent()
+  const appviewClient = useAppviewClient()
   const queryClient = useQueryClient()
   const record = view.record
   const [isProcessing, setIsProcessing] = useState(false)
@@ -48,7 +49,7 @@ export function StarterPackCard({
 
     let listItems: AppBskyGraphDefs.ListItemView[] = []
     try {
-      listItems = await getAllListMembers(agent, view.list.uri)
+      listItems = await getAllListMembers(appviewClient, view.list.uri)
     } catch (e) {
       setIsProcessing(false)
       Toast.show(_(msg`An error occurred while trying to follow all`), {

--- a/src/screens/StarterPack/StarterPackScreen.tsx
+++ b/src/screens/StarterPack/StarterPackScreen.tsx
@@ -37,7 +37,7 @@ import {
   useDeleteStarterPackMutation,
   useStarterPackQuery,
 } from '#/state/queries/starter-packs'
-import {useAgent, useSession} from '#/state/session'
+import {useAgent, useAppviewClient, useSession} from '#/state/session'
 import {useSetActiveStarterPack} from '#/state/shell/landing'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
 import {
@@ -312,6 +312,7 @@ function Header({
   const t = useTheme()
   const {currentAccount, hasSession} = useSession()
   const agent = useAgent()
+  const appviewClient = useAppviewClient()
   const queryClient = useQueryClient()
   const setActiveStarterPack = useSetActiveStarterPack()
   const {requestSwitchToAccount} = useLoggedOutViewControls()
@@ -354,7 +355,7 @@ function Header({
 
     let listItems: AppBskyGraphDefs.ListItemView[] = []
     try {
-      listItems = await getAllListMembers(agent, starterPack.list.uri)
+      listItems = await getAllListMembers(appviewClient, starterPack.list.uri)
     } catch (e) {
       setIsProcessing(false)
       Toast.show(_(msg`An error occurred while trying to follow all`), {

--- a/src/state/queries/list-members.ts
+++ b/src/state/queries/list-members.ts
@@ -1,8 +1,5 @@
-import {
-  type AppBskyActorDefs,
-  type AppBskyGraphDefs,
-  type AtpAgent,
-} from '@atproto/api'
+import {type AppBskyActorDefs, type AppBskyGraphDefs} from '@atproto/api'
+import {type Client} from '@atproto/lex'
 import {type AtUriString} from '@atproto/syntax'
 import {
   type InfiniteData,
@@ -13,7 +10,7 @@ import {
 } from '@tanstack/react-query'
 
 import {STALE} from '#/state/queries'
-import {useAgent, useAppviewClient} from '#/state/session'
+import {useAppviewClient} from '#/state/session'
 import {app} from '#/lexicons'
 
 const PAGE_SIZE = 30
@@ -50,36 +47,32 @@ export function useListMembersQuery(uri?: string, limit: number = PAGE_SIZE) {
 }
 
 export function useAllListMembersQuery(uri?: string) {
-  const agent = useAgent()
+  const client = useAppviewClient()
   return useQuery({
     staleTime: STALE.MINUTES.ONE,
     queryKey: RQKEY_ALL(uri ?? ''),
     queryFn: async () => {
-      return getAllListMembers(agent, uri!)
+      return getAllListMembers(client, uri!)
     },
     enabled: Boolean(uri),
   })
 }
 
-/*
- * Still on the legacy agent: four call sites outside this cluster pass their
- * own `AtpAgent`, so the parameter type is migrated with those consumers.
- */
-export async function getAllListMembers(agent: AtpAgent, uri: string) {
+export async function getAllListMembers(client: Client, uri: string) {
   let hasMore = true
   let cursor: string | undefined
   const listItems: AppBskyGraphDefs.ListItemView[] = []
   // We want to cap this at 6 pages, just for anything weird happening with the api
   let i = 0
   while (hasMore && i < 6) {
-    const res = await agent.app.bsky.graph.getList({
-      list: uri,
+    const res = await client.call(app.bsky.graph.getList, {
+      list: uri as AtUriString,
       limit: 50,
       cursor,
     })
-    listItems.push(...res.data.items)
-    hasMore = Boolean(res.data.cursor)
-    cursor = res.data.cursor
+    listItems.push(...res.items)
+    hasMore = Boolean(res.cursor)
+    cursor = res.cursor
     i++
   }
   return listItems


### PR DESCRIPTION
Seventeenth slice of #11182 (stacked on #11369). Tiny unblocker: `getAllListMembers(agent, uri)` becomes `(client, uri)` on the appview client (it is an `app.bsky.graph.getList` read), and its four callers thread `useAppviewClient()`. Landing this first keeps the repo-writes slices about writes only - three of the four callers are touched again there.

## Verification
- `pnpm typecheck` 0 errors (ios + android + web), `pnpm test` 54/54 suites, `pnpm lint` + `pnpm prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
