### PR TITLE
Remove deprecated Android status bar config

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -181,9 +181,6 @@ module.exports = function (_config) {
           ],
         },
       },
-      androidStatusBar: {
-        barStyle: 'light-content',
-      },
       android: {
         icon: './assets/app-icons/android_icon_default_next.png',
         adaptiveIcon: {


### PR DESCRIPTION
## Summary

- remove the deprecated `androidStatusBar` Expo config
- rely on the existing `react-native-edge-to-edge` system bar handling

## Test plan

- resolve the Expo prebuild config and confirm the deprecation warning is gone