### PR TITLE
Handle AppView errors after quote posts

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1213,7 +1213,7 @@ export const ComposePost = ({
     if (initQuote) {
       // We want to wait for the quote count to update before we call `onPost`, which will refetch data
       void whenAppViewReady(client, initQuote.uri, res => {
-        const anchor = res.thread.at(0)
+        const anchor = res?.thread.at(0)
         if (
           bsky.isType(app.bsky.unspecced.defs.threadItemPost, anchor?.value) &&
           anchor.value.post.quoteCount !== initQuote.quoteCount
@@ -2478,7 +2478,9 @@ function useKeyboardVerticalOffset() {
 async function whenAppViewReady(
   client: Client,
   uri: string,
-  fn: (res: app.bsky.unspecced.getPostThreadV2.$OutputBody) => boolean,
+  fn: (
+    res: app.bsky.unspecced.getPostThreadV2.$OutputBody | undefined,
+  ) => boolean,
 ) {
   await until(
     5, // 5 tries


### PR DESCRIPTION
## Summary

- handle missing getPostThreadV2 responses after publishing a quote post
- keep retrying transient AppView failures instead of producing an unhandled rejection

## Test plan

- publish a quote post while the post-thread request fails transiently
- confirm the request is retried without an unhandled error and the normal success callback runs once the quote count updates

Fixes APP-2972
Fixes APP-T4FG