### PR TITLE
Fix chat info panel not using square icons for labellers

### DIFF
--- a/src/screens/Messages/components/MessagesListInfoPanel.tsx
+++ b/src/screens/Messages/components/MessagesListInfoPanel.tsx
@@ -47,7 +47,11 @@ export function MessagesListInfoPanel({
 
   return (
     <View style={[a.align_center, a.justify_center]}>
-      <UserAvatar type="user" size={88} avatar={profile?.avatar} />
+      <UserAvatar
+        type={profile.associated?.labeler ? 'labeler' : 'user'}
+        size={88}
+        avatar={profile?.avatar}
+      />
       <View
         style={[
           a.flex_row,


### PR DESCRIPTION
Currently while in a conversation with a labeller, the icon at the top of the chat is round

This isn't consistant with the top bar of that same conversation or icons in the side-bar for Chats

This only handles single chats and doesn't tackle the same issue when it comes to group chats, as all 3 of the previously mentioned positions are locked to being round and I'm not sure how mixing circles and squares here would best work 🐙