### PR TITLE
Route Claude workflows through Agent Gateway

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -26,6 +26,7 @@ permissions:
   pull-requests: write
   issues: write
   actions: read
+  # Required for claude-code-action's GitHub App token exchange.
   id-token: write
 
 jobs:
@@ -58,19 +59,17 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: ☁️ Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
-        with:
-          role-to-assume: ${{ secrets.AWS_BEDROCK_REVIEW_ROLE_ARN }}
-          aws-region: us-east-2
-
       - name: 🤖 Claude
         uses: anthropics/claude-code-action@1623c36729ac1cd5895198cded705a287de7db79 # v1.0.187
+        env:
+          ANTHROPIC_BASE_URL: https://agentgateway.k1.prod.bsky.dev
         with:
-          use_bedrock: 'true'
+          # Agent Gateway service keys use Authorization: Bearer, the wire
+          # shape emitted by the action's OAuth-token input.
+          claude_code_oauth_token: ${{ secrets.AGENT_GATEWAY_CLAUDE_GH_REVIEW_KEY }}
           additional_permissions: |
             actions: read
           track_progress: true
           claude_args: |
-            --model global.anthropic.claude-opus-5
+            --model claude-opus-5:api
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__download_job_log,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,7 +1,7 @@
 name: claude-review
 
-# Automatic Claude review on PR creation/update, via Bedrock (OIDC, no
-# long-lived tokens). Self-contained: this intentionally uses upstream
+# Automatic Claude review on PR creation/update, via Agent Gateway.
+# Self-contained: this intentionally uses upstream
 # claude-code-action defaults rather than the org reusable workflows in
 # bluesky-social/.github (which a public repo cannot call, and whose
 # customizations added no value over upstream).
@@ -16,14 +16,14 @@ permissions:
   contents: read
   pull-requests: write
   actions: read
+  # Required for claude-code-action's GitHub App token exchange.
   id-token: write
 
 jobs:
   review:
     # Internal PRs only. This repo is public: fork PRs are the bulk of
-    # community traffic and MUST NOT trigger reviews (no Bedrock spend on
-    # unvetted code, and fork PRs can't mint the OIDC token anyway —
-    # belt-and-braces with this explicit guard). Branch PRs can only be
+    # community traffic and MUST NOT trigger reviews (no gateway spend on
+    # unvetted code). Branch PRs can only be
     # created by people with write access, i.e. org members.
     # Bot-authored PRs (dependabot, changesets) are also skipped.
     if: >
@@ -44,21 +44,19 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: ☁️ Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
-        with:
-          role-to-assume: ${{ secrets.AWS_BEDROCK_REVIEW_ROLE_ARN }}
-          aws-region: us-east-2
-
       - name: 🤖 Claude review
         uses: anthropics/claude-code-action@1623c36729ac1cd5895198cded705a287de7db79 # v1.0.187
+        env:
+          ANTHROPIC_BASE_URL: https://agentgateway.k1.prod.bsky.dev
         with:
-          use_bedrock: 'true'
+          # Agent Gateway service keys use Authorization: Bearer, the wire
+          # shape emitted by the action's OAuth-token input.
+          claude_code_oauth_token: ${{ secrets.AGENT_GATEWAY_CLAUDE_GH_REVIEW_KEY }}
           additional_permissions: |
             actions: read
           track_progress: true
           claude_args: |
-            --model global.anthropic.claude-opus-5
+            --model claude-opus-5:api
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__download_job_log,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

- route automatic Claude reviews and `@claude` mentions through the external Agent Gateway listener
- use the scoped `claude-gh-review` service credential from `AGENT_GATEWAY_CLAUDE_GH_REVIEW_KEY`
- remove AWS credential setup while retaining OIDC solely for claude-code-action's GitHub App token exchange
- select the gateway model `claude-opus-5:api`

## Validation

- `actionlint .github/workflows/claude-review.yml .github/workflows/claude-mention.yml`
- external service key accepted by `agentgateway.k1.prod.bsky.dev` with `audience=service-external`
- live Anthropic Messages request passed through Agent Gateway
- clean Claude Code 2.1.226 auth and inference smoke test passed
- pull request workflow completed successfully after the GitHub App OIDC exchange
- Roast: no findings