### PR TITLE
[SDK] Address stack review feedback

### DIFF
--- a/src/lib/lexClient.ts
+++ b/src/lib/lexClient.ts
@@ -40,7 +40,12 @@ export function createLexClient(
  * Requests use PLAIN `fetch`, not `networkAwareFetch`: the host is untrusted
  * input, and a typo'd or dead service must not be reported as the app losing
  * network reachability.
+ *
+ * `appLabelers: null` suppresses the global `Client.appLabelers` static: these
+ * are `com.atproto.server` calls to a host the user typed, which have no use
+ * for moderation labels, and the header would disclose the app's configured
+ * moderation authorities to an arbitrary third-party server.
  */
 export function createServiceClient(service: string): Client {
-  return createLexClient({service})
+  return createLexClient({service}, {appLabelers: null})
 }

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -27,6 +27,15 @@ const TRUSTED_REGEX = new RegExp(
   )})|/|#)`,
 )
 
+export function canParseUrl(url: string | URL, base?: string | URL): boolean {
+  try {
+    new URL(url, base)
+    return true
+  } catch {
+    return false
+  }
+}
+
 export function isValidDomain(str: string): boolean {
   return !!TLDs.find(tld => {
     let i = str.lastIndexOf(tld)

--- a/src/screens/Login/LoginForm.tsx
+++ b/src/screens/Login/LoginForm.tsx
@@ -169,7 +169,9 @@ export const LoginForm = ({
           )
         } else {
           logger.warn('Failed to login', {error: errMsg})
-          setError(cleanError(errMsg))
+          /* the error object, not its stringification: cleanError only
+           * extracts the clean server message from a live LexError */
+          setError(cleanError(err))
         }
       }
     }

--- a/src/screens/Signup/state.ts
+++ b/src/screens/Signup/state.ts
@@ -354,7 +354,6 @@ export function useSubmitSignup() {
         onboardingDispatch({type: 'start'})
       } catch (err) {
         const e = err as Error
-        let errMsg = e.toString()
         if (
           matchXrpcError(e, com.atproto.server.createAccount) ===
           'InvalidInviteCode'
@@ -368,7 +367,9 @@ export function useSubmitSignup() {
           return
         }
 
-        const error = cleanError(errMsg)
+        /* the error object, not its stringification: cleanError only extracts
+         * the clean server message from a live LexError */
+        const error = cleanError(e)
         const isHandleError = error.toLowerCase().includes('handle')
 
         dispatch({type: 'setIsLoading', value: false})

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -206,21 +206,21 @@ export function useProfileUpdateMutation() {
         appviewClient,
         profile.did,
         checkCommitted ||
-          (profile => {
+          (fresh => {
             if (typeof newUserAvatar !== 'undefined') {
-              if (newUserAvatar === null && profile.avatar) {
+              if (newUserAvatar === null && fresh.avatar) {
                 // url hasn't cleared yet
                 return false
-              } else if (profile.avatar === profile.avatar) {
+              } else if (fresh.avatar === profile.avatar) {
                 // url hasn't changed yet
                 return false
               }
             }
             if (typeof newUserBanner !== 'undefined') {
-              if (newUserBanner === null && profile.banner) {
+              if (newUserBanner === null && fresh.banner) {
                 // url hasn't cleared yet
                 return false
-              } else if (profile.banner === profile.banner) {
+              } else if (fresh.banner === profile.banner) {
                 // url hasn't changed yet
                 return false
               }
@@ -229,8 +229,8 @@ export function useProfileUpdateMutation() {
               return true
             }
             return (
-              profile.displayName === updates.displayName &&
-              profile.description === updates.description
+              fresh.displayName === updates.displayName &&
+              fresh.description === updates.description
             )
           }),
       )

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -157,7 +157,19 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       sessionEvent: AtpSessionEvent,
       sessionData?: SessionData,
     ) => {
-      if (sessionEvent === 'update' && sessionData) {
+      /*
+       * Only the live bundle may reset the expiry-rescue bookkeeping: a stale
+       * bundle's late update would otherwise clear the failed-generation set
+       * that bounds the rescue loop. (Its dispatch below is separately dropped
+       * by the reducer's identity guard.)
+       */
+      if (
+        sessionEvent === 'update' &&
+        sessionData &&
+        (store.getState().currentBundleState.bundle as unknown as
+          | SessionBundle
+          | PublicSessionBundle) === bundle
+      ) {
         failedExpiryTokensRef.current.get(accountDid)?.clear()
       }
 
@@ -504,6 +516,18 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
     const after = await bundle.session.refresh()
     if (after === before) {
       throw new Error('Failed to refresh session')
+    }
+    /*
+     * The user may have logged out or switched accounts while the refresh was
+     * in flight. Reporting success then would run the caller's success path
+     * (dialogs closing, success toasts, SignupQueued advancing) against an
+     * account that is no longer active, so a stale bundle rejects instead.
+     */
+    if (
+      (store.getState().currentBundleState.bundle as unknown) !==
+      (bundle as unknown)
+    ) {
+      throw new Error('The session changed while it was being refreshed')
     }
     /*
      * The session's `onUpdated` hook dispatches the new tokens into the store,

--- a/src/state/session/session-core.ts
+++ b/src/state/session/session-core.ts
@@ -6,6 +6,7 @@ import {
 } from '@atproto/lex-password-session'
 
 import {PUBLIC_BSKY_SERVICE} from '#/lib/constants'
+import {canParseUrl} from '#/lib/strings/url-helpers'
 import {logger} from '#/logger'
 import {prefetchAgeAssuranceServerData} from '#/ageAssurance/data'
 import {features} from '#/analytics'
@@ -102,7 +103,7 @@ export function buildBundle(
    * and let the session route against its own service instead.
    */
   const agent =
-    storedPdsUrl && URL.canParse(storedPdsUrl)
+    storedPdsUrl && canParseUrl(storedPdsUrl)
       ? routeSessionToPds(session, storedPdsUrl)
       : session
   return {

--- a/src/state/session/session-core.ts
+++ b/src/state/session/session-core.ts
@@ -95,9 +95,16 @@ export function buildBundle(
   session: PasswordSession,
   storedPdsUrl?: string,
 ): SessionBundle {
-  const agent = storedPdsUrl
-    ? routeSessionToPds(session, storedPdsUrl)
-    : session
+  /*
+   * The stored url is persisted data and may be malformed (legacy writes,
+   * corruption). `routeSessionToPds` feeds it to `new URL()` on every request,
+   * so an invalid value would throw from every client call; discard it here
+   * and let the session route against its own service instead.
+   */
+  const agent =
+    storedPdsUrl && URL.canParse(storedPdsUrl)
+      ? routeSessionToPds(session, storedPdsUrl)
+      : session
   return {
     session,
     appviewClient: buildAppviewClient(agent),

--- a/src/state/session/session-data.ts
+++ b/src/state/session/session-data.ts
@@ -1,4 +1,3 @@
-import {getPdsEndpoint, isValidDidDoc} from '@atproto/common-web'
 import {type SessionData} from '@atproto/lex-password-session'
 import {jwtDecode} from 'jwt-decode'
 
@@ -6,6 +5,42 @@ import {BSKY_SERVICE} from '#/lib/constants'
 import {isJwtExpired} from '#/lib/jwt'
 import {hasProp} from '#/lib/type-guards'
 import {type SessionAccount} from './types'
+
+/**
+ * The PDS endpoint declared by a DID document, or `undefined`.
+ *
+ * This deliberately mirrors `extractPdsUrl` in `@atproto/lex-password-session`,
+ * the predicate `PasswordSession` uses to route its own requests: the first
+ * service entry whose `id` ends with `#atproto_pds`, taking its
+ * `serviceEndpoint` if it parses as a URL. A stricter predicate here (schema
+ * validation, `type` checks) would let the PERSISTED `pdsUrl` disagree with
+ * the host the live session actually routes to, so the next cold start would
+ * seed the wrong endpoint.
+ */
+function extractPdsUrl(didDoc: SessionData['didDoc']): string | undefined {
+  const services = prop(didDoc, 'service')
+  if (!Array.isArray(services)) {
+    return undefined
+  }
+  const pds = services.find(service => {
+    const id = prop(service, 'id')
+    return typeof id === 'string' && id.endsWith('#atproto_pds')
+  })
+  const endpoint = prop(pds, 'serviceEndpoint')
+  return typeof endpoint === 'string' && URL.canParse(endpoint)
+    ? endpoint
+    : undefined
+}
+
+/**
+ * Read a property off an unknown value the way JS optional chaining would,
+ * without narrowing assumptions about the shape of a `LexMap`.
+ */
+function prop(value: unknown, key: string): unknown {
+  return typeof value === 'object' && value !== null
+    ? (value as Record<string, unknown>)[key]
+    : undefined
+}
 
 /** Whether an access token was issued for a queued (waitlisted) signup. */
 export function isSignupQueued(accessJwt: string | undefined) {
@@ -40,11 +75,7 @@ export function sessionDataToSessionAccount(
     return undefined
   }
   const normalizedService = new URL(service).toString()
-  const didDocPdsUrl =
-    session.didDoc && isValidDidDoc(session.didDoc)
-      ? getPdsEndpoint(session.didDoc)
-      : undefined
-  const pdsUrl = didDocPdsUrl ?? storedPdsUrl
+  const pdsUrl = extractPdsUrl(session.didDoc) ?? storedPdsUrl
   return {
     service: normalizedService,
     did: session.did,

--- a/src/state/session/session-data.ts
+++ b/src/state/session/session-data.ts
@@ -1,46 +1,13 @@
-import {type SessionData} from '@atproto/lex-password-session'
+import {
+  extractPdsEndpoint,
+  type SessionData,
+} from '@atproto/lex-password-session'
 import {jwtDecode} from 'jwt-decode'
 
 import {BSKY_SERVICE} from '#/lib/constants'
 import {isJwtExpired} from '#/lib/jwt'
 import {hasProp} from '#/lib/type-guards'
 import {type SessionAccount} from './types'
-
-/**
- * The PDS endpoint declared by a DID document, or `undefined`.
- *
- * This deliberately mirrors `extractPdsUrl` in `@atproto/lex-password-session`,
- * the predicate `PasswordSession` uses to route its own requests: the first
- * service entry whose `id` ends with `#atproto_pds`, taking its
- * `serviceEndpoint` if it parses as a URL. A stricter predicate here (schema
- * validation, `type` checks) would let the PERSISTED `pdsUrl` disagree with
- * the host the live session actually routes to, so the next cold start would
- * seed the wrong endpoint.
- */
-function extractPdsUrl(didDoc: SessionData['didDoc']): string | undefined {
-  const services = prop(didDoc, 'service')
-  if (!Array.isArray(services)) {
-    return undefined
-  }
-  const pds = services.find(service => {
-    const id = prop(service, 'id')
-    return typeof id === 'string' && id.endsWith('#atproto_pds')
-  })
-  const endpoint = prop(pds, 'serviceEndpoint')
-  return typeof endpoint === 'string' && URL.canParse(endpoint)
-    ? endpoint
-    : undefined
-}
-
-/**
- * Read a property off an unknown value the way JS optional chaining would,
- * without narrowing assumptions about the shape of a `LexMap`.
- */
-function prop(value: unknown, key: string): unknown {
-  return typeof value === 'object' && value !== null
-    ? (value as Record<string, unknown>)[key]
-    : undefined
-}
 
 /** Whether an access token was issued for a queued (waitlisted) signup. */
 export function isSignupQueued(accessJwt: string | undefined) {
@@ -75,7 +42,7 @@ export function sessionDataToSessionAccount(
     return undefined
   }
   const normalizedService = new URL(service).toString()
-  const pdsUrl = extractPdsUrl(session.didDoc) ?? storedPdsUrl
+  const pdsUrl = extractPdsEndpoint(session.didDoc) ?? storedPdsUrl
   return {
     service: normalizedService,
     did: session.did,


### PR DESCRIPTION
Review-feedback slice on top of the stack (stacked on #11387). Six findings from the stack review, each verified against the code before fixing; two of the findings' fix sites textually belong to lower branches but land here to avoid a 26-branch rebase.

## Fixes

**#11386 (medium) - self-comparing profile commit checks** (`state/queries/profile.ts`)
The type-flip codemod renamed the commit-check callback's param to `profile`, shadowing the outer stale-profile binding - `profile.avatar === profile.avatar` was always true, so the check always reported "not committed", burned all five polls, and verified nothing. The callback param is now `fresh`, restoring fresh-vs-stale comparison.

**#11343 (low) - errors stringified before `cleanError`** (`Login/LoginForm.tsx`, `Signup/state.ts`)
Both passed `String(err)` into `cleanError`, defeating its `LexError` branch and surfacing `XrpcResponseError: [Code] message` prefixes to users. Both now pass the error object.

**#11343 (low) - stale bundle clears expiry-rescue bookkeeping** (`state/session/index.tsx`)
The `update` branch cleared the failed-generation set before the reducer's identity guard could reject a stale bundle, so a replaced bundle's late refresh could unbound the rescue loop. The clear is now gated on live-bundle identity.

**#11343 (low) - persisted-PDS extraction stricter than live routing** (`state/session/session-data.ts`)
Persistence used strict `isValidDidDoc` + `getPdsEndpoint` while the live session routes with the lenient `endsWith('#atproto_pds')` predicate - a didDoc failing strict validation persisted no `pdsUrl` while the session happily routed to it, seeding the wrong host on the next cold start. Persistence now mirrors the session's own predicate (documented local copy).

**#11381 (low) - in-flight refresh reports success after account switch** (`state/session/index.tsx`)
`refreshSession` resolving after logout/switch would run callers' success paths (dialogs closing, toasts, SignupQueued advancing) against a defunct account. It now re-checks bundle identity after the await and rejects on mismatch.

**#11383 (low) - moderation-authority headers sent to arbitrary hosts** (`lib/lexClient.ts`)
`createServiceClient` inherited the global `Client.appLabelers` static, so pre-auth `com.atproto.server` calls to a user-typed PDS host disclosed the app's configured moderation authorities. Now built with `appLabelers: null`. (The other raw service-client sites - chat, video - are first-party and unchanged.)

**#11385 (low) - malformed persisted `pdsUrl` bricks the clients** (`state/session/session-core.ts`)
`routeSessionToPds` feeds the persisted string to `new URL()` on every request, so a corrupt legacy value would throw from every client call. `buildBundle` now guards with `URL.canParse` and falls back to the session's own routing.

## Not fixed here

**#11368 - report classification only accepts legacy `XRPCError`**: real on that branch in isolation, but already resolved at the tip - the `@atproto/api`-removal slice converted `classifyReportError` to `XrpcResponseError`. No change needed.

## Verification
- `pnpm typecheck` 0 errors (ios + android + web), `pnpm test` 55/55 suites (751 passed + 28 todo), `pnpm lint` + `pnpm prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
