### PR TITLE
[APP-2922] Fix cached starter pack navigation

### DIFF
--- a/src/screens/StarterPack/StarterPackScreen.tsx
+++ b/src/screens/StarterPack/StarterPackScreen.tsx
@@ -146,7 +146,10 @@ export function StarterPackScreenInner({
   const isValid =
     starterPack &&
     (starterPack.list || starterPack?.creator?.did === currentAccount?.did) &&
-    bsky.matches(app.bsky.graph.defs.starterPackView, starterPack) &&
+    // Cards may precache a synthetic full view while navigating. Its list CID
+    // is intentionally empty until the server response replaces it, so use
+    // the trusted app-view discriminator here instead of strict validation.
+    bsky.isType(app.bsky.graph.defs.starterPackView, starterPack) &&
     bsky.matches(app.bsky.graph.starterpack, starterPack.record)
 
   if (!did || !starterPack || !isValid || !moderationOpts) {


### PR DESCRIPTION
Starter-pack cards precache a synthetic full view for immediate navigation. The placeholder list uses an empty CID until the server response replaces it. Strictly validating that trusted cached view caused native navigation to render “starter pack not found,” and React Query kept the bad state fresh for subsequent attempts.

Use the starter-pack view type discriminator for the trusted app-view object while retaining strict validation of the starter-pack record.
