### PR TITLE
fix(signup): remove default 20-years-ago birth date assumption

### DIFF
--- a/src/screens/Signup/StepHandle/index.tsx
+++ b/src/screens/Signup/StepHandle/index.tsx
@@ -58,7 +58,7 @@ export function StepHandle() {
     username: draftValue,
     serviceDid: state.serviceDescription?.did ?? 'UNKNOWN',
     serviceDomain: state.userDomain,
-    birthDate: state.dateOfBirth.toISOString(),
+    birthDate: state.dateOfBirth?.toISOString() ?? '',
     email: state.email,
     enabled: validCheck.overall,
   })

--- a/src/screens/Signup/StepInfo/index.tsx
+++ b/src/screens/Signup/StepInfo/index.tsx
@@ -156,6 +156,13 @@ export function StepInfo({
         field: 'password',
       })
     }
+    if (!state.dateOfBirth) {
+      return dispatch({
+        type: 'setError',
+        value: l`Please enter your date of birth.`,
+        field: 'date-of-birth',
+      })
+    }
 
     preemptivelyCompleteActivePolicyUpdate()
     dispatch({type: 'setInviteCode', value: inviteCode})
@@ -288,7 +295,7 @@ export function StepInfo({
               <DateField.DateField
                 testID="date"
                 inputRef={birthdateInputRef}
-                value={state.dateOfBirth}
+                value={state.dateOfBirth ?? ''}
                 onChangeDate={date => {
                   dispatch({
                     type: 'setDateOfBirth',

--- a/src/screens/Signup/state.ts
+++ b/src/screens/Signup/state.ts
@@ -15,10 +15,6 @@ import {com} from '#/lexicons'
 
 export type ServiceDescription = com.atproto.server.describeServer.$OutputBody
 
-const date = new Date()
-date.setFullYear(date.getFullYear() - 20) // default to 20 years ago
-const DEFAULT_DATE = date
-
 export enum SignupStep {
   INFO,
   HANDLE,
@@ -43,7 +39,7 @@ export type SignupState = {
   serviceUrl: string
   serviceDescription?: ServiceDescription
   userDomain: string
-  dateOfBirth: Date
+  dateOfBirth: Date | undefined
   email: string
   password: string
   inviteCode: string
@@ -71,7 +67,7 @@ export type SignupAction =
   | {type: 'setServiceDescription'; value: ServiceDescription | undefined}
   | {type: 'setEmail'; value: string}
   | {type: 'setPassword'; value: string}
-  | {type: 'setDateOfBirth'; value: Date}
+  | {type: 'setDateOfBirth'; value: Date | undefined}
   | {type: 'setInviteCode'; value: string}
   | {type: 'setHandle'; value: string}
   | {type: 'setError'; value: string; field?: ErrorField}
@@ -90,7 +86,7 @@ export const initialState: SignupState = {
   serviceUrl: DEFAULT_SERVICE,
   serviceDescription: undefined,
   userDomain: '',
-  dateOfBirth: DEFAULT_DATE,
+  dateOfBirth: undefined,
   email: '',
   password: '',
   handle: '',
@@ -308,6 +304,15 @@ export function useSubmitSignup() {
           field: 'handle',
         })
       }
+      const dateOfBirth = state.dateOfBirth
+      if (!dateOfBirth) {
+        dispatch({type: 'setStep', value: SignupStep.INFO})
+        return dispatch({
+          type: 'setError',
+          value: l`Please enter your date of birth.`,
+          field: 'date-of-birth',
+        })
+      }
       if (
         state.serviceDescription?.phoneVerificationRequired &&
         !state.pendingSubmit?.verificationCode
@@ -329,7 +334,7 @@ export function useSubmitSignup() {
             email: state.email,
             handle: createFullHandle(state.handle, state.userDomain),
             password: state.password,
-            birthDate: state.dateOfBirth,
+            birthDate: dateOfBirth,
             inviteCode: state.inviteCode.trim(),
             verificationCode: state.pendingSubmit?.verificationCode,
           },


### PR DESCRIPTION
## Summary

The signup form was automatically filling in a birth date 20 years before today. This incorrectly assumed every new user was 20 years old.

Now, the birth date field starts blank, and users must select their actual date of birth before continuing.

## UI Change

**Before:**  
Birth date was automatically filled with a date 20 years ago.
<img width="588" height="87" alt="Screenshot 2026-08-28 144949" src="https://github.com/user-attachments/assets/ec22bfa8-13cf-46d9-9ba4-2a5a23bbc88e" />


**After:**  
Birth date starts empty, and the user must select a date before continuing or creating an account.
<img width="577" height="86" alt="Screenshot 2026-08-28 151008" src="https://github.com/user-attachments/assets/971b7372-7dd7-4a77-9a0e-c1d3c0cb0b98" />


Fixes #10935