### PR TITLE
Tweak alignment of thread numbering

### DIFF
--- a/src/screens/PostThread/components/ThreadItemPostNumber.tsx
+++ b/src/screens/PostThread/components/ThreadItemPostNumber.tsx
@@ -67,8 +67,6 @@ export function ThreadItemPostNumber({
               android: {transform: [{translateY: POST_NUMBER_INLINE_OFFSET}]},
               ios: {transform: [{translateY: a.py_2xs.paddingBottom}]},
               web: {
-                top: -2,
-                marginBottom: -2,
                 // Inline views inherit the surrounding line height on web. Keep
                 // the badge at its usual size when emoji-only text enlarges it.
                 lineHeight: a.text_xs.fontSize * a.leading_normal.lineHeight,


### PR DESCRIPTION
These were too high above the baseline when inlined.