### PR TITLE
Unblock React Compiler for 13 components by hoisting finally blocks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -126,9 +126,8 @@ function InnerApp() {
         }
       } catch (e) {
         logger.warn(`session: resume failed`, {message: e})
-      } finally {
-        setIsReady(true)
       }
+      setIsReady(true)
     }
     const account = readLastActiveAccount()
     void onLaunch(account)

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -105,9 +105,8 @@ function InnerApp() {
         }
       } catch (e) {
         logger.warn('session: resumeSession failed', {message: e})
-      } finally {
-        setIsReady(true)
       }
+      setIsReady(true)
     }
     const account = readLastActiveAccount()
     void onLaunch(account)

--- a/src/components/PostControls/PostMenu/PostMenuItems.tsx
+++ b/src/components/PostControls/PostMenu/PostMenuItems.tsx
@@ -429,14 +429,13 @@ let PostMenuItems = ({
           type: 'error',
         })
       }
-    } finally {
-      ax.metric('postMenu:blockAccount', {
-        uri: postUri,
-        authorDid: postAuthor.did,
-        logContext,
-        feedDescriptor: feedFeedback.feedDescriptor,
-      })
     }
+    ax.metric('postMenu:blockAccount', {
+      uri: postUri,
+      authorDid: postAuthor.did,
+      logContext,
+      feedDescriptor: feedFeedback.feedDescriptor,
+    })
   }
 
   const onMuteAuthor = async () => {
@@ -452,14 +451,13 @@ let PostMenuItems = ({
             type: 'error',
           })
         }
-      } finally {
-        ax.metric('postMenu:unmuteAccount', {
-          uri: postUri,
-          authorDid: postAuthor.did,
-          logContext,
-          feedDescriptor: feedFeedback.feedDescriptor,
-        })
       }
+      ax.metric('postMenu:unmuteAccount', {
+        uri: postUri,
+        authorDid: postAuthor.did,
+        logContext,
+        feedDescriptor: feedFeedback.feedDescriptor,
+      })
     } else {
       try {
         await queueMute()
@@ -472,14 +470,13 @@ let PostMenuItems = ({
             type: 'error',
           })
         }
-      } finally {
-        ax.metric('postMenu:muteAccount', {
-          uri: postUri,
-          authorDid: postAuthor.did,
-          logContext,
-          feedDescriptor: feedFeedback.feedDescriptor,
-        })
       }
+      ax.metric('postMenu:muteAccount', {
+        uri: postUri,
+        authorDid: postAuthor.did,
+        logContext,
+        feedDescriptor: feedFeedback.feedDescriptor,
+      })
     }
   }
 

--- a/src/components/dialogs/DeviceLocationRequestDialog.tsx
+++ b/src/components/dialogs/DeviceLocationRequestDialog.tsx
@@ -95,9 +95,8 @@ function DeviceLocationRequestDialogInner({onLocationAcquired}: Props) {
           safeMessage: e.message,
         })
       }
-    } finally {
-      setIsRequesting(false)
     }
+    setIsRequesting(false)
   }
 
   return (

--- a/src/components/dialogs/PostInteractionSettingsDialog.tsx
+++ b/src/components/dialogs/PostInteractionSettingsDialog.tsx
@@ -241,9 +241,8 @@ export function PostInteractionSettingsDialogControlledInner(
           type: 'error',
         },
       )
-    } finally {
-      setIsSaving(false)
     }
+    setIsSaving(false)
   }, [
     _,
     ax,

--- a/src/components/moderation/ReportDialog/index.tsx
+++ b/src/components/moderation/ReportDialog/index.tsx
@@ -319,9 +319,8 @@ function Inner(
         type: 'setError',
         error,
       })
-    } finally {
-      setIsPending(false)
     }
