### PR TITLE
Disallow robots crawling compose intent paths

### DIFF
--- a/bskyweb/static/robots.txt
+++ b/bskyweb/static/robots.txt
@@ -6,6 +6,7 @@
 # codes are used for rate-limiting. Up to a handful concurrent requests should
 # be ok.
 User-Agent: *
+Disallow: /intent/compose
 Allow: /
 
 Sitemap: https://bsky.app/sitemap/users.xml.gz


### PR DESCRIPTION
## Summary

Disallow crawlers from fetching `/intent/compose` URLs generated by external share widgets while preserving crawling for the rest of `bsky.app`. This was brought to our attention by our SEO partner at Google.

[APP-2843](https://linear.app/blueskyweb/issue/APP-2843/disallow-crawling-of-intentcompose-urls)