### PR TITLE
Update video embed lexicon

### DIFF
--- a/lexicons.json
+++ b/lexicons.json
@@ -426,7 +426,7 @@
     },
     "app.bsky.embed.video": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.embed.video",
-      "cid": "bafyreie3nug4ezpwodl6yrpgv5edkazzn22t7ea4yaeuun4rctyekkngai"
+      "cid": "bafyreiaqos23yv3t4ptrxily6s6qea5fcxfjzjlm42zq46xweby2mkgr4m"
     },
     "app.bsky.feed.defs": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.feed.defs",

--- a/lexicons/app/bsky/embed/video.json
+++ b/lexicons/app/bsky/embed/video.json
@@ -18,8 +18,8 @@
           "accept": [
             "video/mp4"
           ],
-          "maxSize": 100000000,
-          "description": "The mp4 video file. May be up to 100mb, formerly limited to 50mb."
+          "maxSize": 300000000,
+          "description": "The mp4 video file. May be up to 300mb, formerly limited to 100mb."
         },
         "captions": {
           "type": "array",


### PR DESCRIPTION
## Summary

- update `app.bsky.embed.video` to the current authoritative lexicon
- raise the declared video blob limit from 100 MB to 300 MB
- prevent valid long-form video posts from failing strict client-side record validation and disappearing from feeds

## Testing

- `pnpm lexicons:verify`
- `git diff --check`