### PR TITLE
Fix `lab_*` preferences

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@bsky.app/tapper": "^0.6.1",
     "@bsky.app/video": "0.3.6",
     "@bsky.app/video-compressor": "0.2.0",
-    "@bsky/sdk": "1.0.0",
+    "@bsky/sdk": "1.0.1",
     "@emoji-mart/data": "^1.2.1",
     "@emoji-mart/react": "^1.1.1",
     "@expo/html-elements": "^0.12.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,8 +299,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0(83e0f64f4281e4798012214ad5b2d72d)
       '@bsky/sdk':
-        specifier: 1.0.0
-        version: 1.0.0(@atproto/lex@0.3.6)
+        specifier: 1.0.1
+        version: 1.0.1(@atproto/lex@0.3.6)
       '@emoji-mart/data':
         specifier: ^1.2.1
         version: 1.2.1
@@ -1760,8 +1760,8 @@ packages:
       react: '*'
       react-native: '*'
 
-  '@bsky/sdk@1.0.0':
-    resolution: {integrity: sha512-nnVYpbESETN5R/dyBLWE+5u52HkJO0+EWMv+bLDRZUkHEQtHV2RX3kLMqXaEWVJgijagziLPXb6179mkml8WZA==}
+  '@bsky/sdk@1.0.1':
+    resolution: {integrity: sha512-COhrmIZFsUJ1gj4gvqm2UWkRhTbmXZAL1osTZKgSaFftD4Xy0RRl8S9SRluCxo4/VPw/R3p7NQZ4X3BQFbUjVQ==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@atproto/lex': ^0.3.0
@@ -10765,7 +10765,7 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(patch_hash=91fd85363059530dea649a5ca6012b933f79c8491737fbfdc685abc727e48403)(@babel/core@7.29.0(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.0)(supports-color@8.1.1)
 
-  '@bsky/sdk@1.0.0(@atproto/lex@0.3.6)':
+  '@bsky/sdk@1.0.1(@atproto/lex@0.3.6)':
     dependencies:
       '@atproto-labs/handle-resolver': 0.4.8
       '@atproto/lex': 0.3.6


### PR DESCRIPTION
Bumps `@bsky/sdk` to 1.0.1. Relevant change here: https://github.com/bluesky-social/bsky/pull/29

### Test plan

Confirm thread view pref is persisted again