### PR TITLE
Update lexicons for 300 MB videos

### DIFF
--- a/lexicons.json
+++ b/lexicons.json
@@ -426,7 +426,7 @@
     },
     "app.bsky.embed.video": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.embed.video",
-      "cid": "bafyreie3nug4ezpwodl6yrpgv5edkazzn22t7ea4yaeuun4rctyekkngai"
+      "cid": "bafyreiaqos23yv3t4ptrxily6s6qea5fcxfjzjlm42zq46xweby2mkgr4m"
     },
     "app.bsky.feed.defs": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.feed.defs",

--- a/lexicons/app/bsky/embed/video.json
+++ b/lexicons/app/bsky/embed/video.json
@@ -18,8 +18,8 @@
           "accept": [
             "video/mp4"
           ],
-          "maxSize": 100000000,
-          "description": "The mp4 video file. May be up to 100mb, formerly limited to 50mb."
+          "maxSize": 300000000,
+          "description": "The mp4 video file. May be up to 300mb, formerly limited to 100mb."
         },
         "captions": {
           "type": "array",

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -169,6 +169,28 @@
         }
       }
     },
+    "knownLikers": {
+      "type": "object",
+      "required": [
+        "count",
+        "actors"
+      ],
+      "properties": {
+        "count": {
+          "type": "integer"
+        },
+        "actors": {
+          "type": "array",
+          "items": {
+            "ref": "app.bsky.actor.defs#profileViewBasic",
+            "type": "ref"
+          },
+          "maxLength": 5,
+          "minLength": 0
+        }
+      },
+      "description": "The post's likers whom you also follow"
+    },
     "requestLess": {
       "type": "token",
       "description": "Request that less content like the given feed item be shown in the feed"
@@ -194,6 +216,11 @@
         "bookmarked": {
           "type": "boolean"
         },
+        "knownLikers": {
+          "ref": "#knownLikers",
+          "type": "ref",
+          "description": "This property is present only in selected cases, as an optimization."
+        },
         "threadMuted": {
           "type": "boolean"
         },
@@ -202,36 +229,9 @@
         },
         "embeddingDisabled": {
           "type": "boolean"
-        },
-        "knownLikers": {
-          "description": "This property is present only in selected cases, as an optimization.",
-          "type": "ref",
-          "ref": "#knownLikers"
         }
       },
       "description": "Metadata about the requesting account's relationship with the subject content. Only has meaningful content for authed requests."
-    },
-    "knownLikers": {
-      "type": "object",
-      "description": "The post's likers whom you also follow",
-      "required": [
-        "count",
-        "actors"
-      ],
-      "properties": {
-        "count": {
-          "type": "integer"
-        },
-        "actors": {
-          "type": "array",
-          "minLength": 0,
-          "maxLength": 5,
-          "items": {
-            "type": "ref",
-            "ref": "app.bsky.actor.defs#profileViewBasic"
-          }
-        }
-      }
     },
     "feedViewPost": {
       "type": "object",


### PR DESCRIPTION
## Summary

- update the video embed lexicon limit from 100 MB to 300 MB
- refresh the installed lexicon metadata and generated definitions

## Test plan

- Open a post containing a video larger than 100 MB and confirm it appears in feeds and the author’s video tab.

Linear: https://linear.app/blueskyweb/issue/APP-2944/update-social-app-lexicons-for-300mb-videos
