### PR TITLE
Fix metro failing to resolve @ipld/dag-cbor in dev mode

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -35,7 +35,13 @@ module.exports = function (api) {
       // cannot use `env` field because it will put them after
       // the `react-native-worklets/plugin` plugin
       ...(api.env('test')
-        ? ['@babel/plugin-transform-class-static-block']
+        ? [
+            '@babel/plugin-transform-class-static-block',
+            // Compile `import()` to require so jest (which runs without
+            // `--experimental-vm-modules`) can execute lazily-loaded modules
+            // like `@ipld/dag-cbor` via its moduleNameMapper.
+            '@babel/plugin-transform-dynamic-import',
+          ]
         : []),
       ...(api.env('production') ? ['transform-remove-console'] : []),
 

--- a/src/lib/api/computeCid.ts
+++ b/src/lib/api/computeCid.ts
@@ -123,14 +123,9 @@ function isPlainObject(v: any): boolean {
 /**
  * Load `@ipld/dag-cbor` on demand. The dynamic `import()` lets web bundlers
  * emit it (and its ~190KB `cborg` dependency) as a separate chunk that only
- * loads when posting a thread. Under jest (which runs without
- * `--experimental-vm-modules`) dynamic import throws, so we fall back to a
- * lazy `require`, which resolves through the test moduleNameMapper.
+ * loads when posting a thread. Under jest this compiles down to a require
+ * that resolves through the test moduleNameMapper.
  */
 function importDagCbor(): Promise<typeof import('@ipld/dag-cbor')> {
-  if (process.env.NODE_ENV === 'test') {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    return Promise.resolve(require('@ipld/dag-cbor'))
-  }
   return import('@ipld/dag-cbor')
 }


### PR DESCRIPTION
It seems that dev mode Metro resolves every statically visible dependency at bundle time, dead branches included.


```
Metro has encountered an error: While trying to resolve module `@ipld/dag-cbor` from file `/Users/oleksiibulenok/work/social-app/src/lib/api/computeCid.ts`, the package `/Users/oleksiibulenok/work/social-app/node_modules/@ipld/dag-cbor/package.json` was successfully found. However, this package itself specifies a `main` module field that could not be resolved (`/Users/oleksiibulenok/work/social-app/node_modules/@ipld/dag-cbor/index`. Indeed, none of these files exist:

  * /Users/oleksiibulenok/work/social-app/node_modules/@ipld/dag-cbor/index(.ios.ts|.native.ts|.ts|.ios.tsx|.native.tsx|.tsx|.ios.mjs|.native.mjs|.mjs|.ios.js|.native.js|.js|.ios.jsx|.native.jsx|.jsx|.ios.json|.native.json|.json|.ios.cjs|.native.cjs|.cjs|.ios.scss|.native.scss|.scss|.ios.sass|.native.sass|.sass|.ios.css|.native.css|.css)
  * /Users/oleksiibulenok/work/social-app/node_modules/@ipld/dag-cbor/index/index(.ios.ts|.native.ts|.ts|.ios.tsx|.native.tsx|.tsx|.ios.mjs|.native.mjs|.mjs|.ios.js|.native.js|.js|.ios.jsx|.native.jsx|.jsx|.ios.json|.native.json|.json|.ios.cjs|.native.cjs|.cjs|.ios.scss|.native.scss|.scss|.ios.sass|.native.sass|.sass|.ios.css|.native.css|.css): /Users/oleksiibulenok/work/social-app/node_modules/metro/src/node-haste/DependencyGraph.js (267:17)

  265 |         }
  266 |         if (error instanceof _metroResolver.InvalidPackageError) {
> 267 |           throw new _metroCore.PackageResolutionError({
      |                 ^
  268 |             packageError: error,
  269 |             originModulePath,
  270 |             targetModuleName: to,
```