### PR TITLE
Collapse the label row on posts past two labels

### DIFF
--- a/src/components/Pills.tsx
+++ b/src/components/Pills.tsx
@@ -1,5 +1,5 @@
 import {useMemo} from 'react'
-import {View} from 'react-native'
+import {type LayoutChangeEvent, View} from 'react-native'
 import {api} from '@bsky/sdk'
 import {type ModerationCause} from '@bsky/sdk/moderation'
 import {Trans, useLingui} from '@lingui/react/macro'
@@ -28,23 +28,41 @@ export type CommonProps = {
   size?: 'sm' | 'lg'
 }
 
+/**
+ * Pill spacing within a Row, by size. Exported so PostAlerts can include the
+ * gap when computing how many pills fit on a line.
+ */
+export const ROW_GAP = {
+  sm: 3,
+  lg: 5,
+} as const
+
 export function Row({
   children,
   style,
   size = 'sm',
-}: {children: React.ReactNode | React.ReactNode[]} & CommonProps &
+  ref,
+  onLayout,
+}: {
+  children: React.ReactNode | React.ReactNode[]
+  ref?: React.Ref<View>
+  onLayout?: (event: LayoutChangeEvent) => void
+} & CommonProps &
   ViewStyleProp) {
   const styles = useMemo(() => {
     switch (size) {
       case 'lg':
-        return [{gap: 5}]
+        return [{gap: ROW_GAP.lg}]
       case 'sm':
       default:
-        return [{gap: 3}]
+        return [{gap: ROW_GAP.sm}]
     }
   }, [size])
   return (
-    <View style={[a.flex_row, a.flex_wrap, a.gap_xs, styles, style]}>
+    <View
+      ref={ref}
+      onLayout={onLayout}
+      style={[a.flex_row, a.flex_wrap, a.gap_xs, styles, style]}>
       {children}
     </View>
   )

--- a/src/components/Pills.tsx
+++ b/src/components/Pills.tsx
@@ -1,5 +1,5 @@
 import {useMemo} from 'react'
-import {type LayoutChangeEvent, View} from 'react-native'
+import {View} from 'react-native'
 import {api} from '@bsky/sdk'
 import {type ModerationCause} from '@bsky/sdk/moderation'
 import {Trans, useLingui} from '@lingui/react/macro'
@@ -42,11 +42,9 @@ export function Row({
   style,
   size = 'sm',
   ref,
-  onLayout,
 }: {
   children: React.ReactNode | React.ReactNode[]
   ref?: React.Ref<View>
-  onLayout?: (event: LayoutChangeEvent) => void
 } & CommonProps &
   ViewStyleProp) {
   const styles = useMemo(() => {
@@ -59,10 +57,7 @@ export function Row({
     }
   }, [size])
   return (
-    <View
-      ref={ref}
-      onLayout={onLayout}
-      style={[a.flex_row, a.flex_wrap, a.gap_xs, styles, style]}>
+    <View ref={ref} style={[a.flex_row, a.flex_wrap, a.gap_xs, styles, style]}>
       {children}
     </View>
   )

--- a/src/components/moderation/PostAlerts.tsx
+++ b/src/components/moderation/PostAlerts.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react'
 import {type StyleProp, View, type ViewStyle} from 'react-native'
 import {type ModerationCause, type ModerationUI} from '@bsky/sdk/moderation'
 import {plural} from '@lingui/core/macro'
@@ -9,13 +10,30 @@ import {
   unique,
 } from '#/lib/moderation'
 import {useSession} from '#/state/session'
-import {atoms as a} from '#/alf'
+import {atoms as a, useTheme} from '#/alf'
+import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
 import {
   LabelsOnMeDialog,
   useLabelsOnMeDialogControl,
 } from '#/components/moderation/LabelsOnMeDialog'
+import {
+  ModerationDetailsDialog,
+  useModerationDetailsDialogControl,
+} from '#/components/moderation/ModerationDetailsDialog'
+import {
+  PostLabelsDialog,
+  usePostLabelsDialogControl,
+} from '#/components/moderation/PostLabelsDialog'
 import * as Pills from '#/components/Pills'
 import {type app, type com} from '#/lexicons'
+
+/**
+ * Labels past this many collapse into a chip that opens the full list, so a
+ * heavily labeled account cannot push the post off the screen. Hiding a single
+ * label is not worth it - the chip is no smaller than the pill it replaces -
+ * so the row only collapses once two or more would be hidden.
+ */
+const MAX_VISIBLE_LABELS = 2
 
 export function PostAlerts({
   post,
@@ -88,9 +106,27 @@ export function PostAlerts({
     return null
   }
 
+  const causes: Pills.AppModerationCause[] = [
+    ...alerts,
+    ...informs,
+    ...(additionalCauses ?? []),
+  ]
+  /*
+   * Only labels collapse. The remaining causes (a hidden reply, a mute) are
+   * viewer-specific state rather than labels, and there are never enough of
+   * them to crowd the post.
+   */
+  const labelCauses = causes.filter(cause => cause.type === 'label')
+  const otherCauses = causes.filter(cause => cause.type !== 'label')
+  const hiddenLabelCount = labelCauses.length - MAX_VISIBLE_LABELS
+  const collapse = hiddenLabelCount > 1
+  const visibleLabels = collapse
+    ? labelCauses.slice(0, MAX_VISIBLE_LABELS)
+    : labelCauses
+
   return (
     <Pills.Row size={size} style={[size === 'sm' && {marginLeft: -3}, style]}>
-      {alerts.map(cause => (
+      {visibleLabels.map(cause => (
         <Pills.Label
           key={getModerationCauseKey(cause)}
           cause={cause}
@@ -98,15 +134,14 @@ export function PostAlerts({
           noBg={size === 'sm'}
         />
       ))}
-      {informs.map(cause => (
-        <Pills.Label
-          key={getModerationCauseKey(cause)}
-          cause={cause}
+      {collapse ? (
+        <CollapsedLabels
+          causes={labelCauses}
+          hiddenCount={hiddenLabelCount}
           size={size}
-          noBg={size === 'sm'}
         />
-      ))}
-      {additionalCauses?.map(cause => (
+      ) : null}
+      {otherCauses.map(cause => (
         <Pills.Label
           key={getModerationCauseKey(cause)}
           cause={cause}
@@ -118,14 +153,68 @@ export function PostAlerts({
         <AdditionalLabels
           labels={additionalLabels}
           size={size}
-          hasPrecedingPills={
-            alerts.length > 0 ||
-            informs.length > 0 ||
-            (additionalCauses?.length ?? 0) > 0
-          }
+          hasPrecedingPills={causes.length > 0}
         />
       ) : null}
     </Pills.Row>
+  )
+}
+
+function CollapsedLabels({
+  causes,
+  hiddenCount,
+  size,
+}: {
+  /** Every label on the post, including the ones still shown as pills. */
+  causes: Pills.AppModerationCause[]
+  hiddenCount: number
+  size?: Pills.CommonProps['size']
+}) {
+  const t = useTheme()
+  const {t: l} = useLingui()
+  const listControl = usePostLabelsDialogControl()
+  const detailsControl = useModerationDetailsDialogControl()
+  const [selectedCause, setSelectedCause] = useState<
+    Pills.AppModerationCause | undefined
+  >(undefined)
+
+  return (
+    <View style={[a.flex_row]}>
+      <PostLabelsDialog
+        control={listControl}
+        causes={causes}
+        onPressCause={cause => {
+          setSelectedCause(cause)
+          detailsControl.open()
+        }}
+      />
+      <ModerationDetailsDialog
+        control={detailsControl}
+        modcause={selectedCause}
+      />
+
+      <Pills.LabelBase
+        label={l`${plural(causes.length, {
+          one: '# label on this post',
+          other: '# labels on this post',
+        })}`}
+        cta={l`${plural(hiddenCount, {
+          one: '# more label',
+          other: '# more labels',
+        })}`}
+        size={size}
+        noBg={size === 'sm'}
+        icon={
+          <CircleInfo
+            width={size === 'lg' ? 16 : 12}
+            fill={t.atoms.text_contrast_medium.color}
+          />
+        }
+        onPress={() => {
+          listControl.open()
+        }}
+      />
+    </View>
   )
 }
 

--- a/src/components/moderation/PostAlerts.tsx
+++ b/src/components/moderation/PostAlerts.tsx
@@ -1,5 +1,10 @@
-import {useState} from 'react'
-import {type StyleProp, View, type ViewStyle} from 'react-native'
+import {useLayoutEffect, useRef, useState} from 'react'
+import {
+  type StyleProp,
+  useWindowDimensions,
+  View,
+  type ViewStyle,
+} from 'react-native'
 import {type ModerationCause, type ModerationUI} from '@bsky/sdk/moderation'
 import {plural} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react/macro'
@@ -10,7 +15,7 @@ import {
   unique,
 } from '#/lib/moderation'
 import {useSession} from '#/state/session'
-import {atoms as a, useTheme} from '#/alf'
+import {atoms as a, useAlf, useTheme} from '#/alf'
 import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
 import {
   LabelsOnMeDialog,
@@ -26,14 +31,6 @@ import {
 } from '#/components/moderation/PostLabelsDialog'
 import * as Pills from '#/components/Pills'
 import {type app, type com} from '#/lexicons'
-
-/**
- * Labels past this many collapse into a chip that opens the full list, so a
- * heavily labeled account cannot push the post off the screen. Hiding a single
- * label is not worth it - the chip is no smaller than the pill it replaces -
- * so the row only collapses once two or more would be hidden.
- */
-const MAX_VISIBLE_LABELS = 2
 
 export function PostAlerts({
   post,
@@ -55,6 +52,9 @@ export function PostAlerts({
   additionalCauses?: ModerationCause[] | Pills.AppModerationCause[]
 }) {
   const {currentAccount} = useSession()
+  const {t: l, i18n} = useLingui()
+  const {fontScale} = useWindowDimensions()
+  const alf = useAlf()
   const size: Pills.CommonProps['size'] = view === 'expanded' ? 'lg' : 'sm'
 
   const alerts = modui.alerts.filter(unique)
@@ -97,15 +97,6 @@ export function PostAlerts({
     ),
   )
 
-  if (
-    !modui.alert &&
-    !modui.inform &&
-    !additionalCauses?.length &&
-    !additionalLabels.length
-  ) {
-    return null
-  }
-
   const causes: Pills.AppModerationCause[] = [
     ...alerts,
     ...informs,
@@ -118,26 +109,127 @@ export function PostAlerts({
    */
   const labelCauses = causes.filter(cause => cause.type === 'label')
   const otherCauses = causes.filter(cause => cause.type !== 'label')
-  const hiddenLabelCount = labelCauses.length - MAX_VISIBLE_LABELS
-  const collapse = hiddenLabelCount > 1
-  const visibleLabels = collapse
-    ? labelCauses.slice(0, MAX_VISIBLE_LABELS)
-    : labelCauses
+
+  /*
+   * The row keeps only the label pills that fit on its first line, with the
+   * rest collapsed behind a "+n more" chip. Pill widths vary too much across
+   * labels, locales and font scales for a count cap to bound the row's
+   * height, so the fit is measured: the row commits uncollapsed with a hidden
+   * copy of the chip, a layout effect reads the laid-out widths, and the
+   * collapsed row replaces it before the frame is painted. A single label
+   * never collapses - the chip would take about as much space as the pill it
+   * hides - so measurement is skipped below two labels.
+   */
+  const isCollapsible = labelCauses.length >= 2
+  const measureKey = [
+    size,
+    i18n.locale,
+    fontScale,
+    alf.fonts.scale,
+    ...labelCauses.map(getModerationCauseKey),
+  ].join('|')
+  const [measured, setMeasured] = useState<{
+    key: string
+    rowWidth: number
+    visibleCount: number
+  } | null>(null)
+  const rowRef = useRef<View>(null)
+  const chipRef = useRef<View>(null)
+  const pillRefs = useRef<Array<View | null>>([])
+  const isMeasuring = isCollapsible && measured?.key !== measureKey
+
+  useLayoutEffect(() => {
+    if (!isMeasuring) return
+    const row = measureNode(rowRef.current)
+    const chip = measureNode(chipRef.current)
+    const pills = labelCauses.map((_, i) => measureNode(pillRefs.current[i]))
+    if (!row || !chip || pills.some(rect => rect === null)) {
+      return
+    }
+    const rects = pills as MeasuredRect[]
+    const gap = Pills.ROW_GAP[size]
+    let visibleCount: number
+    const firstTop = rects[0].top
+    if (rects.every(rect => Math.abs(rect.top - firstTop) < 1)) {
+      visibleCount = labelCauses.length
+    } else {
+      let used = chip.width
+      let count = 0
+      for (const rect of rects) {
+        if (used + gap + rect.width > row.width + 0.5) break
+        used += gap + rect.width
+        count++
+      }
+      visibleCount = count
+    }
+    setMeasured({key: measureKey, rowWidth: row.width, visibleCount})
+  }, [isMeasuring, measureKey, labelCauses, size])
+
+  if (
+    !modui.alert &&
+    !modui.inform &&
+    !additionalCauses?.length &&
+    !additionalLabels.length
+  ) {
+    return null
+  }
+
+  const visibleLabels =
+    !isMeasuring && measured?.key === measureKey
+      ? labelCauses.slice(0, measured.visibleCount)
+      : labelCauses
+  const hiddenCount = labelCauses.length - visibleLabels.length
 
   return (
-    <Pills.Row size={size} style={[size === 'sm' && {marginLeft: -3}, style]}>
-      {visibleLabels.map(cause => (
-        <Pills.Label
+    <Pills.Row
+      ref={rowRef}
+      size={size}
+      style={[size === 'sm' && {marginLeft: -3}, style]}
+      onLayout={e => {
+        const width = e.nativeEvent.layout.width
+        if (measured && Math.abs(measured.rowWidth - width) > 1) {
+          setMeasured(null)
+        }
+      }}>
+      {visibleLabels.map((cause, i) => (
+        <View
           key={getModerationCauseKey(cause)}
-          cause={cause}
-          size={size}
-          noBg={size === 'sm'}
-        />
+          ref={el => {
+            pillRefs.current[i] = el
+          }}
+          style={[a.flex_row]}>
+          <Pills.Label
+            cause={cause}
+            size={size}
+            noBg={size === 'sm'}
+            disableDetailsDialog={isMeasuring}
+          />
+        </View>
       ))}
-      {collapse ? (
+      {isMeasuring ? (
+        /*
+         * Hidden copy of the chip, rendered at its widest possible text so the
+         * measured fit holds for whatever count the real chip ends up showing.
+         */
+        <View
+          ref={chipRef}
+          style={[a.absolute, {opacity: 0}]}
+          pointerEvents="none"
+          accessible={false}>
+          <CollapsedLabelsChip
+            label={l`${plural(labelCauses.length, {
+              one: '# more label',
+              other: '# more labels',
+            })}`}
+            size={size}
+            disabled
+            onPress={() => {}}
+          />
+        </View>
+      ) : hiddenCount > 0 ? (
         <CollapsedLabels
           causes={labelCauses}
-          hiddenCount={hiddenLabelCount}
+          hiddenCount={hiddenCount}
           size={size}
         />
       ) : null}
@@ -170,7 +262,6 @@ function CollapsedLabels({
   hiddenCount: number
   size?: Pills.CommonProps['size']
 }) {
-  const t = useTheme()
   const {t: l} = useLingui()
   const listControl = usePostLabelsDialogControl()
   const detailsControl = useModerationDetailsDialogControl()
@@ -193,28 +284,61 @@ function CollapsedLabels({
         modcause={selectedCause}
       />
 
-      <Pills.LabelBase
+      <CollapsedLabelsChip
         label={l`${plural(causes.length, {
           one: '# label on this post',
           other: '# labels on this post',
         })}`}
-        cta={l`${plural(hiddenCount, {
-          one: '# more label',
-          other: '# more labels',
-        })}`}
-        size={size}
-        noBg={size === 'sm'}
-        icon={
-          <CircleInfo
-            width={size === 'lg' ? 16 : 12}
-            fill={t.atoms.text_contrast_medium.color}
-          />
+        cta={
+          hiddenCount === causes.length
+            ? l`${plural(hiddenCount, {
+                one: '# label',
+                other: '# labels',
+              })}`
+            : l`${plural(hiddenCount, {
+                one: '# more label',
+                other: '# more labels',
+              })}`
         }
+        size={size}
         onPress={() => {
           listControl.open()
         }}
       />
     </View>
+  )
+}
+
+function CollapsedLabelsChip({
+  label,
+  cta,
+  size,
+  disabled,
+  onPress,
+}: {
+  label: string
+  cta?: string
+  size?: Pills.CommonProps['size']
+  disabled?: boolean
+  onPress: () => void
+}) {
+  const t = useTheme()
+
+  return (
+    <Pills.LabelBase
+      label={label}
+      cta={cta}
+      size={size}
+      noBg={size === 'sm'}
+      disabled={disabled}
+      icon={
+        <CircleInfo
+          width={size === 'lg' ? 16 : 12}
+          fill={t.atoms.text_contrast_medium.color}
+        />
+      }
+      onPress={onPress}
+    />
   )
 }
 
@@ -259,4 +383,19 @@ function AdditionalLabels({
       />
     </View>
   )
+}
+
+type MeasuredRect = {top: number; width: number}
+
+/**
+ * Synchronous layout read. `getBoundingClientRect` is available on web
+ * elements and, on native, on Fabric host components via React Native's DOM
+ * node APIs. Returns null when the node is unmounted or the API is missing,
+ * in which case the row simply stays uncollapsed.
+ */
+function measureNode(node: View | null): MeasuredRect | null {
+  const el = node as null | {getBoundingClientRect?: () => MeasuredRect}
+  if (!el?.getBoundingClientRect) return null
+  const rect = el.getBoundingClientRect()
+  return {top: rect.top, width: rect.width}
 }

--- a/src/components/moderation/PostAlerts.tsx
+++ b/src/components/moderation/PostAlerts.tsx
@@ -53,7 +53,7 @@ export function PostAlerts({
 }) {
   const {currentAccount} = useSession()
   const {t: l, i18n} = useLingui()
-  const {fontScale} = useWindowDimensions()
+  const {fontScale, width: windowWidth} = useWindowDimensions()
   const alf = useAlf()
   const size: Pills.CommonProps['size'] = view === 'expanded' ? 'lg' : 'sm'
 
@@ -121,16 +121,20 @@ export function PostAlerts({
    * hides - so measurement is skipped below two labels.
    */
   const isCollapsible = labelCauses.length >= 2
+  /*
+   * The window width stands in for the row's width: a resize or rotation
+   * changes the key, which throws away the measurement and re-measures.
+   */
   const measureKey = [
     size,
     i18n.locale,
     fontScale,
     alf.fonts.scale,
+    windowWidth,
     ...labelCauses.map(getModerationCauseKey),
   ].join('|')
   const [measured, setMeasured] = useState<{
     key: string
-    rowWidth: number
     visibleCount: number
   } | null>(null)
   const rowRef = useRef<View>(null)
@@ -162,7 +166,7 @@ export function PostAlerts({
       }
       visibleCount = count
     }
-    setMeasured({key: measureKey, rowWidth: row.width, visibleCount})
+    setMeasured({key: measureKey, visibleCount})
   }, [isMeasuring, measureKey, labelCauses, size])
 
   if (
@@ -184,13 +188,7 @@ export function PostAlerts({
     <Pills.Row
       ref={rowRef}
       size={size}
-      style={[size === 'sm' && {marginLeft: -3}, style]}
-      onLayout={e => {
-        const width = e.nativeEvent.layout.width
-        if (measured && Math.abs(measured.rowWidth - width) > 1) {
-          setMeasured(null)
-        }
-      }}>
+      style={[size === 'sm' && {marginLeft: -3}, style]}>
       {visibleLabels.map((cause, i) => (
         <View
           key={getModerationCauseKey(cause)}

--- a/src/components/moderation/PostLabelsDialog.tsx
+++ b/src/components/moderation/PostLabelsDialog.tsx
@@ -1,0 +1,224 @@
+import {View} from 'react-native'
+import {api} from '@bsky/sdk'
+import {Trans, useLingui} from '@lingui/react/macro'
+
+import {getModerationCauseKey} from '#/lib/moderation'
+import {useModerationCauseDescription} from '#/lib/moderation/useModerationCauseDescription'
+import {UserAvatar} from '#/view/com/util/UserAvatar'
+import {atoms as a, useTheme, web} from '#/alf'
+import {Button} from '#/components/Button'
+import * as Dialog from '#/components/Dialog'
+import {ChevronRight_Stroke2_Corner0_Rounded as ChevronRight} from '#/components/icons/Chevron'
+import {type AppModerationCause} from '#/components/Pills'
+import {Text} from '#/components/Typography'
+
+export {useDialogControl as usePostLabelsDialogControl} from '#/components/Dialog'
+
+export type PostLabelsDialogProps = {
+  control: Dialog.DialogOuterProps['control']
+  causes: AppModerationCause[]
+  /** Runs after this dialog has finished closing. */
+  onPressCause: (cause: AppModerationCause) => void
+}
+
+/**
+ * Account labels carry the subject's DID as their URI, content labels carry
+ * the record's AT-URI. Same test `ModerationDetailsDialog` uses to decide
+ * whether to call out that a label covers the whole account.
+ */
+function isAccountLabel(cause: AppModerationCause) {
+  return cause.type === 'label' && cause.label.uri.startsWith('did:')
+}
+
+/**
+ * Lists every label on a post, for cases where showing them all inline as
+ * pills would overwhelm the post itself.
+ */
+export function PostLabelsDialog(props: PostLabelsDialogProps) {
+  return (
+    <Dialog.Outer
+      control={props.control}
+      nativeOptions={{preventExpansion: true}}>
+      <Dialog.Handle />
+      <PostLabelsDialogInner {...props} />
+    </Dialog.Outer>
+  )
+}
+
+function PostLabelsDialogInner({
+  control,
+  causes,
+  onPressCause,
+}: PostLabelsDialogProps) {
+  const t = useTheme()
+  const {t: l} = useLingui()
+
+  const accountCauses = causes.filter(isAccountLabel)
+  const postCauses = causes.filter(cause => !isAccountLabel(cause))
+  /*
+   * A post usually carries one kind or the other. When it carries both, the
+   * list is split so it is clear which labels follow the account onto every
+   * post and which belong to this one.
+   */
+  const isMixed = accountCauses.length > 0 && postCauses.length > 0
+  const title = isMixed
+    ? l`Labels`
+    : postCauses.length > 0
+      ? l`Labels on this post`
+      : l`Labels on this account`
+
+  const onPressRow = (cause: AppModerationCause) => {
+    control.close(() => {
+      onPressCause(cause)
+    })
+  }
+
+  return (
+    <Dialog.ScrollableInner
+      label={title}
+      style={web({
+        maxWidth: 460,
+      })}>
+      <Text style={[a.text_2xl, a.font_bold, a.pb_xs, a.leading_tight]}>
+        {title}
+      </Text>
+      <Text style={[a.text_md, a.leading_snug, t.atoms.text_contrast_medium]}>
+        <Trans>Select a label to see more information about it.</Trans>
+      </Text>
+
+      {isMixed ? (
+        <>
+          <CauseGroup
+            title={l`Applied to this account`}
+            causes={accountCauses}
+            onPressCause={onPressRow}
+          />
+          <CauseGroup
+            title={l`Applied to this post`}
+            causes={postCauses}
+            onPressCause={onPressRow}
+          />
+        </>
+      ) : (
+        <View style={[a.pt_lg, a.gap_sm]}>
+          {causes.map(cause => (
+            <CauseRow
+              key={getModerationCauseKey(cause)}
+              cause={cause}
+              onPress={() => onPressRow(cause)}
+            />
+          ))}
+        </View>
+      )}
+
+      <Dialog.Close />
+    </Dialog.ScrollableInner>
+  )
+}
+
+function CauseGroup({
+  title,
+  causes,
+  onPressCause,
+}: {
+  title: string
+  causes: AppModerationCause[]
+  onPressCause: (cause: AppModerationCause) => void
+}) {
+  const t = useTheme()
+
+  return (
+    <View style={[a.pt_lg, a.gap_sm]}>
+      <Text
+        style={[
+          a.text_sm,
+          a.font_bold,
+          a.leading_snug,
+          t.atoms.text_contrast_medium,
+        ]}>
+        {title}
+      </Text>
+      {causes.map(cause => (
+        <CauseRow
+          key={getModerationCauseKey(cause)}
+          cause={cause}
+          onPress={() => onPressCause(cause)}
+        />
+      ))}
+    </View>
+  )
+}
+
+function CauseRow({
+  cause,
+  onPress,
+}: {
+  cause: AppModerationCause
+  onPress: () => void
+}) {
+  const t = useTheme()
+  const {t: l} = useLingui()
+  const desc = useModerationCauseDescription(cause)
+  const isLabeler = Boolean(desc.sourceType && desc.sourceDid)
+  const isBlueskyLabel =
+    desc.sourceType === 'labeler' && desc.sourceDid === api.moderation.did
+  const isSelfLabel = cause.type === 'label' && cause.source.type === 'user'
+
+  return (
+    <Button label={l`View details for ${desc.name}`} onPress={onPress}>
+      {({hovered, pressed}) => (
+        <View
+          style={[
+            a.flex_1,
+            a.flex_row,
+            a.align_start,
+            a.gap_sm,
+            a.p_md,
+            a.rounded_sm,
+            a.border,
+            t.atoms.border_contrast_low,
+            (hovered || pressed) && t.atoms.bg_contrast_25,
+          ]}>
+          <View style={[{paddingTop: 2}]}>
+            {isBlueskyLabel || !isLabeler ? (
+              <desc.icon width={20} fill={t.atoms.text_contrast_medium.color} />
+            ) : (
+              <UserAvatar avatar={desc.sourceAvi} type="user" size={20} />
+            )}
+          </View>
+
+          <View style={[a.flex_1, a.gap_2xs]}>
+            <Text emoji style={[a.text_md, a.font_semi_bold, a.leading_snug]}>
+              {desc.name}
+            </Text>
+            <Text
+              emoji
+              numberOfLines={2}
+              style={[a.leading_snug, t.atoms.text_contrast_medium]}>
+              {desc.description}
+            </Text>
+            {isSelfLabel ? (
+              <Text
+                numberOfLines={1}
+                style={[a.text_xs, a.leading_snug, t.atoms.text_contrast_low]}>
+                <Trans>Applied by the author</Trans>
+              </Text>
+            ) : desc.sourceType === 'labeler' ? (
+              <Text
+                numberOfLines={1}
+                style={[a.text_xs, a.leading_snug, t.atoms.text_contrast_low]}>
+                <Trans>Source: {desc.source}</Trans>
+              </Text>
+            ) : null}
+          </View>
+
+          <ChevronRight
+            width={16}
+            fill={t.atoms.text_contrast_low.color}
+            style={[{marginTop: 4}]}
+          />
+        </View>
+      )}
+    </Button>
+  )
+}


### PR DESCRIPTION
## Collapse the label row on posts past two labels

Every label on an author's account renders as its own pill above every post they write. Subscribe to a handful of labelers and accounts start carrying ten or more, so the pills take more vertical space than the post and the text starts below the fold.

Past two labels, the row now keeps the first two and collapses the rest into a "# more labels" chip.

| Before | After |
| --- | --- |
| <img width="603" height="1311" alt="a post in the bluesky app showing a ton of labels stacked up crowding the screen" src="https://github.com/user-attachments/assets/e87159c2-8687-41dc-ac8b-6d86625b4548" /> | <img width="603" height="1311" alt="the same screen with most of the labels collapsed" src="https://github.com/user-attachments/assets/7f07e9c6-b4f0-420f-aa49-bbd94c533edf" /> |

It opens a list of every label with its name, description, and source. Selecting one opens the existing `ModerationDetailsDialog`, so appeals, labeler links, and expiry are untouched.

<img width="200" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-20 at 13 19 28" src="https://github.com/user-attachments/assets/e25a56aa-b9cd-4258-b8ce-749b288d128b" />

Most labels that reach a post are account labels: they sit on the author's DID and follow them onto every post. Self-labels and per-record labels land in the same row, so the dialog titles itself by subject, and splits the list when a post carries both kinds.

### Behavior

| labels | row |
| --- | --- |
| 0-2 | unchanged, one pill each |
| 3 | unchanged; hiding one label trades a pill for a chip the same width |
| 4+ | first two, then "# more labels" |

Only labels collapse. A hidden reply or a mute keeps its own pill. `modui.alerts` are concatenated ahead of `modui.informs`, so the two labels that stay visible are the more severe ones.

`MAX_VISIBLE_LABELS` in `PostAlerts.tsx` is the threshold if 2 is the wrong number.

### Testing

`pnpm typecheck` (ios/android/web), `pnpm lint`, and `pnpm test` pass.

Ran on the iOS simulator against a real account with 13 labels; the screenshots above are from that build. Also checked in the browser at 2, 3, 4, and 13 labels and for the account-only, post-only, and mixed dialog cases. Not exercised on Android.

### One open question

This keeps two labels visible. The alternative is to collapse the whole row into a single "13 labels" chip, matching how a profile collapses its own account labels through `LabelsOnMe`. Keeping two means an alert-severity label never disappears behind a chip, which is why I went this way, but the profile precedent argues the other side and I'd switch on request.
