### PR TITLE
Keep chat reaction bar on screen

### DIFF
--- a/src/components/ContextMenu/index.tsx
+++ b/src/components/ContextMenu/index.tsx
@@ -530,7 +530,7 @@ export function AuxiliaryView({
       transform: [
         {
           translateY:
-            (ensureOnScreenTranslationSV.get() || translationSV.get()) *
+            Math.max(ensureOnScreenTranslationSV.get(), translationSV.get()) *
             animationSV.get(),
         },
         {scale: interpolate(animationSV.get(), [0, 1], [0.2, 1])},
@@ -544,21 +544,17 @@ export function AuxiliaryView({
   const onLayout = useCallback(() => {
     if (!measurement) return
 
-    let translation = 0
-
     // vibes based, just assuming it'll fit within this space. revisit if we use
     // AuxiliaryView for something tall
     const TOP_INSET = topInset + 80
 
     const distanceMessageFromTop = measurement.y - TOP_INSET
-    if (distanceMessageFromTop < 0) {
-      translation = -distanceMessageFromTop
-    }
+    const minimumTranslation = -distanceMessageFromTop
 
     // normally, the context menu is responsible for measuring itself and moving everything into the right place
     // however, in auxiliary-only mode, that doesn't happen, so we need to do it ourselves here
     if (mode === 'auxiliary-only') {
-      translationSV.set(translation)
+      translationSV.set(Math.max(minimumTranslation, 0))
       ensureOnScreenTranslationSV.set(0)
     }
     // however, we also need to make sure that for super tall triggers, we don't go off the screen
@@ -567,7 +563,7 @@ export function AuxiliaryView({
     // we'll just have to live with it for now, fixing it would be possible but be a large complexity
     // increase for an edge case
     else {
-      ensureOnScreenTranslationSV.set(translation)
+      ensureOnScreenTranslationSV.set(minimumTranslation)
     }
   }, [mode, measurement, translationSV, topInset, ensureOnScreenTranslationSV])
 


### PR DESCRIPTION
## Summary

- clamp the native context menu reaction bar against a signed safe-area boundary
- allow it to follow upward menu movement until it reaches that boundary
- preserve the existing downward and auxiliary-only positioning behavior

## Screenshots

### Before

<img width="568" height="1084" alt="Screenshot 2026-08-24 at 15 07 34" src="https://github.com/user-attachments/assets/150ae0c0-e0ae-492e-9583-3745927b9630" />



### After



<img width="568" height="1084" alt="Screenshot 2026-08-24 at 14 51 53" src="https://github.com/user-attachments/assets/2db51c01-de2a-4371-9f07-9252e85888dd" />

## Test plan

- Long press messages that force the context menu upward and confirm the reaction bar remains visible near the top safe area.
- Long press messages near the top of the screen and confirm the reaction bar moves downward into the safe area.