### PR TITLE
Truncate handles in collapsed profile headers

### DIFF
--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -219,7 +219,7 @@ export function SubtitleText({children}: {children: React.ReactNode}) {
         IS_IOS && align === 'platform' && a.text_center,
         t.atoms.text_contrast_medium,
       ]}
-      numberOfLines={2}>
+      numberOfLines={1}>
       {children}
     </Text>
   )


### PR DESCRIPTION
## Summary

- truncate handles in collapsed profile headers to a single line
- prevent long handles from increasing the collapsed header height

Closes APP-2791

## Test plan

- Open a profile with a long handle and scroll until the header collapses.
- Confirm the handle truncates with an ellipsis and remains on one line.