### PR TITLE
increase ci node heap

### DIFF
--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -22,6 +22,7 @@ permissions: {}
 # job downloads. Bump this one line to roll denis.
 env:
   DENIS_RELEASE_TAG: denis-v0.1.1
+  NODE_OPTIONS: --max-old-space-size=4096
 
 jobs:
   # Populate this from main so every PR can restore the same trusted baseline.


### PR DESCRIPTION
Raise Node's old-space heap limit to 4 GB for PR Tests. Non-public GitHub runners otherwise derive a roughly 2 GB limit and OOM during Expo export and webpack stats generation. Public runners already default to approximately 4 GB, so this should not materially change their behavior. This also ensures the setting is carried into social-app-internal by the sync workflow.