### PR TITLE
Preserve app state across Android foldable configuration changes

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -301,6 +301,7 @@ module.exports = function (_config) {
         './plugins/withAndroidManifestLargeHeapPlugin.js',
         './plugins/withAndroidManifestFCMIconPlugin.js',
         './plugins/withAndroidManifestIntentQueriesPlugin.js',
+        './plugins/withAndroidManifestConfigChangesPlugin.js',
         './plugins/withAndroidStylesAccentColorPlugin.js',
         './plugins/withAndroidNoJitpackPlugin.js',
         './plugins/shareExtension/withShareExtensions.js',

--- a/plugins/withAndroidManifestConfigChangesPlugin.js
+++ b/plugins/withAndroidManifestConfigChangesPlugin.js
@@ -1,0 +1,27 @@
+const {withAndroidManifest} = require('expo/config-plugins')
+
+module.exports = function withAndroidManifestConfigChangesPlugin(appConfig) {
+  return withAndroidManifest(appConfig, function (decoratedAppConfig) {
+    try {
+      const application =
+        decoratedAppConfig.modResults.manifest.application?.[0]
+      const activity = application?.activity?.find(
+        a => a.$?.['android:name'] === '.MainActivity',
+      )
+      if (!activity) {
+        console.warn(
+          'withAndroidManifestConfigChangesPlugin: .MainActivity not found',
+        )
+        return decoratedAppConfig
+      }
+      const existing = activity.$['android:configChanges'] || ''
+      const tokens = new Set(existing.split('|').filter(Boolean))
+      tokens.add('smallestScreenSize')
+      tokens.add('density')
+      activity.$['android:configChanges'] = Array.from(tokens).join('|')
+    } catch (e) {
+      console.error(`withAndroidManifestConfigChangesPlugin failed`, e)
+    }
+    return decoratedAppConfig
+  })
+}


### PR DESCRIPTION
# Fix: preserve app state across foldable configuration changes

Closes #6693.

## What

On Android foldables (Samsung Fold, Pixel Fold, etc.), unfolding the device destroys and recreates the `MainActivity`, wiping in-memory app state. Users end up back at the start of the feed and lose the post/thread/DM they were viewing.

Root cause: the default `android:configChanges` value emitted by Expo SDK 54's template is

```
keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode
```

which is missing `smallestScreenSize` and `density` — the two configuration flags that fire on a fold/unfold transition. Without those flags, the runtime treats those config changes as "the Activity does not handle this," so it destroys and recreates.

## How

New Expo config plugin at `plugins/withAndroidManifestConfigChangesPlugin.js` that appends `smallestScreenSize` and `density` to `MainActivity`'s `android:configChanges` attribute. Uses a `Set` for idempotency so it stays clean if the underlying default ever changes upstream.

Follows the same shape as the existing `withAndroidManifestLargeHeapPlugin.js` and other `withAndroidManifest*Plugin.js` files in this repo.

## Test plan

Verified on a Samsung Galaxy Z Fold 5 (Android 14):

1. Sideloaded a build produced with this patch (EAS, Android APK).
2. Opened the app on the outer (front) screen, navigated into a specific post's thread view.
3. Unfolded to the inner (large) screen.
4. **Before this patch:** the app would restart, dropping the user back at the top of their feed.
5. **After this patch:** the app stays on the thread view. React Native's dimensions listener re-flows the layout for the new screen size. Very minor visible artifact on window resize, no state loss.

Also validated no regression on:
- Folding back to the outer screen.
- Rotation between portrait and landscape on both screens.

## Notes

- This is the "handle configChanges" approach from odbol's original write-up on #6693, option 2. The fix is to simply prevent the activity from being destroyed, no scrappy deep-linking or savestate needed. It does NOT address app-restart-from-low-memory-kill scenarios — that would need state persistence via React Navigation + `onSaveInstanceState`, and can be a follow-up.
