### PR TITLE
Unblock React Compiler for 5 components with early exits inside try

### DIFF
--- a/src/lib/hooks/useGoogleTranslate.ts
+++ b/src/lib/hooks/useGoogleTranslate.ts
@@ -21,12 +21,12 @@ export function useGoogleTranslate() {
       if (IS_ANDROID) {
         try {
           // use `getApplicationIconAsync` to determine if the translate app is installed
-          if (
-            !(await IntentLauncher.getApplicationIconAsync(
-              'com.google.android.apps.translate',
-            ))
-          ) {
-            throw new Error('Translate app not installed')
+          const installed = await IntentLauncher.getApplicationIconAsync(
+            'com.google.android.apps.translate',
+          )
+          if (!installed) {
+            openLink(translateUrl)
+            return
           }
 
           // TODO: this should only be called one at a time, use something like

--- a/src/screens/Settings/BetaFeaturesSettings.tsx
+++ b/src/screens/Settings/BetaFeaturesSettings.tsx
@@ -83,10 +83,10 @@ export function BetaFeaturesSettingsScreen({}: Props) {
     } catch (e) {
       logger.error('Failed to toggle beta features', {safeMessage: e})
       Toast.show(l`Something went wrong, please try again.`, {type: 'error'})
-      return
-    } finally {
       setIsPending(false)
+      return
     }
+    setIsPending(false)
     /*
      * The toggle already succeeded; re-evaluate feature gates against the new
      * attribute in-session as a best-effort follow-up. A failure here should

--- a/src/screens/Signup/StepHandle/index.tsx
+++ b/src/screens/Signup/StepHandle/index.tsx
@@ -76,10 +76,11 @@ export function StepHandle() {
 
     dispatch({type: 'setIsLoading', value: true})
 
+    const serviceDid = state.serviceDescription?.did ?? 'UNKNOWN'
     try {
       const {available: handleAvailable} = await checkHandleAvailability(
         createFullHandle(handle, state.userDomain),
-        state.serviceDescription?.did ?? 'UNKNOWN',
+        serviceDid,
         {},
       )
 
@@ -90,6 +91,7 @@ export function StepHandle() {
           value: _(msg`That username is already taken`),
           field: 'handle',
         })
+        dispatch({type: 'setIsLoading', value: false})
         return
       } else {
         ax.metric('signup:handleAvailable', {typeahead: false})
@@ -99,9 +101,8 @@ export function StepHandle() {
         safeMessage: error,
       })
       // do nothing on error, let them pass
-    } finally {
-      dispatch({type: 'setIsLoading', value: false})
     }
+    dispatch({type: 'setIsLoading', value: false})
 
     ax.metric('signup:nextPressed', {
       activeStep: state.activeStep,

--- a/src/screens/Signup/state.ts
+++ b/src/screens/Signup/state.ts
@@ -322,6 +322,7 @@ export function useSubmitSignup() {
       dispatch({type: 'setError', value: ''})
       dispatch({type: 'setIsLoading', value: true})
 
+      const verificationCode = state.pendingSubmit?.verificationCode
       try {
         await createAccount(
           {
@@ -331,7 +332,7 @@ export function useSubmitSignup() {
             password: state.password,
             birthDate: state.dateOfBirth,
             inviteCode: state.inviteCode.trim(),
-            verificationCode: state.pendingSubmit?.verificationCode,
+            verificationCode,
           },
           {
             signupDuration: Date.now() - state.signupStartTime,
@@ -360,6 +361,7 @@ export function useSubmitSignup() {
             field: 'invite-code',
           })
           dispatch({type: 'setStep', value: SignupStep.INFO})
+          dispatch({type: 'setIsLoading', value: false})
           return
         }
 
@@ -384,9 +386,8 @@ export function useSubmitSignup() {
             safeMessage: e,
           })
         }
-      } finally {
-        dispatch({type: 'setIsLoading', value: false})
       }
+      dispatch({type: 'setIsLoading', value: false})
     },
     [l, ax, createAccount, onboardingDispatch],
   )

--- a/src/state/queries/pinned-post.ts
+++ b/src/state/queries/pinned-post.ts
@@ -10,6 +10,16 @@ import {updatePostShadow} from '../cache/post-shadow'
 import {useAppviewClient, useSession} from '../session'
 import {useProfileUpdateMutation} from './profile'
 
+/**
+ * Out of the hook because React Compiler cannot lower an optional chain inside a
+ * `try` block, and `profile` only exists once the request inside it resolves.
+ */
+function getPinnedPostUri(profile: {
+  pinnedPost?: {uri: string}
+}): string | undefined {
+  return profile.pinnedPost?.uri
+}
+
 export function usePinnedPostMutation() {
   const {_} = useLingui()
   const {currentAccount} = useSession()
@@ -27,19 +37,24 @@ export function usePinnedPostMutation() {
       postCid: string
       action: 'pin' | 'unpin'
     }) => {
+      if (!currentAccount) throw new Error('Not signed in')
+
       const pinCurrentPost = action === 'pin'
       let prevPinnedPost: string | undefined
       try {
         updatePostShadow(queryClient, postUri, {pinned: pinCurrentPost})
 
         // get the currently pinned post so we can optimistically remove the pin from it
-        if (!currentAccount) throw new Error('Not signed in')
         const profile = await client.call(app.bsky.actor.getProfile, {
           actor: currentAccount.did,
         })
-        prevPinnedPost = profile.pinnedPost?.uri
-        if (prevPinnedPost && prevPinnedPost !== postUri) {
-          updatePostShadow(queryClient, prevPinnedPost, {pinned: false})
+        prevPinnedPost = getPinnedPostUri(profile)
+        if (prevPinnedPost) {
+          // Nested rather than `&&`: React Compiler cannot lower a logical
+          // expression in a test position inside a `try`.
+          if (prevPinnedPost !== postUri) {
+            updatePostShadow(queryClient, prevPinnedPost, {pinned: false})
+          }
         }
 
         await profileUpdateMutate({

--- a/src/state/queries/pinned-post.ts
+++ b/src/state/queries/pinned-post.ts
@@ -11,6 +11,15 @@ import {useAppviewClient, useSession} from '../session'
 import {useProfileUpdateMutation} from './profile'
 
 /**
+ * Out of the hook because React Compiler cannot lower a `throw` inside a `try`.
+ * Keeping the check in place - rather than hoisting it above the `try` - means
+ * the catch below still shows its toast and reverts the optimistic update.
+ */
+function assertSignedIn(account: unknown): asserts account {
+  if (!account) throw new Error('Not signed in')
+}
+
+/**
  * Out of the hook because React Compiler cannot lower an optional chain inside a
  * `try` block, and `profile` only exists once the request inside it resolves.
  */
@@ -37,21 +46,22 @@ export function usePinnedPostMutation() {
       postCid: string
       action: 'pin' | 'unpin'
     }) => {
-      if (!currentAccount) throw new Error('Not signed in')
-
       const pinCurrentPost = action === 'pin'
       let prevPinnedPost: string | undefined
       try {
         updatePostShadow(queryClient, postUri, {pinned: pinCurrentPost})
 
         // get the currently pinned post so we can optimistically remove the pin from it
+        assertSignedIn(currentAccount)
         const profile = await client.call(app.bsky.actor.getProfile, {
           actor: currentAccount.did,
         })
         prevPinnedPost = getPinnedPostUri(profile)
         if (prevPinnedPost) {
-          // Nested rather than `&&`: React Compiler cannot lower a logical
-          // expression in a test position inside a `try`.
+          /*
+           * Nested rather than `&&`: React Compiler cannot lower a logical
+           * expression in a test position inside a `try`.
+           */
           if (prevPinnedPost !== postUri) {
             updatePostShadow(queryClient, prevPinnedPost, {pinned: false})
           }


### PR DESCRIPTION
Batch 6, finishing the `try` control-flow families. Independent of #11540, #11542, #11543, #11544 and #11545.

Two shapes remained after #11545:

- **A `return` in the try or the catch.** The `finally` body has to be duplicated on that exit path before it can be hoisted below the `try`/`catch`.
- **A `throw` used to jump to the catch.** `useGoogleTranslate` threw `'Translate app not installed'` purely to reach the catch's `openLink` fallback; an explicit test replaces it.

Every one of these then revealed a *second* cause inside the same `try`, so the two fixes have to go together to clear anything. Those are all value blocks:

| site | fix |
| --- | --- |
| `StepHandle`, `Signup/state` | optional chain hoisted above the `try` - it did not depend on anything the `try` produces |
| `pinned-post` | `profile.pinnedPost?.uri` moved to a module-scope helper, since `profile` only exists once the request inside the `try` resolves |
| `pinned-post` | `if (a && b)` split into nested ifs |

Skipped components: **125 &rarr; 120**, and all five edited files are now completely free of diagnostics.

**Worth flagging for the value-block family.** That last fix is a one-line, behaviour-identical change:

```diff
-        if (prevPinnedPost && prevPinnedPost !== postUri) {
+        if (prevPinnedPost) {
+          if (prevPinnedPost !== postUri) {
```

The compiler cannot lower a logical expression in a test position inside a `try`, but it handles nested ifs fine. A good part of the 27-component value-block family is exactly `if (a && b)` inside a `try`, which suggests that family is cheaper than its current Medium rating implies. I will re-survey it before the next batch.

Deferred: `Composer` (its `finally` is a large metrics loop that would need extracting rather than duplicating) and `useOTAUpdates` (three `try` sites, only useful done together).

`pnpm typecheck`, `pnpm lint`, `pnpm prettier` and `pnpm test` (58 suites, 771 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)