### PR TITLE
Use useEffectEvent for effects with deliberately narrow deps

### DIFF
--- a/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/VideoEmbedInnerWeb.tsx
+++ b/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/VideoEmbedInnerWeb.tsx
@@ -1,4 +1,11 @@
-import {useCallback, useEffect, useId, useRef, useState} from 'react'
+import {
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useId,
+  useRef,
+  useState,
+} from 'react'
 import {View} from 'react-native'
 import {useLingui} from '@lingui/react/macro'
 import type * as HlsTypes from 'hls.js'
@@ -264,6 +271,14 @@ function useHLS({
     },
   )
 
+  /*
+   * The hls handler below must call the latest `updateCuePositions` without the
+   * effect tearing down and re-attaching every time its identity changes.
+   */
+  const onSubtitleFragProcessed = useEffectEvent(() => {
+    updateCuePositions()
+  })
+
   useEffect(() => {
     if (!videoRef.current) return
     if (!Hls) return
@@ -302,7 +317,7 @@ function useHLS({
     })
 
     hls.on(Hls.Events.SUBTITLE_FRAG_PROCESSED, () => {
-      updateCuePositions()
+      onSubtitleFragProcessed()
     })
 
     hls.on(Hls.Events.FRAG_BUFFERED, (_event, {frag}) => {

--- a/src/components/forms/AutosizedTextarea.tsx
+++ b/src/components/forms/AutosizedTextarea.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useRef, useState} from 'react'
+import {useEffect, useEffectEvent, useMemo, useRef, useState} from 'react'
 import {
   TextInput,
   type TextInputContentSizeChangeEvent,
@@ -141,13 +141,17 @@ export function AutosizedTextarea({
    * Reset native height state after a programmatic clear. Android uses it as
    * the explicit input height, while iOS uses it to decide when to scroll.
    */
+  const reportHeight = useEffectEvent((height: number) => {
+    onUpdateHeight?.(height)
+  })
+
   const prevRawValue = useRef(rawValue || '')
   useEffect(() => {
     if (!IS_NATIVE) return
     if (rawValue === undefined) return // uncontrolled
     if (prevRawValue.current?.length && rawValue === '') {
       setNativeHeight(minInputHeight)
-      onUpdateHeight?.(minInputHeight)
+      reportHeight(minInputHeight)
     }
     prevRawValue.current = rawValue
   }, [rawValue, minInputHeight])

--- a/src/screens/Settings/FindContactsSettings.tsx
+++ b/src/screens/Settings/FindContactsSettings.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useState} from 'react'
+import {useCallback, useEffect, useEffectEvent, useState} from 'react'
 import {type ListRenderItemInfo, View} from 'react-native'
 import * as Contacts from 'expo-contacts'
 import {type DidString} from '@atproto/syntax'
@@ -61,12 +61,17 @@ export function FindContactsSettingsScreen({}: Props) {
   const {data, error, refetch} = useContactsSyncStatusQuery()
 
   const isFocused = useIsFocused()
+
+  const logPresented = useEffectEvent(() => {
+    ax.metric('contacts:settings:presented', {
+      hasPreviouslySynced: !!data?.syncStatus,
+      matchCount: data?.syncStatus?.matchesCount,
+    })
+  })
+
   useEffect(() => {
     if (data && isFocused) {
-      ax.metric('contacts:settings:presented', {
-        hasPreviouslySynced: !!data.syncStatus,
-        matchCount: data.syncStatus?.matchesCount,
-      })
+      logPresented()
     }
   }, [data, isFocused])
 

--- a/src/view/com/composer/select-language/SuggestedLanguage.tsx
+++ b/src/view/com/composer/select-language/SuggestedLanguage.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useRef, useState} from 'react'
+import {useEffect, useEffectEvent, useMemo, useRef, useState} from 'react'
 import {Platform, Text as RNText, View} from 'react-native'
 import {parseLanguageString} from '@atproto/syntax'
 import {
@@ -332,15 +332,18 @@ function GuessedLanguage({
     onDeclineOuter()
   }
 
-  const metaRef = useNonReactiveObject(metadata)
-  useEffect(() => {
+  const logSuggestion = useEffectEvent(() => {
     ax.metric('composer:language:suggestLanguage', {
       os: Platform.OS,
       suggestedLanguage: language,
-      currentTargetLanguages: metaRef.current.currentTargetLanguages,
+      currentTargetLanguages: metadata.currentTargetLanguages,
       textLength: sanitizeTextForDetection(metadata.rawText).length,
     })
-  }, [ax, language])
+  })
+
+  useEffect(() => {
+    logSuggestion()
+  }, [language])
 
   return (
     <LanguageSuggestionButton

--- a/src/view/com/posts/CustomFeedEmptyState.tsx
+++ b/src/view/com/posts/CustomFeedEmptyState.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef} from 'react'
+import {useCallback, useEffect, useEffectEvent, useRef} from 'react'
 import {StyleSheet, View} from 'react-native'
 import {Trans, useLingui} from '@lingui/react/macro'
 import {useNavigation} from '@react-navigation/native'
@@ -23,6 +23,11 @@ export function CustomFeedEmptyState() {
   const {currentAccount} = useSession()
   const hasLoggedDiscoverEmptyErrorRef = useRef(false)
 
+  const logDiscoverEmptyError = useEffectEvent((did: string) => {
+    hasLoggedDiscoverEmptyErrorRef.current = true
+    ax.metric('feed:discover:emptyError', {userDid: did})
+  })
+
   useEffect(() => {
     // Log the empty feed error event
     if (feedFeedback.feedSourceInfo && currentAccount?.did) {
@@ -31,10 +36,7 @@ export function CustomFeedEmptyState() {
         uri === DISCOVER_FEED_URI &&
         !hasLoggedDiscoverEmptyErrorRef.current
       ) {
-        hasLoggedDiscoverEmptyErrorRef.current = true
-        ax.metric('feed:discover:emptyError', {
-          userDid: currentAccount.did,
-        })
+        logDiscoverEmptyError(currentAccount.did)
       }
     }
   }, [feedFeedback.feedSourceInfo, currentAccount?.did])


### PR DESCRIPTION
Follow-up from the React Compiler work, but independent of it - this touches no compiler diagnostics.

**`pnpm lint` runs oxlint with `--quiet`, which hides warnings.** There are 14 `react-hooks/exhaustive-deps` warnings that nobody sees. Five are exactly the shape `useEffectEvent` exists for: an effect that must read the latest value of something without re-running when that value changes.

| file | was | now |
| --- | --- | --- |
| `CustomFeedEmptyState` | metric effect omitting `ax` from deps | `useEffectEvent` |
| `FindContactsSettings` | metric effect omitting `ax` from deps | `useEffectEvent` |
| `AutosizedTextarea` | `onUpdateHeight` callback prop omitted | `useEffectEvent` |
| `SuggestedLanguage` | `useNonReactiveObject` mirror doing the job by hand | `useEffectEvent`, mirror dropped |
| `VideoEmbedInnerWeb` | hls subtitle handler captured `updateCuePositions` | `useEffectEvent` |

The last one is a latent bug rather than lint noise: the `SUBTITLE_FRAG_PROCESSED` handler closed over `updateCuePositions` from the render that set up the effect, so a change in that callback's identity would leave the handler calling a stale one.

Warnings: **14 &rarr; 9**. The remaining nine are `useMemo`, `useCallback` and `useImperativeHandle`, where `useEffectEvent` does not apply, plus one ref-in-cleanup warning.

Two things I looked for and did **not** find:

- **Render-time mirror refs** (`xRef.current = x` in a component body). An AST scan turns up exactly three, and all three are already flagged by React Compiler and queued in the existing PRs.
- **`useNonReactiveCallback` migrations.** 27 files use it, but its result is nearly always passed to a child as a prop, and `useEffectEvent` must not be passed to other components. Not a migration target.

`pnpm typecheck`, `pnpm lint`, `pnpm prettier` and `pnpm test` (58 suites, 771 tests) all pass, and the React Compiler skip count is unchanged at 125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)