+    setIsPending(false)
   }, [logger, submitReport, props, state, ax, l, videoTimestampSeconds])
 
   useCallOnce(() => {

--- a/src/lib/hooks/useAccountSwitcher.ts
+++ b/src/lib/hooks/useAccountSwitcher.ts
@@ -54,9 +54,8 @@ export function useAccountSwitcher() {
         Toast.show(_(msg`Please sign in as @${account.handle}`), {
           type: 'warning',
         })
-      } finally {
-        setPendingDid(null)
       }
+      setPendingDid(null)
     },
     [_, ax, resumeSession, requestSwitchToAccount, pendingDid],
   )

--- a/src/screens/Deactivated.tsx
+++ b/src/screens/Deactivated.tsx
@@ -95,9 +95,8 @@ export function Deactivated() {
       logger.error(e, {
         message: 'Failed to activate account',
       })
-    } finally {
-      setPending(false)
     }
+    setPending(false)
   }, [_, pdsClient, refreshSession, setPending, setError, queryClient])
 
   return (

--- a/src/screens/List/ListHiddenScreen.tsx
+++ b/src/screens/List/ListHiddenScreen.tsx
@@ -103,9 +103,8 @@ export function ListHiddenScreen({
           msg`There was an issue. Please check your internet connection and try again.`,
         ),
       )
-    } finally {
-      setIsProcessing(false)
     }
+    setIsProcessing(false)
   }
 
   return (

--- a/src/screens/Login/ChooseAccountForm.tsx
+++ b/src/screens/Login/ChooseAccountForm.tsx
@@ -58,9 +58,8 @@ export const ChooseAccountForm = ({
         })
         // Move to login form.
         onSelectAccount(account)
-      } finally {
-        setPendingDid(null)
       }
+      setPendingDid(null)
     },
     [
       currentAccount,

--- a/src/screens/Settings/components/ChangePasswordDialog.tsx
+++ b/src/screens/Settings/components/ChangePasswordDialog.tsx
@@ -102,9 +102,8 @@ function Inner() {
         logger.error('Failed to request password reset', {safeMessage: e})
         setError(cleanError(e))
       }
-    } finally {
-      setIsProcessing(false)
     }
+    setIsProcessing(false)
   }
 
   const onChangePassword = async () => {
@@ -151,9 +150,8 @@ function Inner() {
         logger.error('Failed to set new password', {safeMessage: e})
         setError(cleanError(e))
       }
-    } finally {
-      setIsProcessing(false)
     }
+    setIsProcessing(false)
   }
 
   const onBlur = () => {

--- a/src/screens/Settings/components/DeactivateAccountDialog.tsx
+++ b/src/screens/Settings/components/DeactivateAccountDialog.tsx
@@ -64,9 +64,8 @@ function DeactivateAccountDialogInner({
       logger.error(e, {
         message: 'Failed to deactivate account',
       })
-    } finally {
-      setPending(false)
     }
+    setPending(false)
   }, [client, control, logoutCurrentAccount, _, setPending])
 
   return (

--- a/src/screens/Settings/components/DisableEmail2FADialog.tsx
+++ b/src/screens/Settings/components/DisableEmail2FADialog.tsx
@@ -49,9 +49,8 @@ export function DisableEmail2FADialog({
       setStage(Stages.ConfirmCode)
     } catch (e) {
       setError(cleanError(String(e)))
-    } finally {
-      setIsProcessing(false)
     }
+    setIsProcessing(false)
   }
 
   const onConfirmDisable = async () => {
@@ -80,9 +79,8 @@ export function DisableEmail2FADialog({
       } else {
         setError(cleanError(e))
       }
-    } finally {
-      setIsProcessing(false)
     }
+    setIsProcessing(false)
   }
 
   return (

--- a/src/screens/Settings/components/ExportCarDialog.tsx
+++ b/src/screens/Settings/components/ExportCarDialog.tsx
@@ -53,9 +53,8 @@ export function ExportCarDialog({
     } catch (e) {
       logger.error('Error occurred while downloading CAR file', {message: e})
       Toast.show(l`Error occurred while saving file`, {type: 'error'})
-    } finally {
-      setLoading(false)
     }
+    setLoading(false)
   }, [l, currentAccount, pdsClient])
 
   const downloadChatData = useCallback(async () => {
@@ -84,9 +83,8 @@ export function ExportCarDialog({
     } catch (e) {
       logger.error('Error occurred while downloading chat data', {message: e})
       Toast.show(l`Error occurred while saving file`, {type: 'error'})
-    } finally {
-      setLoading(false)
     }
+    setLoading(false)
   }, [l, currentAccount, chatClient])
 
   return (

--- a/src/screens/Signup/StepCaptcha/index.tsx
+++ b/src/screens/Signup/StepCaptcha/index.tsx
@@ -51,9 +51,8 @@ export function StepCaptchaNative() {
       } catch (err) {
         const e = err as Error
         logger.error(e)
-      } finally {
-        setReady(true)
       }
+      setReady(true)
     })()
   }, [])
 

