### PR TITLE
fix: Truncate strings on grapheme boundaries

### DIFF
--- a/__tests__/lib/string.test.ts
+++ b/__tests__/lib/string.test.ts
@@ -201,6 +201,49 @@ describe('enforceLen', () => {
       expect(result).toEqual(outputs[i])
     }
   })
+
+  /*
+   * A code-unit slice can land inside an emoji. The leftover renders as a
+   * replacement character instead of the emoji - see #11390.
+   */
+  const RAINBOW_FLAG = '\u{1F3F3}\uFE0F\u200D\u{1F308}'
+  const LONE_SURROGATE =
+    /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/
+
+  it('drops a trailing emoji rather than cutting it in half', () => {
+    // 'Max Dubler ' is 11 code units, the flag sequence is another 6
+    expect(enforceLen(`Max Dubler ${RAINBOW_FLAG}`, 12, true)).toEqual(
+      'Max Dubler …',
+    )
+  })
+
+  it('keeps a trailing emoji that fits whole', () => {
+    expect(enforceLen(`Max Dubler ${RAINBOW_FLAG}!`, 17, true)).toEqual(
+      `Max Dubler ${RAINBOW_FLAG}…`,
+    )
+  })
+
+  it('never leaves a lone surrogate', () => {
+    for (let len = 0; len < 8; len++) {
+      for (const mode of ['end', 'middle'] as const) {
+        for (const ellipsis of [true, false]) {
+          const result = enforceLen('🎉🎉🎉🎉', len, ellipsis, mode)
+          expect(result).not.toMatch(LONE_SURROGATE)
+        }
+      }
+    }
+  })
+
+  it('does not split emoji when truncating in the middle', () => {
+    expect(enforceLen('🎉'.repeat(10), 6, true, 'middle')).toEqual('🎉…🎉')
+  })
+
+  it('never returns more code units than the requested length', () => {
+    const str = `hi ${RAINBOW_FLAG} there 🎉`
+    for (let len = 0; len < str.length; len++) {
+      expect(enforceLen(str, len, false).length).toBeLessThanOrEqual(len)
+    }
+  })
 })
 
 describe('cleanError', () => {

--- a/src/lib/strings/helpers.ts
+++ b/src/lib/strings/helpers.ts
@@ -1,7 +1,39 @@
 import {type RichText} from '@bsky/sdk/richtext'
-import {countGraphemes} from 'unicode-segmenter/grapheme'
+import {countGraphemes, splitGraphemes} from 'unicode-segmenter/grapheme'
 
 import {shortenLinks} from './rich-text-manip'
+
+/**
+ * Takes at most `len` UTF-16 code units from the start of `str`, stopping at
+ * the last whole grapheme cluster that fits.
+ *
+ * Slicing by code unit alone can cut an emoji in half. The leftover - a lone
+ * surrogate, or a flag/ZWJ sequence missing its tail - renders as a
+ * replacement character rather than as the emoji.
+ */
+function takeGraphemes(str: string, len: number): string {
+  if (len <= 0) return ''
+  let out = ''
+  for (const grapheme of splitGraphemes(str)) {
+    if (out.length + grapheme.length > len) break
+    out += grapheme
+  }
+  return out
+}
+
+/**
+ * Same as {@link takeGraphemes}, but takes from the end of the string.
+ */
+function takeGraphemesFromEnd(str: string, len: number): string {
+  if (len <= 0) return ''
+  const graphemes = [...splitGraphemes(str)]
+  let out = ''
+  for (let i = graphemes.length - 1; i >= 0; i--) {
+    if (out.length + graphemes[i].length > len) break
+    out = graphemes[i] + out
+  }
+  return out
+}
 
 export function enforceLen(
   str: string,
@@ -13,16 +45,16 @@ export function enforceLen(
   if (str.length > len) {
     if (ellipsis) {
       if (mode === 'end') {
-        return str.slice(0, len) + '…'
+        return takeGraphemes(str, len) + '…'
       } else if (mode === 'middle') {
         const half = Math.floor(len / 2)
-        return str.slice(0, half) + '…' + str.slice(-half)
+        return takeGraphemes(str, half) + '…' + takeGraphemesFromEnd(str, half)
       } else {
         // fallback
-        return str.slice(0, len)
+        return takeGraphemes(str, len)
       }
     } else {
-      return str.slice(0, len)
+      return takeGraphemes(str, len)
     }
   }
   return str


### PR DESCRIPTION
enforceLen sliced by UTF-16 code unit, which can cut a multi-codepoint emoji in half. The leftover lone surrogate renders as a replacement character instead of the emoji - visible on any display name ending in a ZWJ sequence such as the rainbow flag.

This also applies to alt text, where the truncated value is written to the record rather than only displayed.

The result is never longer than it was before, so existing limits are unchanged.

Fixes #11390