### PR TITLE
Adopt pnpm/setup for CI

### DIFF
--- a/.github/actions/setup-expo-project/action.yml
+++ b/.github/actions/setup-expo-project/action.yml
@@ -24,13 +24,11 @@ runs:
           exit 1
         fi
 
-    - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-    - name: 🔧 Setup Node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+    - name: 📦 Setup pnpm and Node
+      uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
       with:
-        node-version-file: package.json
-        cache: pnpm
+        cache: true
+        install: false
 
     - name: 🪛 Setup jq
       uses: dcarbone/install-jq-action@4fcb5062d7ce9bc4382d1a352d19ba3ba2c317c1 # v4.0.1

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -116,13 +116,11 @@ jobs:
             echo "version-changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
-      - name: 🔧 Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - name: 📦 Setup pnpm and Node
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          node-version-file: package.json
-          cache: pnpm
+          cache: true
+          install: false
 
       - name: ⬇️ Load fingerprint baseline
         id: baseline

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,9 +55,6 @@ jobs:
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
           cache: true
-          install: false
-      - name: 📦 pnpm install
-        run: pnpm install --frozen-lockfile
       - name: 🔤 Check & compile i18n
         run: pnpm intl:build
       - name: 🧹 Lint checks
@@ -92,9 +89,6 @@ jobs:
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
           cache: true
-          install: false
-      - name: 📦 pnpm install
-        run: pnpm install --frozen-lockfile
       - name: 🔤 Check & compile i18n
         run: pnpm intl:build
       - name: 🧪 Run tests

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,12 +51,11 @@ jobs:
           v=$(grep -oE '"node":[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' eas.json | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u)
           check "eas.json" "$v"
           exit $rc
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - name: 🔧 Install node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - name: 📦 Setup pnpm and Node
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          node-version-file: package.json
-          cache: pnpm
+          cache: true
+          install: false
       - name: 📦 pnpm install
         run: pnpm install --frozen-lockfile
       - name: 🔤 Check & compile i18n
@@ -89,12 +88,11 @@ jobs:
     steps:
       - name: ⬇️ Check out Git repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - name: 🔧 Install node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - name: 📦 Setup pnpm and Node
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          node-version-file: package.json
-          cache: pnpm
+          cache: true
+          install: false
       - name: 📦 pnpm install
         run: pnpm install --frozen-lockfile
       - name: 🔤 Check & compile i18n

--- a/.github/workflows/nightly-update-source-languages.yaml
+++ b/.github/workflows/nightly-update-source-languages.yaml
@@ -19,12 +19,11 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ssh-key: ${{secrets.GH_ACTION_DEPLOY_KEY}}
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - name: 🔧 Install node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - name: 📦 Setup pnpm and Node
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          node-version-file: package.json
-          cache: pnpm
+          cache: true
+          install: false
       - name: 📦 pnpm install
         run: pnpm install --frozen-lockfile
       - name: 🔤 Extract language strings

--- a/.github/workflows/nightly-update-source-languages.yaml
+++ b/.github/workflows/nightly-update-source-languages.yaml
@@ -23,9 +23,6 @@ jobs:
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
           cache: true
-          install: false
-      - name: 📦 pnpm install
-        run: pnpm install --frozen-lockfile
       - name: 🔤 Extract language strings
         run: pnpm intl:extract
       - name: 📝 Create commit

--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -35,13 +35,11 @@ jobs:
       - name: ⬇️ Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
-      - name: 🔧 Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - name: 📦 Setup pnpm and Node
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          node-version-file: package.json
-          cache: pnpm
+          cache: true
+          install: false
 
       - name: ⬇️ Get base stats from cache
         id: get-base-stats
@@ -76,13 +74,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
-      - name: 🔧 Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - name: 📦 Setup pnpm and Node
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          node-version-file: package.json
-          cache: pnpm
+          cache: true
+          install: false
 
       - name: 🌿 Ensure tracking relevant branches and checkout base
         env:
@@ -175,13 +171,11 @@ jobs:
         run: git fetch origin main:main --depth 100
         if: github.event_name == 'pull_request'
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
-      - name: 🔧 Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - name: 📦 Setup pnpm and Node
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          node-version-file: package.json
-          cache: pnpm
+          cache: true
+          install: false
 
       - name: 📷 Check fingerprint and install dependencies
         id: fingerprint

--- a/.github/workflows/verify-pnpm-lock.yml
+++ b/.github/workflows/verify-pnpm-lock.yml
@@ -24,12 +24,10 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: git fetch origin $BASE_REF --depth=1
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
-      - name: 🔧 Install node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - name: 📦 Setup pnpm and Node
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          node-version-file: package.json
+          install: false
 
       - name: ⏪ Reset pnpm-lock.yaml to base
         env:


### PR DESCRIPTION
## Summary

- replace pnpm/action-setup and actions/setup-node with pnpm/setup v2.0.2
- use the action built-in install when dependency installation is the immediate next step
- preserve deferred or specialized dependency installation where workflow ordering requires it
- name the combined setup step consistently across workflows

## Testing

- actionlint (workflow schema and expressions)
- prettier --check on changed YAML files
- roast review: no findings