### PR TITLE
Temporarily run webpack analyzer action on Node 20

### DIFF
--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -67,6 +67,9 @@ jobs:
   webpack-analyzer:
     runs-on: ubuntu-24.04
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request'}}
+    env:
+      # Temporary workaround while bundle-size-diff still targets Node.js 20.
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Purpose

Test whether allowing the pinned bundle-size-diff action to run on its declared Node.js 20 runtime fixes the webpack-analyzer failure seen across PRs.

The workaround is scoped to the webpack-analyzer job and should be removed when the action is replaced or updated for Node.js 24.

## Failure being tested

The action currently fails under GitHub's forced Node.js 24 runtime with:

    Cannot create a string longer than 0x1fffffe8 characters

## Validation

- git diff --check