### PR TITLE
Target Android 16 (API 36)

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -271,8 +271,8 @@ module.exports = function (_config) {
             },
             android: {
               compileSdkVersion: 36,
-              targetSdkVersion: 35,
-              buildToolsVersion: '35.0.0',
+              targetSdkVersion: 36,
+              buildToolsVersion: '36.0.0',
               buildReactNativeFromSource: IS_PRODUCTION,
             },
           },


### PR DESCRIPTION
## Summary

- target Android 16 / API level 36, as required by Google Play from August 31, 2026
- use Android Build Tools 36.0.0

Closes APP-2969

## Test plan

- Build a production Android app and confirm it installs and launches successfully.