### PR TITLE
APP-2971: Fix onboarding avatar compression after Expo 57

### DIFF
--- a/src/lib/media/uriSize.ts
+++ b/src/lib/media/uriSize.ts
@@ -1,0 +1,9 @@
+import {getInfoAsync} from 'expo-file-system/legacy'
+
+export async function getUriSize(uri: string): Promise<number> {
+  const info = await getInfoAsync(uri)
+  if (!info.exists) {
+    throw new Error('Failed to read image size')
+  }
+  return info.size
+}

--- a/src/lib/media/uriSize.web.ts
+++ b/src/lib/media/uriSize.web.ts
@@ -1,0 +1,5 @@
+export async function getUriSize(uri: string): Promise<number> {
+  const response = await fetch(uri)
+  const blob = await response.blob()
+  return blob.size
+}

--- a/src/screens/Onboarding/StepProfile/index.tsx
+++ b/src/screens/Onboarding/StepProfile/index.tsx
@@ -22,7 +22,7 @@ import {IMAGE_SIZE_CONFIG_2K_1MB} from '#/lib/constants'
 import {usePhotoLibraryPermission} from '#/lib/hooks/usePermissions'
 import {compressIfNeeded} from '#/lib/media/manip'
 import {openCropper} from '#/lib/media/picker'
-import {getDataUriSize} from '#/lib/media/util'
+import {getUriSize} from '#/lib/media/uriSize'
 import {useRequestNotificationsPermission} from '#/lib/notifications/notifications'
 import {isCancelledError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
@@ -133,7 +133,7 @@ export function StepProfile() {
             height: rendered.height,
             width: rendered.width,
             path: result.uri,
-            size: getDataUriSize(result.uri),
+            size: await getUriSize(result.uri),
           },
         ]
       } catch {


### PR DESCRIPTION
## Summary

- measure manipulated image size from the underlying blob on web and filesystem metadata on native
- restore the 1 MB onboarding avatar compression check after Expo 57 changed web image results to blob URLs
- fix Sentry issue APP-T4PR

Linear: https://linear.app/blueskyweb/issue/APP-2971/compress-onboarding-avatars-below-the-profile-blob-limit
Sentry: https://blueskyweb.sentry.io/issues/APP-T4PR

## Test plan

- On web, select an image larger than 1 MB as the onboarding avatar, finish onboarding, and confirm the profile is created with the avatar.