### PR TITLE
Fix hidden adult content takes time to appear

### DIFF
--- a/src/components/moderation/ContentHider.tsx
+++ b/src/components/moderation/ContentHider.tsx
@@ -1,10 +1,6 @@
 import {useMemo, useState} from 'react'
-import {
-  LayoutAnimation,
-  type StyleProp,
-  View,
-  type ViewStyle,
-} from 'react-native'
+import {type StyleProp, View, type ViewStyle} from 'react-native'
+import Animated, {FadeIn, LinearTransition} from 'react-native-reanimated'
 import {type ModerationUI} from '@bsky/sdk/moderation'
 import {Trans, useLingui} from '@lingui/react/macro'
 
@@ -18,7 +14,7 @@ import {getDefinition, getLabelStrings} from '#/lib/moderation/useLabelInfo'
 import {useModerationCauseDescription} from '#/lib/moderation/useModerationCauseDescription'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {useLabelDefinitions} from '#/state/preferences'
-import {atoms as a, useBreakpoints, useTheme, web} from '#/alf'
+import {atoms as a, native, useBreakpoints, useTheme, web} from '#/alf'
 import {Button} from '#/components/Button'
 import {
   ModerationDetailsDialog,
@@ -147,14 +143,16 @@ function ContentHiderActive({
   ])
 
   return (
-    <View testID={testID} style={[a.overflow_hidden, style]}>
+    <Animated.View
+      testID={testID}
+      layout={native(LinearTransition)}
+      style={[a.overflow_hidden, style]}>
       <ModerationDetailsDialog control={control} modcause={blur} />
       <Button
         onPress={e => {
           e.preventDefault()
           e.stopPropagation()
           if (!modui.noOverride) {
-            LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
             setOverride(v => !v)
           } else {
             control.open()
@@ -256,7 +254,11 @@ function ContentHiderActive({
           )}
         </Button>
       )}
-      {override && <View style={childContainerStyle}>{children}</View>}
-    </View>
+      {override && (
+        <Animated.View entering={native(FadeIn)} style={childContainerStyle}>
+          {children}
+        </Animated.View>
+      )}
+    </Animated.View>
   )
 }

--- a/src/components/moderation/ContentHider.tsx
+++ b/src/components/moderation/ContentHider.tsx
@@ -1,10 +1,6 @@
 import {useMemo, useState} from 'react'
-import {
-  LayoutAnimation,
-  type StyleProp,
-  View,
-  type ViewStyle,
-} from 'react-native'
+import {type StyleProp, View, type ViewStyle} from 'react-native'
+import Animated, {FadeIn, LinearTransition} from 'react-native-reanimated'
 import {type ModerationUI} from '@bsky/sdk/moderation'
 import {Trans, useLingui} from '@lingui/react/macro'
 
@@ -18,7 +14,7 @@ import {getDefinition, getLabelStrings} from '#/lib/moderation/useLabelInfo'
 import {useModerationCauseDescription} from '#/lib/moderation/useModerationCauseDescription'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {useLabelDefinitions} from '#/state/preferences'
-import {atoms as a, useBreakpoints, useTheme, web} from '#/alf'
+import {atoms as a, native, useBreakpoints, useTheme, web} from '#/alf'
 import {Button} from '#/components/Button'
 import {
   ModerationDetailsDialog,
@@ -140,14 +136,16 @@ function ContentHiderActive({
   ])
 
   return (
-    <View testID={testID} style={[a.overflow_hidden, style]}>
+    <Animated.View
+      testID={testID}
+      layout={native(LinearTransition)}
+      style={[a.overflow_hidden, style]}>
       <ModerationDetailsDialog control={control} modcause={blur} />
       <Button
         onPress={e => {
           e.preventDefault()
           e.stopPropagation()
           if (!modui.noOverride) {
-            LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
             setOverride(v => !v)
           } else {
             control.open()
@@ -249,7 +247,11 @@ function ContentHiderActive({
           )}
         </Button>
       )}
-      {override && <View style={childContainerStyle}>{children}</View>}
-    </View>
+      {override && (
+        <Animated.View entering={native(FadeIn)} style={childContainerStyle}>
+          {children}
+        </Animated.View>
+      )}
+    </Animated.View>
   )
 }


### PR DESCRIPTION
Expo Image was constantly receiving new props references during animation, which was triggering a reload 

now:

https://github.com/user-attachments/assets/42957d8a-2122-49a9-8150-f34c688d58b2

before:


https://github.com/user-attachments/assets/7f96c8a8-1985-4df3-88e4-ff163031d7bf



