### PR TITLE
Fix "Tried to synchronously call a Remote Function" crash

### DIFF
--- a/src/Splash.tsx
+++ b/src/Splash.tsx
@@ -124,14 +124,14 @@ export function Splash(props: React.PropsWithChildren<Props>) {
     if (isReady) {
       SplashScreen.hideAsync()
         .then(() => {
-          intro.set(() =>
+          intro.set(
             withTiming(
               1,
               {duration: 400, easing: Easing.out(Easing.cubic)},
               () => {
                 'worklet'
                 // set these values to check animation at specific point
-                outroLogo.set(() =>
+                outroLogo.set(
                   withTiming(
                     1,
                     {duration: 1200, easing: Easing.in(Easing.cubic)},
@@ -140,13 +140,13 @@ export function Splash(props: React.PropsWithChildren<Props>) {
                     },
                   ),
                 )
-                outroApp.set(() =>
+                outroApp.set(
                   withTiming(1, {
                     duration: 1200,
                     easing: Easing.inOut(Easing.cubic),
                   }),
                 )
-                outroAppOpacity.set(() =>
+                outroAppOpacity.set(
                   withTiming(1, {
                     duration: 1200,
                     easing: Easing.in(Easing.cubic),

--- a/src/components/AvatarBubbles.tsx
+++ b/src/components/AvatarBubbles.tsx
@@ -72,7 +72,7 @@ export function AvatarBubbles({
     if (!animate) return
     const animateBubble = (p: SharedValue<number>, i: number) => {
       p.set(0)
-      p.set(() =>
+      p.set(
         withDelay(
           500 + i * 100,
           withTiming(1, {

--- a/src/components/Lightbox/pager/ImagePager.tsx
+++ b/src/components/Lightbox/pager/ImagePager.tsx
@@ -119,16 +119,12 @@ export default function ImageViewRoot({
 
     // https://github.com/software-mansion/react-native-reanimated/issues/6677
     rAF_FIXED(() => {
-      openProgress.set(() =>
-        isAnimated ? withClampedSpring(1, SLOW_SPRING) : 1,
-      )
+      openProgress.set(isAnimated ? withClampedSpring(1, SLOW_SPRING) : 1)
     })
     return () => {
       // https://github.com/software-mansion/react-native-reanimated/issues/6677
       rAF_FIXED(() => {
-        openProgress.set(() =>
-          isAnimated ? withClampedSpring(0, SLOW_SPRING) : 0,
-        )
+        openProgress.set(isAnimated ? withClampedSpring(0, SLOW_SPRING) : 0)
       })
     }
   }, [nextLightbox, openProgress, thumbRects])
@@ -591,25 +587,23 @@ function LightboxImage({
           // This is a bug in Reanimated, but for now we'll work around it like this.
           dismissSwipeTranslateY.set(1)
         }
-        dismissSwipeTranslateY.set(() => {
-          'worklet'
-          return withDecay({
+        dismissSwipeTranslateY.set(
+          withDecay({
             velocity: e.velocityY,
             velocityFactor: Math.max(3500 / Math.abs(e.velocityY), 1), // Speed up if it's too slow.
             deceleration: 1, // Danger! This relies on the reaction below stopping it.
             reduceMotion: ReduceMotion.Never, // If this animation doesn't run, the image gets stuck - therefore override Reduce Motion
-          })
-        })
+          }),
+        )
       } else {
-        dismissSwipeTranslateY.set(() => {
-          'worklet'
-          return withSpring(0, {
+        dismissSwipeTranslateY.set(
+          withSpring(0, {
             stiffness: 700,
             damping: 50,
             mass: 1,
             reduceMotion: ReduceMotion.Never,
-          })
-        })
+          }),
+        )
       }
     })
 

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -21,7 +21,7 @@ export function Loader(props: Props) {
   }))
 
   useEffect(() => {
-    rotation.set(() =>
+    rotation.set(
       withRepeat(withTiming(360, {duration: 500, easing: Easing.linear}), -1),
     )
   }, [rotation])

--- a/src/components/ProgressGuide/Toast.tsx
+++ b/src/components/ProgressGuide/Toast.tsx
@@ -62,7 +62,7 @@ export const ProgressGuideToast = forwardRef<
 
     // animate the opacity then set isOpen to false when done
     const setIsntOpen = () => setIsOpen(false)
-    opacity.set(() =>
+    opacity.set(
       withTiming(
         0,
         {
@@ -81,7 +81,7 @@ export const ProgressGuideToast = forwardRef<
     // animate the vertical translation, the opacity, and the checkmark
     const playCheckmark = () => animatedCheckRef.current?.play()
     opacity.set(0)
-    opacity.set(() =>
+    opacity.set(
       withTiming(
         1,
         {
@@ -92,7 +92,7 @@ export const ProgressGuideToast = forwardRef<
       ),
     )
     translateY.set(0)
-    translateY.set(() =>
+    translateY.set(
       withTiming(insets.top + 10, {
         duration: 500,
         easing: Easing.out(Easing.cubic),

--- a/src/components/anim/AnimatedCheck.tsx
+++ b/src/components/anim/AnimatedCheck.tsx
@@ -41,10 +41,8 @@ export const AnimatedCheck = forwardRef<AnimatedCheckRef, AnimatedCheckProps>(
         circleAnim.set(0)
         checkAnim.set(0)
 
-        circleAnim.set(() =>
-          withTiming(1, {duration: 500, easing: Easing.linear}),
-        )
-        checkAnim.set(() =>
+        circleAnim.set(withTiming(1, {duration: 500, easing: Easing.linear}))
+        checkAnim.set(
           withDelay(
             500,
             withTiming(1, {duration: 300, easing: Easing.linear}, cb),

--- a/src/components/dms/NewMessagesPill.tsx
+++ b/src/components/dms/NewMessagesPill.tsx
@@ -32,12 +32,12 @@ export function NewMessagesPill({
 
   const onPressIn = useCallback(() => {
     if (IS_WEB) return
-    scale.set(() => withTiming(1.075, {duration: 100}))
+    scale.set(withTiming(1.075, {duration: 100}))
   }, [scale])
 
   const onPressOut = useCallback(() => {
     if (IS_WEB) return
-    scale.set(() => withTiming(1, {duration: 100}))
+    scale.set(withTiming(1, {duration: 100}))
   }, [scale])
 
   const onPress = useCallback(() => {

--- a/src/components/dms/SwipeToReply.tsx
+++ b/src/components/dms/SwipeToReply.tsx
@@ -78,12 +78,13 @@ export function SwipeToReply({
     const runPop = () => {
       'worklet'
       if (isReducedMotion) return
-      iconScale.set(() =>
-        withSequence(
+      iconScale.set(() => {
+        'worklet'
+        return withSequence(
           withTiming(1.2, {duration: 175}),
           withTiming(1, {duration: 100}),
-        ),
-      )
+        )
+      })
     }
 
     return (

--- a/src/components/dms/SwipeToReply.tsx
+++ b/src/components/dms/SwipeToReply.tsx
@@ -78,13 +78,12 @@ export function SwipeToReply({
     const runPop = () => {
       'worklet'
       if (isReducedMotion) return
-      iconScale.set(() => {
-        'worklet'
-        return withSequence(
+      iconScale.set(
+        withSequence(
           withTiming(1.2, {duration: 175}),
           withTiming(1, {duration: 100}),
-        )
-      })
+        ),
+      )
     }
 
     return (

--- a/src/lib/custom-animations/GestureActionView.tsx
+++ b/src/lib/custom-animations/GestureActionView.tsx
@@ -63,13 +63,12 @@ export function GestureActionView({
       return
     }
 
-    iconScale.set(() => {
-      'worklet'
-      return withSequence(
+    iconScale.set(
+      withSequence(
         withTiming(1.2, {duration: 175}),
         withTiming(1, {duration: 100}),
-      )
-    })
+      ),
+    )
   }
 
   useAnimatedReaction(
@@ -206,10 +205,7 @@ export function GestureActionView({
           scheduleOnRN(actions.rightFirst.action)
         }
       }
-      transX.set(() => {
-        'worklet'
-        return withTiming(0, {duration: 200})
-      })
+      transX.set(withTiming(0, {duration: 200}))
       hitFirst.set(false)
       hitSecond.set(false)
       isActive.set(false)

--- a/src/lib/custom-animations/GestureActionView.tsx
+++ b/src/lib/custom-animations/GestureActionView.tsx
@@ -63,12 +63,13 @@ export function GestureActionView({
       return
     }
 
-    iconScale.set(() =>
-      withSequence(
+    iconScale.set(() => {
+      'worklet'
+      return withSequence(
         withTiming(1.2, {duration: 175}),
         withTiming(1, {duration: 100}),
-      ),
-    )
+      )
+    })
   }
 
   useAnimatedReaction(
@@ -205,7 +206,10 @@ export function GestureActionView({
           scheduleOnRN(actions.rightFirst.action)
         }
       }
-      transX.set(() => withTiming(0, {duration: 200}))
+      transX.set(() => {
+        'worklet'
+        return withTiming(0, {duration: 200})
+      })
       hitFirst.set(false)
       hitSecond.set(false)
       isActive.set(false)

--- a/src/lib/custom-animations/PressableScale.tsx
+++ b/src/lib/custom-animations/PressableScale.tsx
@@ -45,14 +45,14 @@ export function PressableScale({
           onPressIn(e)
         }
         cancelAnimation(scale)
-        scale.set(() => withTiming(targetScale, {duration: 100}))
+        scale.set(withTiming(targetScale, {duration: 100}))
       }}
       onPressOut={e => {
         if (onPressOut) {
           onPressOut(e)
         }
         cancelAnimation(scale)
-        scale.set(() => withTiming(1, {duration: 100}))
+        scale.set(withTiming(1, {duration: 100}))
       }}
       style={[!reducedMotion && animatedStyle, style]}
       {...rest}>

--- a/src/state/shell/minimal-mode.tsx
+++ b/src/state/shell/minimal-mode.tsx
@@ -33,13 +33,12 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   const setModeWorklet = useCallback(
     (v: boolean) => {
       'worklet'
-      footerMode.set(() => {
-        'worklet'
-        return withSpring(v ? 1 : 0, {
+      footerMode.set(
+        withSpring(v ? 1 : 0, {
           ...Reanimated3DefaultSpringConfig,
           overshootClamping: true,
-        })
-      })
+        }),
+      )
     },
     [footerMode],
   )

--- a/src/state/shell/minimal-mode.tsx
+++ b/src/state/shell/minimal-mode.tsx
@@ -33,12 +33,13 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   const setModeWorklet = useCallback(
     (v: boolean) => {
       'worklet'
-      footerMode.set(() =>
-        withSpring(v ? 1 : 0, {
+      footerMode.set(() => {
+        'worklet'
+        return withSpring(v ? 1 : 0, {
           ...Reanimated3DefaultSpringConfig,
           overshootClamping: true,
-        }),
-      )
+        })
+      })
     },
     [footerMode],
   )

--- a/src/view/com/util/MainScrollProvider.tsx
+++ b/src/view/com/util/MainScrollProvider.tsx
@@ -104,12 +104,13 @@ export function MainScrollProvider({children}: {children: React.ReactNode}) {
   const setMode = useCallback(
     (v: boolean) => {
       'worklet'
-      headerMode.set(() =>
-        withSpring(v ? 1 : 0, {
+      headerMode.set(() => {
+        'worklet'
+        return withSpring(v ? 1 : 0, {
           ...Reanimated3DefaultSpringConfig,
           overshootClamping: true,
-        }),
-      )
+        })
+      })
     },
     [headerMode],
   )

--- a/src/view/com/util/MainScrollProvider.tsx
+++ b/src/view/com/util/MainScrollProvider.tsx
@@ -104,13 +104,12 @@ export function MainScrollProvider({children}: {children: React.ReactNode}) {
   const setMode = useCallback(
     (v: boolean) => {
       'worklet'
-      headerMode.set(() => {
-        'worklet'
-        return withSpring(v ? 1 : 0, {
+      headerMode.set(
+        withSpring(v ? 1 : 0, {
           ...Reanimated3DefaultSpringConfig,
           overshootClamping: true,
-        })
-      })
+        }),
+      )
     },
     [headerMode],
   )

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -150,13 +150,12 @@ function HomeScreenReady({
   const headerMode = useHomeHeaderMode()
   const showHeader = useCallback(() => {
     'worklet'
-    headerMode.set(() => {
-      'worklet'
-      return withSpring(0, {
+    headerMode.set(
+      withSpring(0, {
         ...Reanimated3DefaultSpringConfig,
         overshootClamping: true,
-      })
-    })
+      }),
+    )
   }, [headerMode])
 
   useFocusEffect(

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -150,12 +150,13 @@ function HomeScreenReady({
   const headerMode = useHomeHeaderMode()
   const showHeader = useCallback(() => {
     'worklet'
-    headerMode.set(() =>
-      withSpring(0, {
+    headerMode.set(() => {
+      'worklet'
+      return withSpring(0, {
         ...Reanimated3DefaultSpringConfig,
         overshootClamping: true,
-      }),
-    )
+      })
+    })
   }, [headerMode])
 
   useFocusEffect(


### PR DESCRIPTION
## Summary

- Fixes a fatal Android crash (`[Worklets] Tried to synchronously call a Remote Function`) triggered when ViewPager2 intercepts a touch during a scroll state transition on the Home pager, plus the same latent crash in DM swipe-to-reply and chat list swipe actions
- Root cause: React Compiler outlines capture-free updaters like `sv.set(() => withSpring(...))` to module scope. The outlined function is not workletized, so worklets capture it as a remote function, and `set()` invokes updaters synchronously on the current runtime
- Fix: pass the animation directly, `sv.set(withSpring(...))`. Reanimated already invokes updaters synchronously on the calling runtime, so the wrapper was never buying anything - it only gave the compiler something to outline. Converted all 25 such call sites so the hazard cannot reappear

## Test plan

- Verified in Reanimated's source that `defineAnimation` returns a built animation object on the UI runtime and an `__isAnimationDefinition`-marked definition on the RN runtime, which `set()` passes through untouched - both forms are equivalent
- Compiled the affected files with the project babel config: worklet closures now capture the reanimated worklets (`withSpring`, `withTiming`, `withSequence`) directly, with no outlined plain function
- Scanned all 118 worklet-related files (compile + AST analysis of worklet closures) for captured non-workletized functions: zero findings
- `pnpm typecheck`, `pnpm lint`, `pnpm prettier`, `pnpm test` (770 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)