### PR TITLE
perf: skip minute-tick subscription for actors without a live status

### DIFF
--- a/src/features/liveNow/index.tsx
+++ b/src/features/liveNow/index.tsx
@@ -97,7 +97,13 @@ export function useLiveNowConfig(): LiveNowConfig {
 
 export function useActorStatus(actor?: bsky.profile.AnyProfileView) {
   const shadowed = useMaybeProfileShadow(actor)
-  const tick = useTickEveryMinute()
+  /*
+   * The minute tick only exists to re-validate an existing status's expiry,
+   * so actors without a status record skip the subscription entirely. This
+   * keeps the every-minute tick from re-rendering every post in a feed.
+   */
+  const hasStatus = !!(shadowed && 'status' in shadowed && shadowed.status)
+  const tick = useTickEveryMinute(hasStatus)
   const config = useLiveNowConfig()
   const moderationOpts = useModerationOpts()
 

--- a/src/state/shell/tick-every-minute.tsx
+++ b/src/state/shell/tick-every-minute.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext, useEffect, useState} from 'react'
+import {createContext, use, useEffect, useState} from 'react'
 
 type StateContext = number
 
@@ -16,6 +16,15 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   return <stateContext.Provider value={tick}>{children}</stateContext.Provider>
 }
 
-export function useTickEveryMinute() {
-  return useContext(stateContext)
+/**
+ * Returns a timestamp that updates once per minute, re-rendering the caller
+ * on every tick. Pass `enabled: false` to skip subscribing entirely - the
+ * caller then never re-renders on tick and receives a stable `0`. Relies on
+ * React 19 `use()`, which may be called conditionally.
+ */
+export function useTickEveryMinute(enabled: boolean = true) {
+  if (enabled) {
+    return use(stateContext)
+  }
+  return 0
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI with [Argent](https://argent.swmansion.com) on behalf of @tomekzaw.

## Why

`useActorStatus` unconditionally subscribes to `TickEveryMinuteContext`, and it is called by `PostMeta`, `PreviewableUserAvatar`, `PostFeedItem`, and ~15 other components. As a result, every minute tick re-renders **every visible post in every feed** (memo is bypassed by the context read), even though the tick only exists to re-validate the expiry of an *existing* live status – which the vast majority of feed authors do not have.

Profiling the Android home feed showed a single ~800–950 ms (dev mode) React commit every 60 seconds, re-rendering all visible `FeedItemInner` subtrees.

## How

- `useTickEveryMinute(enabled = true)`: when `enabled` is `false`, the hook skips the context read entirely and returns a stable `0`, so the caller never re-renders on tick. This relies on React 19 `use()`, which may be called conditionally.
- `useActorStatus` passes `enabled: hasStatus` – only actors that actually have a status record subscribe. When a status appears (profile shadow update), the component re-renders anyway, `hasStatus` flips to `true`, and the subscription starts, so live rings still expire on the tick as before.

All existing callers of `useTickEveryMinute` are unchanged (default `true`).

## Benchmark

Measured with the React DevTools commit profiler (via Hermes CDP) on an Android emulator, dev mode, mock PDS feed with 20 visible posts, idle on the home feed for ~3.5 minutes (3 ticks). Measured on the `expo-57` branch (commit `ba9468f6d`); the patch applies identically to `main`.

| Per minute tick | before | after |
|---|---|---|
| Commit duration (dev) | 815 / 798 / 956 ms | 15.6 / 64.3 / 46.4 ms |
| Fiber renders | 2,654 | ~120 |
| `FeedItemInner` re-rendered | 20 | 0 |
| What re-renders | every visible post subtree | only `TimeElapsed` (×24) + its Text children |

Pull-to-refresh behavior verified unchanged (same commit structure and render counts as before the patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
