### PR TITLE
Add Storybook button for testing Sentry crashes

### DIFF
--- a/src/lib/api/feed/merge.test.ts
+++ b/src/lib/api/feed/merge.test.ts
@@ -1,6 +1,6 @@
 import {type Client} from '@atproto/lex'
 
-import {app} from '#/lexicons'
+import {type app} from '#/lexicons'
 import {MergeFeedAPI} from './merge'
 
 const post = {} as app.bsky.feed.defs.FeedViewPost

--- a/src/view/screens/Storybook/Storybook.tsx
+++ b/src/view/screens/Storybook/Storybook.tsx
@@ -13,6 +13,7 @@ import {
   useDeviceGeolocationApi,
   useRequestDeviceGeolocation,
 } from '#/geolocation'
+import {Sentry} from '#/logger/sentry/lib'
 import {Admonitions} from './Admonitions'
 import {Breakpoints} from './Breakpoints'
 import {Buttons} from './Buttons'
@@ -97,8 +98,16 @@ export default function Storybook() {
                   }
                 })
               }}
-              label="crash">
+              label="Get GPS location">
               <ButtonText>Get GPS Location</ButtonText>
+            </Button>
+
+            <Button
+              color="negative"
+              size="large"
+              onPress={() => Sentry.nativeCrash()}
+              label="Crash the app to test Sentry">
+              <ButtonText>Crash the app</ButtonText>
             </Button>
 
             <Button

--- a/src/view/screens/Storybook/Storybook.tsx
+++ b/src/view/screens/Storybook/Storybook.tsx
@@ -3,6 +3,7 @@ import {View} from 'react-native'
 import {useNavigation} from '@react-navigation/native'
 
 import {type NavigationProp} from '#/lib/routes/types'
+import {Sentry} from '#/logger/sentry/lib'
 import {useSetThemePrefs} from '#/state/shell'
 import {ListContained} from '#/view/screens/Storybook/ListContained'
 import {atoms as a, ThemeProvider} from '#/alf'
@@ -13,7 +14,6 @@ import {
   useDeviceGeolocationApi,
   useRequestDeviceGeolocation,
 } from '#/geolocation'
-import {Sentry} from '#/logger/sentry/lib'
 import {Admonitions} from './Admonitions'
 import {Breakpoints} from './Breakpoints'
 import {Buttons} from './Buttons'


### PR DESCRIPTION
## Summary

- add a destructive Storybook button that triggers `Sentry.nativeCrash()`
- fix the GPS button accessibility label

## Test plan

- open Storybook in a Sentry-enabled internal/release build
- tap “Crash the app” and confirm the app terminates
- relaunch and confirm the native crash appears in Sentry