### PR TITLE
Fix profile handle resolution errors

### DIFF
--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -115,7 +115,9 @@ function ProfileScreenInner({route}: Props) {
   }, [queryClient, profile?.viewer?.blockedBy, resolvedDid])
 
   // Most pushes will happen here, since we will have only placeholder data
-  if (isDidPending || isProfilePending) {
+  // A disabled dependent query remains pending, so only consider the profile
+  // pending once handle resolution has produced a DID.
+  if (isDidPending || (!!resolvedDid && isProfilePending)) {
     return (
       <Layout.Content>
         <ProfileHeaderLoading />


### PR DESCRIPTION
https://github.com/bluesky-social/social-app/pull/9853 introduced an issue where 404-ing profiles would get stuck in the skeleton state. this is because it OR'd `isPending` from two dependant queries, and if the handle one failed the other would stay `pending` forever

## Summary

- stop a disabled profile query from masking handle-resolution failures
- preserve the loading state when cached handle resolution has produced a DID

## Test Plan

- Open a profile with an unresolvable handle and confirm the error screen appears instead of loading indefinitely.