### PR TITLE
Use Bluesky CI app for Denis setup

### DIFF
--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -264,8 +264,8 @@ jobs:
         uses: ./.github/actions/setup-denis
         with:
           release-tag: ${{ env.DENIS_RELEASE_TAG }}
-          app-id: ${{ vars.SYNC_INTERNAL_APP_ID }}
-          private-key: ${{ secrets.SYNC_INTERNAL_PK }}
+          app-id: ${{ secrets.BLUESKY_CI_APP_ID }}
+          private-key: ${{ secrets.BLUESKY_CI_APP_PRIVATE_KEY }}
 
       - name: 🚀 Publish OTA to denis (S3)
         if: ${{ !steps.fingerprint.outputs.includes-changes &&

--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -344,8 +344,8 @@ jobs:
         uses: ./.github/actions/setup-denis
         with:
           release-tag: ${{ env.DENIS_RELEASE_TAG }}
-          app-id: ${{ vars.SYNC_INTERNAL_APP_ID }}
-          private-key: ${{ secrets.SYNC_INTERNAL_PK }}
+          app-id: ${{ secrets.BLUESKY_CI_APP_ID }}
+          private-key: ${{ secrets.BLUESKY_CI_APP_PRIVATE_KEY }}
 
       - name: 🔢 Get native build numbers
         id: build-info


### PR DESCRIPTION
## Summary

- use the available Bluesky CI GitHub App credentials when downloading Denis from tango
- update both PR OTA and bundle deployment workflows
- leave the sync-internal workflow on its dedicated credential names

## Test plan

- Prettier passes for both changed workflows
- actionlint reports only existing shell-quoting findings in pull-request-commit.yml lines 91-104