### PR TITLE
Fix profile icon on custom feeds

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -67,13 +67,14 @@ import {NotificationsScreen} from '#/view/screens/Notifications'
 import {PostThreadScreen} from '#/view/screens/PostThread'
 import {PrivacyPolicyScreen} from '#/view/screens/PrivacyPolicy'
 import {ProfileScreen} from '#/view/screens/Profile'
-import {ProfileFeedLikedByScreen} from '#/view/screens/ProfileFeedLikedBy'
 import {StorybookScreen} from '#/view/screens/Storybook'
 import {SupportScreen} from '#/view/screens/Support'
 import {TermsOfServiceScreen} from '#/view/screens/TermsOfService'
 import {BottomBar} from '#/view/shell/bottom-bar/BottomBar'
 import {createNativeStackNavigatorWithAuth} from '#/view/shell/createNativeStackNavigatorWithAuth'
 import {BookmarksScreen} from '#/screens/Bookmarks'
+import {CustomFeedScreen} from '#/screens/CustomFeed'
+import {CustomFeedLikedByScreen} from '#/screens/CustomFeed/CustomFeedLikedBy'
 import {SharedPreferencesTesterScreen} from '#/screens/E2E/SharedPreferencesTesterScreen'
 import {FindContactsFlowScreen} from '#/screens/FindContactsFlowScreen'
 import HashtagScreen from '#/screens/Hashtag'
@@ -92,7 +93,6 @@ import {PostLikedByScreen} from '#/screens/Post/PostLikedBy'
 import {PostQuotesScreen} from '#/screens/Post/PostQuotes'
 import {PostRepostedByScreen} from '#/screens/Post/PostRepostedBy'
 import {ProfileKnownFollowersScreen} from '#/screens/Profile/KnownFollowers'
-import {ProfileFeedScreen} from '#/screens/Profile/ProfileFeed'
 import {ProfileFollowersScreen} from '#/screens/Profile/ProfileFollowers'
 import {ProfileFollowsScreen} from '#/screens/Profile/ProfileFollows'
 import {ProfileLabelerLikedByScreen} from '#/screens/Profile/ProfileLabelerLikedBy'
@@ -288,13 +288,13 @@ function commonScreens(Stack: typeof Flat, unreadCountLabel?: string) {
         })}
       />
       <Stack.Screen
-        name="ProfileFeed"
-        getComponent={() => ProfileFeedScreen}
+        name="CustomFeed"
+        getComponent={() => CustomFeedScreen}
         options={{title: title(msg`Feed`)}}
       />
       <Stack.Screen
-        name="ProfileFeedLikedBy"
-        getComponent={() => ProfileFeedLikedByScreen}
+        name="CustomFeedLikedBy"
+        getComponent={() => CustomFeedLikedByScreen}
         options={{title: title(msg`Liked by`)}}
       />
       <Stack.Screen

