### PR TITLE
Fix HLS playback in Chrome embeds

### DIFF
--- a/bskyembed/src/components/embed.tsx
+++ b/bskyembed/src/components/embed.tsx
@@ -466,6 +466,7 @@ function VideoEmbed({content}: {content: AppBskyEmbedVideo.View}) {
         preload="metadata"
         // @ts-expect-error https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video#loading
         loading="lazy"
+        crossorigin="anonymous"
         aria-label={content.alt || undefined}
         onClickCapture={evt => evt.stopPropagation()}
         className="w-full rounded-xl bg-black"


### PR DESCRIPTION
## Summary

- opt embedded HLS videos into anonymous CORS requests
- allow Chrome to securely follow segment redirects from `video.bsky.app` to `video.cdn.bsky.app`

## Test plan

- Open a Bluesky video post embed in Chrome and confirm the video loads and plays.