### PR TITLE
Adds a small padding for labeller avatars in group chat 'Add people' selector

### DIFF
--- a/src/components/dms/ChatProfileTabs.tsx
+++ b/src/components/dms/ChatProfileTabs.tsx
@@ -95,6 +95,8 @@ function Tab({
     moderation.ui('displayName'),
   )
 
+  const isLabeler = profile.associated?.labeler
+
   const onPressItem = useCallback(
     (did: string) => {
       onRemove?.(did)
@@ -111,7 +113,7 @@ function Tab({
         a.border,
         a.justify_center,
         a.rounded_lg,
-        a.pl_xs,
+        isLabeler ? a.pl_sm : a.pl_xs,
         a.pr_sm,
         a.py_xs,
         t.atoms.border_contrast_low,


### PR DESCRIPTION
When creating a group chat and selecting members, the pills for currently selected users have no padding for labeller icons

It may be slightly more visually appealing to have extra padding here so the icon isn't touching the sides of the pill 🐙