### PR TITLE
Work around reanimated bug in sign up screen

### DIFF
--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -172,14 +172,9 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
               <LayoutAnimationConfig skipEntering>
                 <ScreenTransition
                   key={state.activeStep}
-                  direction={state.screenTransitionDirection}>
-                  <View
-                    style={[
-                      a.flex_1,
-                      a.px_xl,
-                      a.pt_2xl,
-                      !gtMobile && {paddingBottom: 100},
-                    ]}>
+                  direction={state.screenTransitionDirection}
+                  style={a.flex_1}>
+                  <View style={[a.flex_1, a.px_xl, a.pt_2xl]}>
                     <View style={[a.gap_sm, a.pb_3xl]}>
                       <Text
                         style={[


### PR DESCRIPTION
Details on the bug here: https://github.com/software-mansion/react-native-reanimated/issues/10161

Temporary fix: `flex:1` the animating view so that it doesn't have to change size during the animation

### Before
<img width="300" alt="Simulator Screenshot - iPhone 17 - 2026-08-06 at 21 33 10" src="https://github.com/user-attachments/assets/1a27153a-edaf-4771-82cb-9c3dbfdc63a3" />

### After

<img width="300" alt="Simulator Screenshot - iPhone 17 - 2026-08-06 at 21 33 00" src="https://github.com/user-attachments/assets/2c566d84-a213-4b2a-9531-ee807e9b740c" />
