### PR TITLE
Update tech stack versions and fix markdown in CLAUDE.md 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -561,7 +561,7 @@ Only use `useMemo`/`useCallback` when you have a specific reason, such as:
 
 1. **Accessibility**: Always provide `label` prop for interactive elements, use `accessibilityHint` where helpful
 
-2. **Translations**: Wrap ALL user-facing strings with ` `l` `` or `<Trans>`
+2. **Translations**: Wrap ALL user-facing strings with the `` l`…` `` macro or the `<Trans>` component
 
 3. **Styling**: Combine static atoms with theme atoms, use platform utilities for platform-specific styles
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@ Bluesky Social is a cross-platform social media application built with React Nat
 
 **Tech Stack:**
 
-- React 19.1
-- React Native 0.81 with Expo 54
+- React 19.2
+- React Native 0.86 with Expo 57
 - TypeScript 7
 - React Navigation 7 for routing
 - TanStack Query (React Query) for data fetching


### PR DESCRIPTION
This PR proposes two tweaks to `CLAUDE.md`.

The first is to update the **Tech Stack** section to reflect recent updates in React, React Native and Expo versions.

Secondly, although Claude will still understand line 564 (**Translations**), it currently looks broken to a human reader.

As Claude explains:

**Why it breaks.** The raw source at `CLAUDE.md:564` is:

```
2. **Translations**: Wrap ALL user-facing strings with ` `l` `` or `<Trans>`
```

CommonMark closes a code span only with a backtick run of *exactly* the opening length, so those delimiters mis-pair:

- `` ` `` + space + `` ` `` → a code span containing one space (the empty chip)
- `l` falls outside any span
- the next `` ` `` opens a span; the two-backtick run can't close a one-backtick opener, so it runs on to the backtick before `<Trans>` — content `` `` or `` (the second chip)
- `<Trans>` is then plain text, and GitHub's sanitizer drops it as an unknown HTML tag
- the final backtick is unmatched and prints literally

Claude reads the raw file, so it still gets the gist — but the source is ambiguous and the rendered page loses `<Trans>` entirely.

**The fix.** Show backticks inside inline code by using a longer delimiter run with one space of padding (stripped at render). The file already does this correctly at `CLAUDE.md:305`, so this is just making line 564 consistent:

```
2. **Translations**: Wrap ALL user-facing strings with the `` l`…` `` macro or the `<Trans>` component
```

**Before:**
<img width="1762" height="307" alt="IMG_0566" src="https://github.com/user-attachments/assets/c0fb74b6-5bfc-4c70-9e34-e7fc0dc5fe7d" />

**After:**
<img width="1779" height="311" alt="IMG_0568" src="https://github.com/user-attachments/assets/30ed5ea0-5776-45df-ae8b-c8961014baf3" />