### PR TITLE
Unblock React Compiler for 4 components with deferred ref access

### DIFF
--- a/src/components/forms/SearchInput.tsx
+++ b/src/components/forms/SearchInput.tsx
@@ -47,7 +47,13 @@ export function SearchInput({
       <TextField.Root>
         <TextField.Icon icon={MagnifyingGlassIcon} />
         <TextField.Input
-          inputRef={mergeRefs([internalRef, ref])}
+          /*
+           * Deferred into the callback: React Compiler only special-cases the
+           * `ref` prop, so a merged ref built during render and handed to
+           * `inputRef` reads as accessing a ref. `mergeRefs` already returns a
+           * fresh function per render, so this adds no identity churn.
+           */
+          inputRef={node => mergeRefs([internalRef, ref])(node)}
           label={label || l`Search`}
           value={value}
           placeholder={l`Search`}

--- a/src/components/forms/TextField.tsx
+++ b/src/components/forms/TextField.tsx
@@ -26,6 +26,7 @@ import {
 import {useInteractionState} from '#/components/hooks/useInteractionState'
 import {type Props as SVGIconProps} from '#/components/icons/common'
 import {Text} from '#/components/Typography'
+import {IS_WEB} from '#/env'
 
 const Context = createContext<{
   inputRef: React.RefObject<React.ComponentRef<typeof TextInput> | null> | null
@@ -101,11 +102,13 @@ export function Root({children, isInvalid = false, style}: RootProps) {
           {zIndex: 0},
           style,
         ]}
-        {...web({
-          onClick: () => inputRef.current?.focus(),
-          onMouseOver: onHoverIn,
-          onMouseOut: onHoverOut,
-        })}>
+        {...(IS_WEB
+          ? {
+              onClick: () => inputRef.current?.focus(),
+              onMouseOver: onHoverIn,
+              onMouseOut: onHoverOut,
+            }
+          : {})}>
         {children}
       </View>
     </Context.Provider>

--- a/src/lib/hooks/useDraggableScrollView.ts
+++ b/src/lib/hooks/useDraggableScrollView.ts
@@ -74,8 +74,13 @@ export function useDraggableScroll<
     }
   }, [cursor])
 
+  /*
+   * Deferred into the callback so the merge does not happen during the render of
+   * whichever component uses this hook - see SearchInput for the full reasoning.
+   */
   const refs = useMemo(
-    () => mergeRefs(outerRef ? [ref, outerRef] : [ref]),
+    () => (node: Scrollable | null) =>
+      mergeRefs(outerRef ? [ref, outerRef] : [ref])(node),
     [ref, outerRef],
   )
 

--- a/src/lib/merge-refs.ts
+++ b/src/lib/merge-refs.ts
@@ -31,7 +31,7 @@ function assignRef<T>(
  * @returns The function `mergeRefs` is being returned. It takes an array of mutable or legacy refs and
  * returns a ref callback function that can be used to merge multiple refs into a single ref.
  */
-export function mergeRefs<T>(refs: (Ref<T> | undefined)[]): Ref<T> {
+export function mergeRefs<T>(refs: (Ref<T> | undefined)[]): RefCallback<T> {
   return (value: T | null) => {
     const cleanups: (() => void)[] = []
 

--- a/src/screens/Onboarding/StepFinished/ValuePropositionPager.tsx
+++ b/src/screens/Onboarding/StepFinished/ValuePropositionPager.tsx
@@ -1,4 +1,4 @@
-import {useRef, useState} from 'react'
+import {useEffect, useRef, useState} from 'react'
 import {View} from 'react-native'
 import PagerView from 'react-native-pager-view'
 import {type PagerViewOnPageSelectedEvent} from 'react-native-pager-view'
@@ -26,8 +26,16 @@ export function ValuePropositionPager({
 
   if (step !== activePage) {
     setActivePage(step)
-    ref.current?.setPage(step)
   }
+
+  /*
+   * In an effect rather than inline above: driving the pager is a side effect,
+   * and reading a ref during render is a Rules of React violation. `initialPage`
+   * already covers the first render, so the mount run is a no-op.
+   */
+  useEffect(() => {
+    ref.current?.setPage(step)
+  }, [step])
 
   const images = [PROP_1[t.name], PROP_2[t.name], PROP_3[t.name]]
 


### PR DESCRIPTION
Batch 9. Independent of the seven open PRs.

I went in expecting to fix `mergeRefs` itself, since three components fail on it and it is used in 10 files. Probing the compiler showed that was the wrong theory:

```
ref={mergeRefs([...])}                      compiles
inputRef={mergeRefs([...])}                 skipped
inputRef={node => mergeRefs([...])(node)}   compiles
```

React Compiler special-cases the `ref` prop. A ref-derived value built during render and handed to **any other** prop reads as accessing a ref. So the helper is fine; the fix is to defer the call into the callback. `mergeRefs` already returns a fresh function per render, so this adds no identity churn.

| component | fix |
| --- | --- |
| `SearchInput`, `useDraggableScrollView` | defer the `mergeRefs` call into the callback |
| `merge-refs` | return `RefCallback<T>` instead of `Ref<T>` - which is what it has always returned - so the deferred call sites typecheck |
| `TextField` | `web({...})` hides a ref-reading handler from the compiler; a plain `IS_WEB` conditional does not |
| `ValuePropositionPager` | `ref.current?.setPage(step)` moves out of render into an effect. `initialPage` already covers the first render, so the mount run is a no-op |

Skipped components: **125 &rarr; 121**.

Also worth recording: an inline callback ref writing `inner.current = node` **fails** with `This value cannot be modified`, so that obvious-looking alternative is not one.

Three candidates investigated and left out:

- **`Gallery`** takes the same deferral fine but still fails on `cloneElement(node, ...)` reading `node.props.ref` - a different cause, so fixing only the merge clears nothing. Reverted rather than shipped as dead diff.
- **`Pager`** calls its `renderTabBar` render prop during render with a ref-reading `onSelect`. Fixing it means rendering an element instead, which changes the component's public API across every consumer.
- **`Search`** surfaces refs from a third-party positioning hook (`sift.refs`, `sift.targetProps`).

`pnpm typecheck`, `pnpm lint`, `pnpm prettier` and `pnpm test` (58 suites, 771 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)