### PR TITLE
Update algorithm visibility toggle copy

### DIFF
--- a/src/screens/Settings/components/AlgoVisibilityOptOut.tsx
+++ b/src/screens/Settings/components/AlgoVisibilityOptOut.tsx
@@ -41,9 +41,9 @@ export function AlgoVisibilityOptOut() {
 
       <Text style={[a.leading_snug, t.atoms.text_contrast_high]}>
         <Trans>
-          On Bluesky, this means your posts will only appear in the Discover
-          feed to people who follow you. Other apps can choose to use this
-          preference in their own algorithmic recommendations.
+          Bluesky will not show your posts in the Discover feed (except to your
+          followers) and will ask other apps not to show your posts in their own
+          algorithmic recommendations.
         </Trans>
       </Text>
     </View>


### PR DESCRIPTION
## Summary

- clarify how opting out affects posts in Bluesky’s Discover feed
- clarify that Bluesky asks other apps to exclude posts from algorithmic recommendations

## Test plan

- pre-commit oxlint and Prettier checks passed