### PR TITLE
Test requiring at least one interest in onboarding

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -933,17 +933,6 @@
       "count": 1
     }
   },
-  "src/screens/Onboarding/StepInterests/index.tsx": {
-    "typescript/no-explicit-any": {
-      "count": 1
-    },
-    "typescript/no-misused-promises": {
-      "count": 1
-    },
-    "typescript/require-await": {
-      "count": 1
-    }
-  },
   "src/screens/Onboarding/StepProfile/index.tsx": {
     "typescript/no-floating-promises": {
       "count": 2

--- a/src/analytics/features/types.ts
+++ b/src/analytics/features/types.ts
@@ -22,6 +22,7 @@ export enum Features {
   VideoMultipartUploadEnable = 'video:multipart_upload:enable',
   SearchStarterPacksV2Enable = 'search_starter_packs_v2:enable',
   FollowSortEnable = 'follow_sort:enable',
+  OnboardingInterestsRequiredEnable = 'onboarding:interests:required:enable',
 
   // values
   TrendingDiscoverValues = 'trending_discover:values',

--- a/src/analytics/metrics/types.ts
+++ b/src/analytics/metrics/types.ts
@@ -143,6 +143,7 @@ export type Events = {
     selectedInterests: string[]
     selectedInterestsLength: number
   }
+  'onboarding:interests:disabledNextPressed': {}
   'onboarding:suggestedAccounts:tabPressed': {
     tab: string
   }

--- a/src/components/Toast/types.ts
+++ b/src/components/Toast/types.ts
@@ -19,6 +19,7 @@ export type BaseToastOptions = Pick<
   'duration' | 'dismissible' | 'promiseOptions'
 > & {
   type?: ToastType
+  position?: 'top-center' | 'bottom-center'
 
   /**
    * These methods differ between web/native implementations

--- a/src/components/Toast/types.ts
+++ b/src/components/Toast/types.ts
@@ -19,7 +19,6 @@ export type BaseToastOptions = Pick<
   'duration' | 'dismissible' | 'promiseOptions'
 > & {
   type?: ToastType
-  position?: 'top-center' | 'bottom-center'
 
   /**
    * These methods differ between web/native implementations

--- a/src/screens/Onboarding/StepInterests/index.tsx
+++ b/src/screens/Onboarding/StepInterests/index.tsx
@@ -1,5 +1,5 @@
 import {useCallback, useState} from 'react'
-import {View} from 'react-native'
+import {Pressable, View} from 'react-native'
 import {Trans, useLingui} from '@lingui/react/macro'
 
 import {interests, useInterestsDisplayNames} from '#/lib/interests'
@@ -17,6 +17,7 @@ import {atoms as a} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import * as Toggle from '#/components/forms/Toggle'
 import {Loader} from '#/components/Loader'
+import * as Toast from '#/components/Toast'
 import {useAnalytics} from '#/analytics'
 
 export function StepInterests() {
@@ -69,6 +70,7 @@ export function StepInterests() {
         {interestRequired ? (
           <Trans>
             Choose at least one. We'll use this to customize your experience.
+            You can change these anytime.
           </Trans>
         ) : (
           <Trans>We'll use this to help customize your experience.</Trans>
@@ -94,27 +96,46 @@ export function StepInterests() {
       </View>
 
       <OnboardingControls.Portal>
-        <Button
-          disabled={saving || missingRequiredInterest}
-          testID="onboardingContinue"
-          variant="solid"
-          color="primary"
-          size="large"
-          label={
-            missingRequiredInterest
-              ? l`Choose an interest`
-              : l`Continue to next step`
-          }
-          onPress={saveInterests}>
-          <ButtonText>
-            {missingRequiredInterest ? (
-              <Trans>Choose an interest</Trans>
-            ) : (
-              <Trans>Continue</Trans>
-            )}
-          </ButtonText>
-          {saving && <ButtonIcon icon={Loader} />}
-        </Button>
+        <View style={[a.relative]}>
+          <Button
+            disabled={saving || missingRequiredInterest}
+            testID="onboardingContinue"
+            variant="solid"
+            color="primary"
+            size="large"
+            label={
+              missingRequiredInterest
+                ? l`Choose an interest`
+                : l`Continue to next step`
+            }
+            onPress={saveInterests}>
+            <ButtonText>
+              {missingRequiredInterest ? (
+                <Trans>Choose an interest</Trans>
+              ) : (
+                <Trans>Continue</Trans>
+              )}
+            </ButtonText>
+            {saving && <ButtonIcon icon={Loader} />}
+          </Button>
+          {missingRequiredInterest && (
+            /*
+             * A disabled button receives no touch events, so this invisible
+             * overlay catches taps on it to explain why it is disabled.
+             */
+            <Pressable
+              accessible={false}
+              focusable={false}
+              style={[a.absolute, a.inset_0]}
+              onPress={() => {
+                Toast.show(l`Choose at least one interest.`, {
+                  position: 'top-center',
+                })
+                ax.metric('onboarding:interests:disabledNextPressed', {})
+              }}
+            />
+          )}
+        </View>
       </OnboardingControls.Portal>
     </View>
   )

--- a/src/screens/Onboarding/StepInterests/index.tsx
+++ b/src/screens/Onboarding/StepInterests/index.tsx
@@ -1,5 +1,5 @@
 import {useCallback, useState} from 'react'
-import {View} from 'react-native'
+import {Pressable, View} from 'react-native'
 import {Trans, useLingui} from '@lingui/react/macro'
 
 import {interests, useInterestsDisplayNames} from '#/lib/interests'
@@ -41,10 +41,9 @@ export function StepInterests() {
   const missingRequiredInterest =
     interestRequired && selectedInterests.length === 0
 
-  const onVisibleChange = (visible: boolean) => {
-    if (!missingRequiredInterest) return
+  const showMissingInterestTooltip = () => {
     ax.metric('onboarding:interests:disabledNextPressed', {})
-    setTooltipVisible(visible)
+    setTooltipVisible(true)
   }
 
   const saveInterests = useCallback(() => {
@@ -67,6 +66,30 @@ export function StepInterests() {
       logger.error(e)
     }
   }, [ax, selectedInterests, setSaving, dispatch])
+
+  const continueButton = (
+    <Button
+      disabled={saving || missingRequiredInterest}
+      testID="onboardingContinue"
+      variant="solid"
+      color="primary"
+      size="large"
+      label={
+        missingRequiredInterest
+          ? l`Choose an interest`
+          : l`Continue to next step`
+      }
+      onPress={() => void saveInterests()}>
+      <ButtonText style={{pointerEvents: 'none'}}>
+        {missingRequiredInterest ? (
+          <Trans>Choose an interest</Trans>
+        ) : (
+          <Trans>Continue</Trans>
+        )}
+      </ButtonText>
+      {saving && <ButtonIcon icon={Loader} />}
+    </Button>
+  )
 
   return (
     <View style={[a.align_start, a.gap_sm]} testID="onboardingInterests">
@@ -105,37 +128,32 @@ export function StepInterests() {
 
       <OnboardingControls.Portal>
         <View style={[a.relative]}>
-          <Tooltip.Outer
-            color="primary"
-            visible={tooltipVisible}
-            onVisibleChange={onVisibleChange}>
-            <Tooltip.Target>
-              <Button
-                disabled={saving || missingRequiredInterest}
-                testID="onboardingContinue"
-                variant="solid"
-                color="primary"
-                size="large"
-                label={
-                  missingRequiredInterest
-                    ? l`Choose an interest`
-                    : l`Continue to next step`
-                }
-                onPress={() => void saveInterests()}>
-                <ButtonText style={{pointerEvents: 'none'}}>
-                  {missingRequiredInterest ? (
-                    <Trans>Choose an interest</Trans>
-                  ) : (
-                    <Trans>Continue</Trans>
-                  )}
-                </ButtonText>
-                {saving && <ButtonIcon icon={Loader} />}
-              </Button>
-            </Tooltip.Target>
-            <Tooltip.BubbleText label={l`Beta features enabled`}>
-              <Trans>Choose at least one interest.</Trans>
-            </Tooltip.BubbleText>
-          </Tooltip.Outer>
+          {missingRequiredInterest ? (
+            <Tooltip.Outer
+              position="top"
+              visible={tooltipVisible}
+              onVisibleChange={setTooltipVisible}>
+              <Tooltip.Target>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={l`Choose an interest`}
+                  accessibilityHint={l`Choose at least one interest to continue`}
+                  onPress={showMissingInterestTooltip}>
+                  <View
+                    pointerEvents="none"
+                    accessibilityElementsHidden
+                    importantForAccessibility="no-hide-descendants">
+                    {continueButton}
+                  </View>
+                </Pressable>
+              </Tooltip.Target>
+              <Tooltip.BubbleText label={l`Choose at least one interest.`}>
+                <Trans>Choose at least one interest.</Trans>
+              </Tooltip.BubbleText>
+            </Tooltip.Outer>
+          ) : (
+            continueButton
+          )}
         </View>
       </OnboardingControls.Portal>
     </View>

--- a/src/screens/Onboarding/StepInterests/index.tsx
+++ b/src/screens/Onboarding/StepInterests/index.tsx
@@ -35,7 +35,7 @@ export function StepInterests() {
    * Behind this gate, users must choose at least one interest before they can
    * continue.
    */
-  const interestRequired = !ax.features.enabled(
+  const interestRequired = ax.features.enabled(
     ax.features.OnboardingInterestsRequiredEnable,
   )
   const missingRequiredInterest =

--- a/src/screens/Onboarding/StepInterests/index.tsx
+++ b/src/screens/Onboarding/StepInterests/index.tsx
@@ -1,8 +1,6 @@
 import {useCallback, useState} from 'react'
 import {View} from 'react-native'
-import {msg} from '@lingui/core/macro'
-import {useLingui} from '@lingui/react'
-import {Trans} from '@lingui/react/macro'
+import {Trans, useLingui} from '@lingui/react/macro'
 
 import {interests, useInterestsDisplayNames} from '#/lib/interests'
 import {capitalize} from '#/lib/strings/capitalize'
@@ -22,7 +20,7 @@ import {Loader} from '#/components/Loader'
 import {useAnalytics} from '#/analytics'
 
 export function StepInterests() {
-  const {_} = useLingui()
+  const {t: l} = useLingui()
   const ax = useAnalytics()
   const interestsDisplayNames = useInterestsDisplayNames()
 
@@ -31,6 +29,15 @@ export function StepInterests() {
   const [selectedInterests, setSelectedInterests] = useState<string[]>(
     state.interestsStepResults.selectedInterests.map(i => i),
   )
+  /*
+   * Behind this gate, users must choose at least one interest before they can
+   * continue.
+   */
+  const interestRequired = ax.features.enabled(
+    ax.features.OnboardingInterestsRequiredEnable,
+  )
+  const missingRequiredInterest =
+    interestRequired && selectedInterests.length === 0
 
   const saveInterests = useCallback(async () => {
     setSaving(true)
@@ -59,14 +66,20 @@ export function StepInterests() {
         <Trans>What are your interests?</Trans>
       </OnboardingTitleText>
       <OnboardingDescriptionText>
-        <Trans>We'll use this to help customize your experience.</Trans>
+        {interestRequired ? (
+          <Trans>
+            Choose at least one. We'll use this to customize your experience.
+          </Trans>
+        ) : (
+          <Trans>We'll use this to help customize your experience.</Trans>
+        )}
       </OnboardingDescriptionText>
 
       <View style={[a.w_full, a.pt_lg]}>
         <Toggle.Group
           values={selectedInterests}
           onChange={setSelectedInterests}
-          label={_(msg`Select your interests from the options below`)}>
+          label={l`Select your interests from the options below`}>
           <View style={[a.flex_row, a.gap_md, a.flex_wrap]}>
             {interests.map(interest => (
               <Toggle.Item
@@ -82,15 +95,23 @@ export function StepInterests() {
 
       <OnboardingControls.Portal>
         <Button
-          disabled={saving}
+          disabled={saving || missingRequiredInterest}
           testID="onboardingContinue"
           variant="solid"
           color="primary"
           size="large"
-          label={_(msg`Continue to next step`)}
+          label={
+            missingRequiredInterest
+              ? l`Choose an interest`
+              : l`Continue to next step`
+          }
           onPress={saveInterests}>
           <ButtonText>
-            <Trans>Continue</Trans>
+            {missingRequiredInterest ? (
+              <Trans>Choose an interest</Trans>
+            ) : (
+              <Trans>Continue</Trans>
+            )}
           </ButtonText>
           {saving && <ButtonIcon icon={Loader} />}
         </Button>

--- a/src/screens/Onboarding/StepInterests/index.tsx
+++ b/src/screens/Onboarding/StepInterests/index.tsx
@@ -1,5 +1,5 @@
 import {useCallback, useState} from 'react'
-import {Pressable, View} from 'react-native'
+import {View} from 'react-native'
 import {Trans, useLingui} from '@lingui/react/macro'
 
 import {interests, useInterestsDisplayNames} from '#/lib/interests'
@@ -17,7 +17,7 @@ import {atoms as a} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import * as Toggle from '#/components/forms/Toggle'
 import {Loader} from '#/components/Loader'
-import * as Toast from '#/components/Toast'
+import * as Tooltip from '#/components/Tooltip'
 import {useAnalytics} from '#/analytics'
 
 export function StepInterests() {
@@ -27,6 +27,7 @@ export function StepInterests() {
 
   const {state, dispatch} = useOnboardingInternalState()
   const [saving, setSaving] = useState(false)
+  const [tooltipVisible, setTooltipVisible] = useState(false)
   const [selectedInterests, setSelectedInterests] = useState<string[]>(
     state.interestsStepResults.selectedInterests.map(i => i),
   )
@@ -34,13 +35,19 @@ export function StepInterests() {
    * Behind this gate, users must choose at least one interest before they can
    * continue.
    */
-  const interestRequired = ax.features.enabled(
+  const interestRequired = !ax.features.enabled(
     ax.features.OnboardingInterestsRequiredEnable,
   )
   const missingRequiredInterest =
     interestRequired && selectedInterests.length === 0
 
-  const saveInterests = useCallback(async () => {
+  const onVisibleChange = (visible: boolean) => {
+    if (!missingRequiredInterest) return
+    ax.metric('onboarding:interests:disabledNextPressed', {})
+    setTooltipVisible(visible)
+  }
+
+  const saveInterests = useCallback(() => {
     setSaving(true)
 
     try {
@@ -54,8 +61,9 @@ export function StepInterests() {
         selectedInterests,
         selectedInterestsLength: selectedInterests.length,
       })
-    } catch (e: any) {
-      logger.info(`onboading: error saving interests`)
+    } catch (error) {
+      const e = error as Error
+      logger.info(`onboarding: error saving interests`)
       logger.error(e)
     }
   }, [ax, selectedInterests, setSaving, dispatch])
@@ -97,44 +105,37 @@ export function StepInterests() {
 
       <OnboardingControls.Portal>
         <View style={[a.relative]}>
-          <Button
-            disabled={saving || missingRequiredInterest}
-            testID="onboardingContinue"
-            variant="solid"
+          <Tooltip.Outer
             color="primary"
-            size="large"
-            label={
-              missingRequiredInterest
-                ? l`Choose an interest`
-                : l`Continue to next step`
-            }
-            onPress={saveInterests}>
-            <ButtonText>
-              {missingRequiredInterest ? (
-                <Trans>Choose an interest</Trans>
-              ) : (
-                <Trans>Continue</Trans>
-              )}
-            </ButtonText>
-            {saving && <ButtonIcon icon={Loader} />}
-          </Button>
-          {missingRequiredInterest && (
-            /*
-             * A disabled button receives no touch events, so this invisible
-             * overlay catches taps on it to explain why it is disabled.
-             */
-            <Pressable
-              accessible={false}
-              focusable={false}
-              style={[a.absolute, a.inset_0]}
-              onPress={() => {
-                Toast.show(l`Choose at least one interest.`, {
-                  position: 'top-center',
-                })
-                ax.metric('onboarding:interests:disabledNextPressed', {})
-              }}
-            />
-          )}
+            visible={tooltipVisible}
+            onVisibleChange={onVisibleChange}>
+            <Tooltip.Target>
+              <Button
+                disabled={saving || missingRequiredInterest}
+                testID="onboardingContinue"
+                variant="solid"
+                color="primary"
+                size="large"
+                label={
+                  missingRequiredInterest
+                    ? l`Choose an interest`
+                    : l`Continue to next step`
+                }
+                onPress={() => void saveInterests()}>
+                <ButtonText style={{pointerEvents: 'none'}}>
+                  {missingRequiredInterest ? (
+                    <Trans>Choose an interest</Trans>
+                  ) : (
+                    <Trans>Continue</Trans>
+                  )}
+                </ButtonText>
+                {saving && <ButtonIcon icon={Loader} />}
+              </Button>
+            </Tooltip.Target>
+            <Tooltip.BubbleText label={l`Beta features enabled`}>
+              <Trans>Choose at least one interest.</Trans>
+            </Tooltip.BubbleText>
+          </Tooltip.Outer>
         </View>
       </OnboardingControls.Portal>
     </View>


### PR DESCRIPTION
## What this does

Requires new users to pick at least one interest during onboarding, behind the `onboarding:interests:required:enable` feature gate.

When the gate is on and nothing is selected:

- The step description reads “Choose at least one. We'll use this to customize your experience. You can change these anytime.”
- The continue button is disabled and labeled “Choose an interest”
- Tapping the disabled button shows a “Choose at least one interest.” toast (top of the screen, so it doesn't cover the button) and logs a new `onboarding:interests:disabledNextPressed` client event

When the gate is off, nothing changes. 

Also adds an optional per-toast `position` option to the Toast component.

## Why

We want to improve new users' first impression of Discover, which they see right after onboarding. Interests drive feed personalization and account suggestions, but users can currently skip the step with zero selected, which gives them a worse first experience. Requiring an interest during onboarding comes with the tradeoff of added friction, so we want to test this carefully to ensure it's a positive tradeoff for most users. 

## How to test

1. Enable the `onboarding:interests:required:enable` gate (or temporarily force it on locally).
2. Create a new account and go through onboarding to the interests step.
3. With nothing selected: the button should be disabled and read “Choose an interest”. Tapping it shows the toast at the top of the screen.
4. Select an interest: the button should flip to “Continue” and work normally. Deselect it: the button should disable again.
5. With the gate off: the step should look and behave exactly like production today.
