### PR TITLE
Fix site initialization in older versions of Safari

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -1584,5 +1584,16 @@
     "typescript/no-unsafe-member-access": {
       "count": 3
     }
+  },
+  "webpack.config.js": {
+    "import/no-nodejs-modules": {
+      "count": 1
+    },
+    "typescript/no-unsafe-call": {
+      "count": 12
+    },
+    "typescript/no-unsafe-member-access": {
+      "count": 33
+    }
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,10 @@ function patchSourceMapFilter(rules, pathPattern) {
 
 module.exports = async function (env, argv) {
   env.babel = {
-    dangerouslyAddModulePathsToTranspile: ['@bsky.app/expo'],
+    dangerouslyAddModulePathsToTranspile: [
+      '@bsky.app/expo',
+      '@atproto/lex-client',
+    ],
   }
   let config = await createExpoWebpackConfigAsync(env, argv)
   /*

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,8 +47,9 @@ function patchSourceMapFilter(rules, pathPattern) {
 module.exports = async function (env, argv) {
   env.babel = {
     dangerouslyAddModulePathsToTranspile: [
-      '@bsky.app/expo-',
-      '@atproto/lex-',
+      // this covers every package that starts with these strings (e.g. @atproto/lex-client)
+      '@bsky.app/expo',
+      '@atproto/lex',
     ],
   }
   let config = await createExpoWebpackConfigAsync(env, argv)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,8 +47,8 @@ function patchSourceMapFilter(rules, pathPattern) {
 module.exports = async function (env, argv) {
   env.babel = {
     dangerouslyAddModulePathsToTranspile: [
-      '@bsky.app/expo',
-      '@atproto/lex-client',
+      '@bsky.app/expo-',
+      '@atproto/lex-',
     ],
   }
   let config = await createExpoWebpackConfigAsync(env, argv)


### PR DESCRIPTION
#11386 removed `@atproto/api` from `dangerouslyAddModulePathsToTranspile` but didn’t add `@atproto/lex-client`.