### PR TITLE
Fix offset of post numbers for iOS

### DIFF
--- a/src/screens/PostThread/components/ThreadItemPostNumber.tsx
+++ b/src/screens/PostThread/components/ThreadItemPostNumber.tsx
@@ -65,6 +65,7 @@ export function ThreadItemPostNumber({
         inline
           ? platform({
               android: {transform: [{translateY: POST_NUMBER_INLINE_OFFSET}]},
+              ios: {transform: [{translateY: a.py_2xs.paddingBottom}]},
               web: {
                 top: -2,
                 marginBottom: -2,

--- a/src/screens/PostThread/components/ThreadItemPostNumber.tsx
+++ b/src/screens/PostThread/components/ThreadItemPostNumber.tsx
@@ -64,7 +64,7 @@ export function ThreadItemPostNumber({
         },
         inline
           ? platform({
-              native: {transform: [{translateY: POST_NUMBER_INLINE_OFFSET}]},
+              android: {transform: [{translateY: POST_NUMBER_INLINE_OFFSET}]},
               web: {
                 top: -2,
                 marginBottom: -2,


### PR DESCRIPTION
Missed this in #11455; The `RichText` change was only half of it.

| Before | After |
| - | - |
| <img width="1206" height="2622" alt="before" src="https://github.com/user-attachments/assets/b2e15401-ff43-46e9-ac8d-1ebce1f32b0e" /> | <img width="1206" height="2622" alt="after" src="https://github.com/user-attachments/assets/35e2d2b8-f223-4956-ae89-2fc29e8004e6" /> |