### PR TITLE
Fix appearance of post numbers on image posts

### DIFF
--- a/src/screens/PostThread/components/ThreadItemPostNumber.tsx
+++ b/src/screens/PostThread/components/ThreadItemPostNumber.tsx
@@ -53,6 +53,7 @@ export function ThreadItemPostNumber({
         a.rounded_full,
         t.atoms.bg_contrast_50,
         native(a.py_2xs),
+        !inline && a.self_start,
         {
           paddingLeft: 5,
           paddingRight: 5,


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="1206" height="2622" alt="before" src="https://github.com/user-attachments/assets/dadbd952-dab7-4146-b96d-cb8e05831013" /> | <img width="1206" height="2622" alt="after" src="https://github.com/user-attachments/assets/2db47d4c-76dd-4406-b6bd-f507f11344fd" /> |