### PR TITLE
[AA] Set `maxAge: Infinity` on age assurance cache

### DIFF
--- a/src/ageAssurance/data.tsx
+++ b/src/ageAssurance/data.tsx
@@ -57,6 +57,13 @@ const persister = createAsyncStoragePersister({
 const [, cacheHydrationPromise] = persistQueryClient({
   queryClient: qc,
   persister,
+  /*
+   * Device signals are local-only and cannot be recovered without prompting
+   * the user again, so they must survive the persister's default 24-hour
+   * expiration. Server-backed queries still use their own stale times and
+   * refetch normally after hydration.
+   */
+  maxAge: Infinity,
 })
 
 /*


### PR DESCRIPTION
The default `maxAge` of a react query persisted cache is 24hrs ([see here](https://tanstack.com/query/latest/docs/framework/react/plugins/persistQueryClient#how-it-works)). We already correctly set `gcTime`, but the age assurance cache left the default `maxAge` which meant the entire cache got busted every 24hrs.

This affects all age assurance data but it's particularly noticeable with the device signals API as that can't just sync from the server so it results in data loss

The fix: set it to infinity