### PR TITLE
Fix MMKV persistence in Metro builds

### DIFF
--- a/patches/react-native-dotenv@3.4.11.patch
+++ b/patches/react-native-dotenv@3.4.11.patch
@@ -1,0 +1,20 @@
+diff --git a/index.js b/index.js
+index 49b3650..a690ec8 100644
+--- a/index.js
++++ b/index.js
+@@ -153,6 +153,15 @@ module.exports = function(api, options = {}) {
+           const key = path.toComputedKey()
+           if (t.isStringLiteral(key)) {
+             const importedId = key.value
++            // Metro uses Jest workers to transform application code. Do not
++            // leak the build worker's ID into the application runtime, where
++            // libraries can mistake it for an actual test environment.
++            if (
++              importedId === 'JEST_WORKER_ID' ||
++              importedId === 'VITEST_WORKER_ID'
++            ) {
++              return
++            }
+             const value = (env && importedId in env) ? env[importedId] : process.env[importedId]
+             if (value !== undefined) {
+               path.replaceWith(t.valueToNode(value))

--- a/patches/react-native-dotenv@3.4.11.patch.md
+++ b/patches/react-native-dotenv@3.4.11.patch.md
@@ -1,0 +1,4 @@
+# react-native-dotenv@3.4.11.patch
+
+Avoid inlining Metro's `JEST_WORKER_ID` or `VITEST_WORKER_ID` into application
+code, which causes libraries such as react-native-mmkv to use test-only mocks.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,7 @@ patchedDependencies:
   expo@57.0.8: 1722861d12907a2d412d04230545b2fcbfa5547a79f99d763cb3e8de6f3a6f2a
   react-native-compressor@1.13.0: 58379dfaace6ced8590cb341c77f2ca8099dfa8f7df6297032ec51de767a9925
   react-native-date-picker@5.0.13: 92943fb79d17d7342a29bbb12b0d8ee3cf6f7bca12ed322dc8d124a3e9fb75bd
+  react-native-dotenv@3.4.11: 16b34eb974399935d3cf7c2526534f906991ccd876215176658347059cdd2021
   react-native-drawer-layout@4.2.3: 74f2c043cc22ab87054f219e7c7373a509b779b18bfa79d27e7d051d73355130
   react-native-keyboard-controller@1.21.9: ac52bf7502ff3ad34a8594b5e1a916b96bf87a2523b6abc87c31f03607d52271
   react-native-pager-view@6.8.0: c8316acd33c9aef6531e8c272c2bfab7bd02af1255969eeaab2bad5ab48531cc
@@ -853,7 +854,7 @@ importers:
         version: 3.9.6
       react-native-dotenv:
         specifier: ^3.4.11
-        version: 3.4.11(@babel/runtime@7.29.2)
+        version: 3.4.11(patch_hash=16b34eb974399935d3cf7c2526534f906991ccd876215176658347059cdd2021)(@babel/runtime@7.29.2)
       react-refresh:
         specifier: ^0.14.0
         version: 0.14.2
@@ -18190,7 +18191,7 @@ snapshots:
       react: 19.2.3
       react-native: 0.86.0(patch_hash=dd549527bb84c88acc7b0b1d521c9f4b666fda484c75cd0b282f8e9838524909)(@babel/core@7.29.0(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.0(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
 
-  react-native-dotenv@3.4.11(@babel/runtime@7.29.2):
+  react-native-dotenv@3.4.11(patch_hash=16b34eb974399935d3cf7c2526534f906991ccd876215176658347059cdd2021)(@babel/runtime@7.29.2):
     dependencies:
       '@babel/runtime': 7.29.2
       dotenv: 16.6.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,6 +40,7 @@ patchedDependencies:
   expo@57.0.8: patches/expo@57.0.8.patch
   'react-native-compressor@1.13.0': patches/react-native-compressor@1.13.0.patch
   'react-native-date-picker@5.0.13': patches/react-native-date-picker@5.0.13.patch
+  'react-native-dotenv@3.4.11': patches/react-native-dotenv@3.4.11.patch
   'react-native-drawer-layout@4.2.3': patches/react-native-drawer-layout@4.2.3.patch
   'react-native-keyboard-controller@1.21.9': patches/react-native-keyboard-controller@1.21.9.patch
   'react-native-pager-view@6.8.0': patches/react-native-pager-view@6.8.0.patch


### PR DESCRIPTION
## What

Adds a temporary pnpm patch for `react-native-dotenv` that prevents `JEST_WORKER_ID` and `VITEST_WORKER_ID` from being inlined into application bundles.

This restores persistent MMKV storage in native development and production bundles while retaining the plugin's existing replacement behavior for actual application environment variables.

## Root cause

The New Architecture migration replaced our MMKV 2 fork with `react-native-mmkv` 3.3.3. MMKV 3 decides whether to use native storage or its test-only in-memory implementation by checking whether `process.env.JEST_WORKER_ID` or `process.env.VITEST_WORKER_ID` is present.

Metro performs transformations in Jest workers, so its build process has `JEST_WORKER_ID` set. Our Babel configuration still includes `react-native-dotenv` for the legacy webpack build. That plugin visits every `process.env.*` member expression and falls back to the Babel process's environment when the value is not present in a dotenv file. It therefore replaces MMKV's runtime check with Metro's build-time worker ID.

As a result, MMKV believes the app itself is running under Jest and constructs its `Map`-backed test mock instead of the native MMKV instance. Reads and writes succeed within one JavaScript runtime, which made the settings path appear correct, but all values disappear when the bundle reloads and creates a fresh map. Font size exposed the problem, but every store using our MMKV-backed `Storage` class is affected.

## Fix

The patch leaves references to `JEST_WORKER_ID` and `VITEST_WORKER_ID` untouched instead of substituting the transform worker's values. On device those variables are absent, so MMKV selects native persistent storage. In real Jest/Vitest processes the runtime variables remain available, so MMKV can still select its test implementation.

Other environment variables continue through `react-native-dotenv`'s existing replacement path. This is intentionally a temporary patch; it can be removed with `react-native-dotenv` once the legacy webpack build no longer needs the plugin, or replaced by an upstream fix.

Related upstream report: https://github.com/mrousavy/react-native-mmkv/issues/1030

## Manual test plan

1. Open Appearance settings in a native development build.
2. Change Font size from Default to Smaller.
3. Reload the JavaScript bundle or restart the app.
4. Confirm the app still renders with the smaller font size and Appearance settings still selects Smaller.