--- a/src/lib/routes/types.ts
+++ b/src/lib/routes/types.ts
@@ -39,12 +39,12 @@ export type CommonNavigatorParams = {
   PostLikedBy: {name: string; rkey: string}
   PostRepostedBy: {name: string; rkey: string}
   PostQuotes: {name: string; rkey: string}
-  ProfileFeed: {
+  CustomFeed: {
     name: string
     rkey: string
     feedCacheKey?: 'discover' | 'explore' | undefined
   }
-  ProfileFeedLikedBy: {name: string; rkey: string}
+  CustomFeedLikedBy: {name: string; rkey: string}
   ProfileLabelerLikedBy: {name: string}
   Debug: undefined
   DebugMod: undefined

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -33,8 +33,8 @@ export const router = new Router<AllNavigatableRoutes>({
   PostLikedBy: '/profile/:name/post/:rkey/liked-by',
   PostRepostedBy: '/profile/:name/post/:rkey/reposted-by',
   PostQuotes: '/profile/:name/post/:rkey/quotes',
-  ProfileFeed: '/profile/:name/feed/:rkey',
-  ProfileFeedLikedBy: '/profile/:name/feed/:rkey/liked-by',
+  CustomFeed: '/profile/:name/feed/:rkey',
+  CustomFeedLikedBy: '/profile/:name/feed/:rkey/liked-by',
   ProfileLabelerLikedBy: '/profile/:name/labeler/liked-by',
   // debug
   Debug: '/sys/debug',

--- a/src/screens/CustomFeed/CustomFeedLikedBy.tsx
+++ b/src/screens/CustomFeed/CustomFeedLikedBy.tsx
@@ -8,13 +8,13 @@ import {makeRecordUri} from '#/lib/strings/url-helpers'
 import {PostLikedBy as PostLikedByComponent} from '#/view/com/post-thread/PostLikedBy'
 import * as Layout from '#/components/Layout'
 
-type Props = NativeStackScreenProps<CommonNavigatorParams, 'ProfileFeedLikedBy'>
-export const ProfileFeedLikedByScreen = ({route}: Props) => {
+type Props = NativeStackScreenProps<CommonNavigatorParams, 'CustomFeedLikedBy'>
+export const CustomFeedLikedByScreen = ({route}: Props) => {
   const {name, rkey} = route.params
   const uri = makeRecordUri(name, 'app.bsky.feed.generator', rkey)
 
   return (
-    <Layout.Screen testID="postLikedByScreen">
+    <Layout.Screen testID="customFeedLikedByScreen">
       <Layout.Header.Outer>
         <Layout.Header.BackButton />
         <Layout.Header.Content>

--- a/src/screens/CustomFeed/components/CustomFeedHeader.tsx
+++ b/src/screens/CustomFeed/components/CustomFeedHeader.tsx
@@ -52,7 +52,7 @@ import {Text} from '#/components/Typography'
 import {useAnalytics} from '#/analytics'
 import {IS_WEB} from '#/env'
 
-export function ProfileFeedHeaderSkeleton() {
+export function CustomFeedHeaderSkeleton() {
   const t = useTheme()
 
   return (
@@ -82,7 +82,7 @@ export function ProfileFeedHeaderSkeleton() {
   )
 }
 
-export function ProfileFeedHeader({
+export function CustomFeedHeader({
   info,
   isTrending,
 }: {

--- a/src/screens/CustomFeed/index.tsx
+++ b/src/screens/CustomFeed/index.tsx
@@ -34,18 +34,18 @@ import {FAB} from '#/view/com/util/fab/FAB'
 import {type ListRef} from '#/view/com/util/List'
 import {LoadLatestBtn} from '#/view/com/util/load-latest/LoadLatestBtn'
 import {PostFeedLoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
-import {
-  ProfileFeedHeader,
-  ProfileFeedHeaderSkeleton,
-} from '#/screens/Profile/components/ProfileFeedHeader'
 import {useTheme} from '#/alf'
 import {EditBig_Stroke2_Corner2_Rounded as EditBigIcon} from '#/components/icons/EditBig'
 import {HashtagWide_Stroke1_Corner0_Rounded as HashtagWideIcon} from '#/components/icons/Hashtag'
 import * as Layout from '#/components/Layout'
 import {IS_NATIVE} from '#/env'
+import {
+  CustomFeedHeader,
+  CustomFeedHeaderSkeleton,
+} from './components/CustomFeedHeader'
 
-type Props = NativeStackScreenProps<CommonNavigatorParams, 'ProfileFeed'>
-export function ProfileFeedScreen(props: Props) {
+type Props = NativeStackScreenProps<CommonNavigatorParams, 'CustomFeed'>
+export function CustomFeedScreen(props: Props) {
   const {rkey, name: handleOrDid} = props.route.params
 
   const feedParams: FeedParams | undefined = props.route.params.feedCacheKey
@@ -66,7 +66,7 @@ export function ProfileFeedScreen(props: Props) {
 
   if (error && !isRefetching) {
     return (
-      <Layout.Screen testID="profileFeedScreenError">
+      <Layout.Screen testID="customFeedScreenError">
         <ErrorScreen
           showHeader
           title={l`Could not load feed`}
@@ -78,15 +78,15 @@ export function ProfileFeedScreen(props: Props) {
   }
 
   return resolvedUri ? (
-    <Layout.Screen testID="profileFeedScreen">
-      <ProfileFeedScreenIntermediate
+    <Layout.Screen testID="customFeedScreen">
+      <CustomFeedScreenIntermediate
         feedUri={resolvedUri.uri}
         feedParams={feedParams}
       />
     </Layout.Screen>
   ) : (
-    <Layout.Screen testID="profileFeedScreen">
-      <ProfileFeedHeaderSkeleton />
+    <Layout.Screen testID="customFeedScreen">
+      <CustomFeedHeaderSkeleton />
       <Layout.Content>
         <PostFeedLoadingPlaceholder />
       </Layout.Content>
@@ -94,7 +94,7 @@ export function ProfileFeedScreen(props: Props) {
   )
 }
 
-function ProfileFeedScreenIntermediate({
+function CustomFeedScreenIntermediate({
   feedUri,
   feedParams,
 }: {
@@ -107,14 +107,14 @@ function ProfileFeedScreenIntermediate({
   if (!preferences || !info) {
     return (
       <Layout.Content>
-        <ProfileFeedHeaderSkeleton />
+        <CustomFeedHeaderSkeleton />
         <PostFeedLoadingPlaceholder />
       </Layout.Content>
     )
   }
 
   return (
-    <ProfileFeedScreenInner
+    <CustomFeedScreenInner
       preferences={preferences}
       feedInfo={info as FeedSourceFeedInfo}
       feedParams={feedParams}
@@ -122,7 +122,7 @@ function ProfileFeedScreenIntermediate({
   )
 }
 
-export function ProfileFeedScreenInner({
+export function CustomFeedScreenInner({
   feedInfo,
   feedParams,
 }: {
@@ -186,7 +186,7 @@ export function ProfileFeedScreenInner({
 
   return (
     <>
-      <ProfileFeedHeader info={feedInfo} isTrending={isTrending} />
+      <CustomFeedHeader info={feedInfo} isTrending={isTrending} />
       <FeedFeedbackProvider value={feedFeedback}>
         <PostFeed
           enabled

--- a/src/view/com/feeds/FeedSourceCard.tsx
+++ b/src/view/com/feeds/FeedSourceCard.tsx
@@ -193,7 +193,7 @@ export function FeedSourceCardLoaded({
               )
         }
         to={{
-          screen: feed.type === 'feed' ? 'ProfileFeed' : 'ProfileList',
+          screen: feed.type === 'feed' ? 'CustomFeed' : 'ProfileList',
           params: {name: feed.creatorDid, rkey: new AtUri(feed.uri).rkey},
         }}
         style={[


### PR DESCRIPTION
## Summary

- rename the ProfileFeed routes and screens to CustomFeed
- prevent custom and topic feed screens from being treated as profile-related by the left nav
- keep the existing feed URLs unchanged

Fixes https://linear.app/blueskyweb/issue/APP-2819/when-viewing-topic-feed-profile-icon-is-filled-in

## Test plan

- pnpm typecheck
- targeted oxlint
- pnpm test __tests__/lib/routes-helpers.test.ts --runInBand --watchman=false