### PR TITLE
fix: Fix error and label copy across the app

### DIFF
--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -504,7 +504,7 @@ export function FollowButtonInner({
     } catch (e) {
       const err = e as Error
       if (err?.name !== 'AbortError') {
-        Toast.show(l`An issue occurred, please try again.`, {
+        Toast.show(l`An issue occurred. Please try again.`, {
           type: 'error',
         })
       }
@@ -526,7 +526,7 @@ export function FollowButtonInner({
     } catch (e) {
       const err = e as Error
       if (err?.name !== 'AbortError') {
-        Toast.show(l`An issue occurred, please try again.`, {
+        Toast.show(l`An issue occurred. Please try again.`, {
           type: 'error',
         })
       }

--- a/src/components/StarterPack/QrCodeDialog.tsx
+++ b/src/components/StarterPack/QrCodeDialog.tsx
@@ -81,7 +81,7 @@ export function QrCodeDialog({
           // works with the add-only permission on iOS (APP-2374)
           await saveToLibraryAsync(`file://${uri}`)
         } catch (e: unknown) {
-          Toast.show(_(msg`An error occurred while saving the QR code!`), {
+          Toast.show(_(msg`An error occurred while saving the QR code.`), {
             type: 'error',
           })
           logger.error('Failed to save QR code', {error: e})

--- a/src/components/contacts/screens/ViewMatches.tsx
+++ b/src/components/contacts/screens/ViewMatches.tsx
@@ -248,7 +248,9 @@ export function ViewMatches({
       } else {
         logger.error('Dismissing match failed', {safeMessage: err})
         Toast.show(
-          _(msg`An error occurred while hiding suggestion. ${cleanError(err)}`),
+          _(
+            msg`An error occurred while hiding the suggestion. ${cleanError(err)}`,
+          ),
           {type: 'error'},
         )
       }

--- a/src/components/dialogs/DeviceLocationRequestDialog.tsx
+++ b/src/components/dialogs/DeviceLocationRequestDialog.tsx
@@ -108,8 +108,8 @@ function DeviceLocationRequestDialogInner({onLocationAcquired}: Props) {
       <View style={[a.gap_sm, a.pb_xs]}>
         <Text style={[a.text_md, a.leading_snug, t.atoms.text_contrast_medium]}>
           <Trans>
-            Tap below to allow Bluesky to access your GPS location. We will then
-            use that data to more accurately determine the content and features
+            Tap below to allow Bluesky to access your location. We will then use
+            that data to more accurately determine the content and features
             available in your region.
           </Trans>
         </Text>

--- a/src/components/dialogs/PostInteractionSettingsDialog.tsx
+++ b/src/components/dialogs/PostInteractionSettingsDialog.tsx
@@ -575,9 +575,7 @@ export function PostInteractionSettingsForm({
                 ) : isListsError ? (
                   <Toggle.Panel>
                     <Toggle.PanelText>
-                      <Trans>
-                        An error occurred while loading your lists :/
-                      </Trans>
+                      <Trans>An error occurred while loading your lists.</Trans>
                     </Toggle.PanelText>
                   </Toggle.Panel>
                 ) : lists.length === 0 ? (

--- a/src/components/dms/dialogs/NewChatDialog.tsx
+++ b/src/components/dms/dialogs/NewChatDialog.tsx
@@ -49,7 +49,7 @@ export function NewChat({
     },
     onError: error => {
       logger.error('Failed to create chat', {safeMessage: error})
-      let errorMessage = l`An issue occurred starting the chat, please try again.`
+      let errorMessage = l`An issue occurred starting the chat. Please try again.`
       if (isNetworkError(error)) {
         errorMessage = l`A network error occurred. Please check your internet connection.`
       } else {
@@ -84,7 +84,7 @@ export function NewChat({
     },
     onError: error => {
       logger.error('Failed to create groupchat', {safeMessage: error})
-      let errorMessage = l`An issue occurred starting the group chat, please try again.`
+      let errorMessage = l`An issue occurred starting the group chat. Please try again.`
       if (isNetworkError(error)) {
         errorMessage = l`A network error occurred. Please check your internet connection.`
       } else {

--- a/src/components/dms/dialogs/ShareViaChatDialog.tsx
+++ b/src/components/dms/dialogs/ShareViaChatDialog.tsx
@@ -64,7 +64,7 @@ function SendViaChatDialogInner({
     },
     onError: error => {
       logger.error('Failed to share post to chat', {safeMessage: error})
-      let errorMessage = l`An issue occurred starting the chat, please try again.`
+      let errorMessage = l`An issue occurred starting the chat. Please try again.`
       if (isNetworkError(error)) {
         errorMessage = l`A network error occurred. Please check your internet connection.`
       } else {
@@ -100,7 +100,7 @@ function SendViaChatDialogInner({
     },
     onError: error => {
       logger.error('Failed to share post to group chat', {safeMessage: error})
-      let errorMessage = l`An issue occurred starting the group chat, please try again.`
+      let errorMessage = l`An issue occurred starting the group chat. Please try again.`
       if (isNetworkError(error)) {
         errorMessage = l`A network error occurred. Please check your internet connection.`
       } else {

--- a/src/components/hooks/useFollowMethods.ts
+++ b/src/components/hooks/useFollowMethods.ts
@@ -32,7 +32,7 @@ export function useFollowMethods({
       } catch (e: any) {
         logger.error(`useFollowMethods: failed to follow`, {message: String(e)})
         if (e?.name !== 'AbortError') {
-          Toast.show(_(msg`An issue occurred, please try again.`), {
+          Toast.show(_(msg`An issue occurred. Please try again.`), {
             type: 'error',
           })
         }
@@ -49,7 +49,7 @@ export function useFollowMethods({
           message: String(e),
         })
         if (e?.name !== 'AbortError') {
-          Toast.show(_(msg`An issue occurred, please try again.`), {
+          Toast.show(_(msg`An issue occurred. Please try again.`), {
             type: 'error',
           })
         }

--- a/src/components/moderation/ReportDialog/index.tsx
+++ b/src/components/moderation/ReportDialog/index.tsx
@@ -568,8 +568,8 @@ function Inner(
                       // should never happen in our app
                       <Admonition.Admonition type="warning">
                         <Trans>
-                          Unfortunately, none of your subscribed labelers
-                          supports this report type.
+                          None of your subscribed labelers support this report
+                          type.
                         </Trans>
                       </Admonition.Admonition>
                     )}

--- a/src/components/moderation/ReportDialog/utils/useReportOptions.ts
+++ b/src/components/moderation/ReportDialog/utils/useReportOptions.ts
@@ -203,7 +203,7 @@ export function useReportOptions() {
             reason: tools.ozone.report.defs.reasonSelfHarmStunts.value,
           },
           {
-            title: _(msg`Dangerous substances or drug abuse`),
+            title: _(msg`Dangerous substances or drug use`),
             reason: tools.ozone.report.defs.reasonSelfHarmSubstances.value,
           },
           {

--- a/src/features/inviteFriends/InviteFriendsDialogInner.tsx
+++ b/src/features/inviteFriends/InviteFriendsDialogInner.tsx
@@ -104,7 +104,7 @@ export function InviteFriendsDialogInner({
       Toast.show(l`QR code saved to your camera roll!`)
     } catch (err) {
       logger.error('InviteFriendsDialog: download failed', {safeMessage: err})
-      Toast.show(l`An error occurred while saving the QR code!`, {
+      Toast.show(l`An error occurred while saving the QR code.`, {
         type: 'error',
       })
     }

--- a/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
@@ -6,7 +6,6 @@ import {msg, plural} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Plural, Trans} from '@lingui/react/macro'
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import {MAX_LABELERS} from '#/lib/constants'
 import {useHaptics} from '#/lib/haptics'
 import {isAppLabeler} from '#/lib/moderation'
@@ -200,7 +199,7 @@ ProfileHeaderLabeler = memo(ProfileHeaderLabeler)
 export {ProfileHeaderLabeler}
 
 /**
- * Keep this in sync with the value of {@link MAX_LABELERS}
+ * Shown when subscribing would take the user past {@link MAX_LABELERS}.
  */
 function CantSubscribePrompt({
   control,
@@ -211,11 +210,12 @@ function CantSubscribePrompt({
   return (
     <Prompt.Outer control={control}>
       <Prompt.Content>
-        <Prompt.TitleText>Unable to subscribe</Prompt.TitleText>
+        <Prompt.TitleText>
+          <Trans>Unable to subscribe</Trans>
+        </Prompt.TitleText>
         <Prompt.DescriptionText>
           <Trans>
-            We're sorry! You can only subscribe to twenty labelers, and you've
-            reached your limit of twenty.
+            You've reached the limit of {MAX_LABELERS} labeler subscriptions.
           </Trans>
         </Prompt.DescriptionText>
       </Prompt.Content>

--- a/src/screens/Signup/StepInfo/index.tsx
+++ b/src/screens/Signup/StepInfo/index.tsx
@@ -322,11 +322,11 @@ export function StepInfo({
                             <Trans>
                               Have we got your location wrong?{' '}
                               <SimpleInlineLinkText
-                                label={l`Tap here to update your location with GPS.`}
+                                label={l`Tap here to update your location.`}
                                 {...createStaticClick(() => {
                                   locationControl.open()
                                 })}>
-                                Tap here to update your location with GPS.
+                                Tap here to update your location.
                               </SimpleInlineLinkText>
                             </Trans>
                           </Admonition.Text>

--- a/src/view/com/notifications/NotificationFeedItem.tsx
+++ b/src/view/com/notifications/NotificationFeedItem.tsx
@@ -824,7 +824,7 @@ function FollowBackButton({
     } catch (error) {
       const err = error as Error
       if (err?.name !== 'AbortError') {
-        Toast.show(l`An issue occurred, please try again.`, {
+        Toast.show(l`An issue occurred. Please try again.`, {
           type: 'error',
         })
       }
@@ -845,7 +845,7 @@ function FollowBackButton({
     } catch (error) {
       const err = error as Error
       if (err?.name !== 'AbortError') {
-        Toast.show(l`An issue occurred, please try again.`, {
+        Toast.show(l`An issue occurred. Please try again.`, {
           type: 'error',
         })
       }


### PR DESCRIPTION
- "hiding suggestion" -> "hiding the suggestion" (#11208)
- drop the ":/" emoticon from a list-loading error (#11209)
- drop exclamation marks from the QR code save errors (#11210)
- "labelers supports" -> "labelers support", and drop "Unfortunately", which costs a word without helping the reader (#11211)
- state the labeler limit once, as a numeral, from MAX_LABELERS so the copy cannot drift from the constant (#11212)
- replace the comma splices before "please try again" with periods (#11213)
- "drug abuse" -> "drug use", which is neutral rather than stigmatizing (#11217)
- drop "GPS" from the location copy, since device location may come from Wi-Fi access points or cell towers as well (#11218)

Each issue cited specific lines; where the same string appeared elsewhere it is changed there too, so the catalog does not end up with near-duplicate entries to translate.

The labeler prompt title was never wrapped for translation, so wrap it.

Fixes #11208
Fixes #11209
Fixes #11210
Fixes #11211
Fixes #11212
Fixes #11213
Fixes #11217
Fixes #11218