### PR TITLE
Fix display of link cards in DMs

### DIFF
--- a/src/components/Post/Embed/ExternalEmbed/index.tsx
+++ b/src/components/Post/Embed/ExternalEmbed/index.tsx
@@ -92,7 +92,7 @@ export const ExternalEmbed = ({
       style={[a.rounded_md]}
       onPress={onPress}
       onLongPress={onShareExternal}>
-      {({hovered}) => (
+      {({hovered, pressed}) => (
         <View
           style={[
             a.transition_color,
@@ -101,7 +101,7 @@ export const ExternalEmbed = ({
             a.overflow_hidden,
             a.w_full,
             a.border,
-            t.atoms.bg,
+            pressed && t.atoms.bg,
             style,
             hovered
               ? t.atoms.border_contrast_high

--- a/src/components/Post/Embed/StandardSiteEmbed/index.tsx
+++ b/src/components/Post/Embed/StandardSiteEmbed/index.tsx
@@ -129,7 +129,6 @@ export const StandardSiteEmbed = ({
         a.rounded_lg,
         a.w_full,
         a.border,
-        t.atoms.bg,
         interacted ? t.atoms.border_contrast_high : t.atoms.border_contrast_low,
         preview && a.pointer_events_none,
         style,
@@ -154,7 +153,7 @@ export const StandardSiteEmbed = ({
         })}
         onFocus={onInteract}
         onBlur={onInteractOut}>
-        {() => (
+        {({pressed}) => (
           <View
             style={[
               a.w_full,
@@ -171,7 +170,7 @@ export const StandardSiteEmbed = ({
                 borderBottomLeftRadius: a.rounded_lg.borderRadius,
                 borderBottomRightRadius: a.rounded_lg.borderRadius,
               },
-              interacted ? t.atoms.bg_contrast_25 : t.atoms.bg,
+              interacted ? t.atoms.bg_contrast_25 : pressed && t.atoms.bg,
             ]}>
             {imageUri ? (
               <Image

--- a/src/components/Post/Embed/index.tsx
+++ b/src/components/Post/Embed/index.tsx
@@ -68,7 +68,11 @@ export function Embed({embed: rawEmbed, ...rest}: EmbedProps) {
     }
     case 'post_with_media': {
       return (
-        <View style={rest.style}>
+        <View
+          style={[
+            rest.style,
+            rest.viewContext === PostEmbedViewContext.ChatMessage && a.gap_sm,
+          ]}>
           <MediaEmbed embed={embed.media} {...rest} />
           <RecordEmbed embed={embed.view} {...rest} />
         </View>


### PR DESCRIPTION
Two parts to this:

- only give the cards a solid background on press. This is needed for the peek menu, but it only needs to happen when pressing on the element
- make a gap between media and record for media+record embeds in DMs. This is due to DMs reusing the quote element and suppressing its top margin, so the usual gap is missing

## Before

<img width="423" height="471" alt="Screenshot 2026-08-13 at 10 28 53" src="https://github.com/user-attachments/assets/011d2c4c-d74c-4051-ae84-7a1fc1b7dec7" />


## After

<img width="325" height="431" alt="Screenshot 2026-08-13 at 10 33 57" src="https://github.com/user-attachments/assets/f56847fd-82d3-4b52-aab3-39d59d3ed61e" />

## Test plan

- Post https://bsky.app/profile/samuel.fm/post/3mswzzi3q7k2p in DMs, confirm it looks better
- Ensure long pressing links on iOS still shows the peek menu as it should


APP-2861