--- a/src/screens/SignupQueued.tsx
+++ b/src/screens/SignupQueued.tsx
@@ -60,9 +60,8 @@ export function SignupQueued() {
       }
     } catch (e: any) {
       logger.error('Failed to check signup queue', {err: e.toString()})
-    } finally {
-      setProcessing(false)
     }
+    setProcessing(false)
   }, [
     setProcessing,
     setEstimatedTime,

--- a/src/view/com/notifications/NotificationFeed.tsx
+++ b/src/view/com/notifications/NotificationFeed.tsx
@@ -103,9 +103,8 @@ export function NotificationFeed({
       logger.error('Failed to refresh notifications feed', {
         message: err,
       })
-    } finally {
-      setIsPTRing(false)
     }
+    setIsPTRing(false)
   }, [refreshNotifications, setIsPTRing])
 
   const onEndReached = useCallback(async () => {

--- a/src/view/com/notifications/NotificationFeedItem.tsx
+++ b/src/view/com/notifications/NotificationFeedItem.tsx
@@ -920,9 +920,8 @@ function SayHelloBtn({profile}: {profile: app.bsky.actor.defs.ProfileView}) {
       })
     } catch (e) {
       logger.error('Failed to get conversation', {safeMessage: e})
-    } finally {
-      setIsLoading(false)
     }
+    setIsLoading(false)
   }
 
   if (

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -559,9 +559,8 @@ function ComposeBtn({minimal}: {minimal: boolean}) {
           handle = await fetchHandle(handle)
         } catch (e) {
           handle = undefined
-        } finally {
-          setIsFetchingHandle(false)
         }
+        setIsFetchingHandle(false)
       }
 
       if (


### PR DESCRIPTION
React Compiler cannot lower a `finally` block, so any component containing one is skipped entirely - it was the single largest cause, 38 sites across 31 components.

This does the provably-safe subset: **24 sites in 19 files** where the `try` has a `catch` that completes normally and neither block returns or throws. There, `finally { cleanup() }` is exactly equivalent to running `cleanup()` after the `try`/`catch`.

```diff
       } catch (e) {
         logger.warn(`session: resume failed`, {message: e})
-      } finally {
-        setIsReady(true)
       }
+      setIsReady(true)
```

Deliberately **not** included: 4 sites with no `catch` at all. There the cleanup also runs on the throw path, so hoisting it below would silently skip cleanup on error. Those need a different fix.

Skipped components: **125 &rarr; 112**. Compiled: 2075 &rarr; 2088. Measured with the report script in #11539, which this PR no longer depends on.

Worth knowing for the batches after this one: only 13 of the 19 edited components actually cleared. The compiler reports one diagnostic per function and stops, so six were hiding a second cause underneath (five value blocks in a `try`, one hook reached through a property). The reported count is a floor, not a total.

`pnpm typecheck`, `pnpm lint`, `pnpm prettier` and `pnpm test` (58 suites, 771 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)