### PR TITLE
Prevent last line of post text from being clipped on Android

### DIFF
--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -32,10 +32,10 @@ export type RichTextProps = TextStyleProp &
      * How far below the text baseline `suffix` extends, in px.
      *
      * Inline views inside `Text` sit with their bottom edge on the baseline, so
-     * a suffix nudged below it overflows the `Text`'s measured bounds and iOS
-     * clips it. We reserve this much room as bottom padding and cancel it with
-     * an equal negative margin, so the suffix can paint without moving anything
-     * after it. Pass the same offset the suffix nudges itself by.
+     * a suffix nudged below it overflows the `Text`'s measured bounds and
+     * native clips it. We reserve this much room as bottom padding and cancel
+     * it with an equal negative margin, so the suffix can paint without moving
+     * anything after it. Pass the same offset the suffix nudges itself by.
      *
      * Overrides any `paddingBottom`/`marginBottom` set via `style`.
      */

--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -3,7 +3,7 @@ import {type StyleProp, type TextStyle} from 'react-native'
 import {AppBskyRichtextFacet, RichText as RichTextAPI} from '@atproto/api'
 
 import {toShortUrl} from '#/lib/strings/url-helpers'
-import {atoms as a, flatten, ios, type TextStyleProp} from '#/alf'
+import {atoms as a, flatten, native, type TextStyleProp} from '#/alf'
 import {isOnlyEmoji} from '#/alf/typography'
 import {InlineLinkText, type LinkProps} from '#/components/Link'
 import {ProfileHoverCard} from '#/components/ProfileHoverCard'
@@ -84,7 +84,7 @@ export function RichText({
   const plainStyles = style
   const suffixStyles =
     suffix && suffixOffset
-      ? ios({paddingBottom: suffixOffset, marginBottom: -suffixOffset})
+      ? native({paddingBottom: suffixOffset, marginBottom: -suffixOffset})
       : null
   const interactiveStyles = [plainStyles, interactiveStyle]
 

--- a/src/screens/PostThread/components/ThreadItemPostNumber.tsx
+++ b/src/screens/PostThread/components/ThreadItemPostNumber.tsx
@@ -8,7 +8,7 @@ import {useAnalytics} from '#/analytics'
 /**
  * How far the inline badge is nudged below the text baseline to optically
  * center it. The containing `RichText` must reserve matching room via
- * `suffixOffset`, or iOS clips the overflow.
+ * `suffixOffset`, or native clips the overflow.
  */
 export const POST_NUMBER_INLINE_OFFSET = 6
 

--- a/src/screens/PostThread/components/ThreadItemPostNumber.tsx
+++ b/src/screens/PostThread/components/ThreadItemPostNumber.tsx
@@ -76,7 +76,7 @@ export function ThreadItemPostNumber({
         style={[
           a.text_xs,
           a.font_medium,
-          t.atoms.text_contrast_high,
+          t.atoms.text_contrast_medium,
           {
             fontVariant: ['tabular-nums'],
           },

--- a/src/screens/PostThread/components/ThreadItemPostNumber.tsx
+++ b/src/screens/PostThread/components/ThreadItemPostNumber.tsx
@@ -2,7 +2,7 @@ import {Text, View} from 'react-native'
 import {type AppBskyUnspeccedDefs} from '@atproto/api'
 import {Trans, useLingui} from '@lingui/react/macro'
 
-import {atoms as a, native, platform, useTheme} from '#/alf'
+import {atoms as a, ios, platform, useTheme} from '#/alf'
 import {useAnalytics} from '#/analytics'
 
 /**
@@ -52,8 +52,8 @@ export function ThreadItemPostNumber({
         a.flex_shrink_0,
         a.rounded_full,
         t.atoms.bg_contrast_50,
-        native(a.py_2xs),
         !inline && a.self_start,
+        ios(a.py_2xs),
         {
           paddingLeft: 5,
           paddingRight: 5,


### PR DESCRIPTION
No change to iOS or web.

| Before | After |
| - | - |
| <img width="864" height="1920" alt="before" src="https://github.com/user-attachments/assets/ba404d35-4ff9-4f7a-9e80-7705e9a9c8d9" /> | <img width="864" height="1920" alt="after" src="https://github.com/user-attachments/assets/8e1267fa-d582-4e51-ac73-d8c553d2b1f7" /> |