### PR TITLE
APP-2977: Handle AppView polling errors

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -549,11 +549,6 @@
       "count": 2
     }
   },
-  "src/lib/async/until.ts": {
-    "typescript/no-explicit-any": {
-      "count": 2
-    }
-  },
   "src/lib/broadcast/stub.ts": {
     "typescript/no-explicit-any": {
       "count": 1

--- a/src/components/dialogs/lists/CreateListFromStarterPackDialog.tsx
+++ b/src/components/dialogs/lists/CreateListFromStarterPackDialog.tsx
@@ -102,7 +102,7 @@ export function CreateListFromStarterPackDialog({
             await until(
               5,
               1e3,
-              (res: {items: unknown[]}) => res.items.length > 0,
+              res => !!res?.items.length,
               () =>
                 appviewClient.call(app.bsky.graph.getList, {
                   list: listUri as AtUriString,

--- a/src/lib/async/until.test.ts
+++ b/src/lib/async/until.test.ts
@@ -1,0 +1,29 @@
+import {describe, expect, it, jest} from '@jest/globals'
+
+import {until} from './until'
+
+describe('until', () => {
+  it('does not invoke the condition when an attempt rejects', async () => {
+    const fn = jest
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error('failed'))
+      .mockResolvedValue('ready')
+    const cond = jest.fn((value: string) => value === 'ready')
+
+    await expect(until(2, 0, cond, fn)).resolves.toBe(true)
+    expect(fn).toHaveBeenCalledTimes(2)
+    expect(cond).toHaveBeenCalledTimes(1)
+    expect(cond).toHaveBeenCalledWith('ready')
+  })
+
+  it('returns false when every attempt rejects', async () => {
+    const fn = jest
+      .fn<() => Promise<string>>()
+      .mockRejectedValue(new Error('failed'))
+    const cond = jest.fn((_value: string) => true)
+
+    await expect(until(2, 0, cond, fn)).resolves.toBe(false)
+    expect(fn).toHaveBeenCalledTimes(2)
+    expect(cond).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/async/until.test.ts
+++ b/src/lib/async/until.test.ts
@@ -3,27 +3,40 @@ import {describe, expect, it, jest} from '@jest/globals'
 import {until} from './until'
 
 describe('until', () => {
-  it('does not invoke the condition when an attempt rejects', async () => {
+  it('passes attempt errors to the condition', async () => {
+    const error = new Error('failed')
     const fn = jest
       .fn<() => Promise<string>>()
-      .mockRejectedValueOnce(new Error('failed'))
+      .mockRejectedValueOnce(error)
       .mockResolvedValue('ready')
-    const cond = jest.fn((value: string) => value === 'ready')
+    const cond = jest.fn((value: string | undefined) => value === 'ready')
 
     await expect(until(2, 0, cond, fn)).resolves.toBe(true)
     expect(fn).toHaveBeenCalledTimes(2)
-    expect(cond).toHaveBeenCalledTimes(1)
-    expect(cond).toHaveBeenCalledWith('ready')
+    expect(cond).toHaveBeenNthCalledWith(1, undefined, error)
+    expect(cond).toHaveBeenNthCalledWith(2, 'ready', undefined)
   })
 
   it('returns false when every attempt rejects', async () => {
     const fn = jest
       .fn<() => Promise<string>>()
       .mockRejectedValue(new Error('failed'))
-    const cond = jest.fn((_value: string) => true)
+    const cond = jest.fn((_value: string | undefined) => false)
 
     await expect(until(2, 0, cond, fn)).resolves.toBe(false)
     expect(fn).toHaveBeenCalledTimes(2)
-    expect(cond).not.toHaveBeenCalled()
+    expect(cond).toHaveBeenCalledTimes(2)
+  })
+
+  it('can stop when an attempt rejects', async () => {
+    const error = new Error('failed')
+    const fn = jest.fn<() => Promise<string>>().mockRejectedValue(error)
+    const cond = jest.fn(
+      (_value: string | undefined, err: unknown) => err === error,
+    )
+
+    await expect(until(2, 0, cond, fn)).resolves.toBe(true)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(cond).toHaveBeenCalledWith(undefined, error)
   })
 })

--- a/src/lib/async/until.ts
+++ b/src/lib/async/until.ts
@@ -3,21 +3,20 @@ import {timeout} from './timeout'
 export async function until<T>(
   retries: number,
   delay: number,
-  cond: (v: T, err: any) => boolean,
+  cond: (v: T) => boolean,
   fn: () => Promise<T>,
 ): Promise<boolean> {
   while (retries > 0) {
+    let v: T
     try {
-      const v = await fn()
-      if (cond(v, undefined)) {
-        return true
-      }
-    } catch (e: any) {
-      // TODO: change the type signature of cond to accept undefined
-      // however this breaks every existing usage of until -sfn
-      if (cond(undefined as unknown as T, e)) {
-        return true
-      }
+      v = await fn()
+    } catch {
+      await timeout(delay)
+      retries--
+      continue
+    }
+    if (cond(v)) {
+      return true
     }
     await timeout(delay)
     retries--

--- a/src/lib/async/until.ts
+++ b/src/lib/async/until.ts
@@ -1,22 +1,24 @@
 import {timeout} from './timeout'
 
+/**
+ * Retries an async operation until its result or error matches `cond`.
+ */
 export async function until<T>(
   retries: number,
   delay: number,
-  cond: (v: T) => boolean,
+  cond: (v: T | undefined, err: unknown) => boolean,
   fn: () => Promise<T>,
 ): Promise<boolean> {
   while (retries > 0) {
-    let v: T
     try {
-      v = await fn()
-    } catch {
-      await timeout(delay)
-      retries--
-      continue
-    }
-    if (cond(v)) {
-      return true
+      const v = await fn()
+      if (cond(v, undefined)) {
+        return true
+      }
+    } catch (err) {
+      if (cond(undefined, err)) {
+        return true
+      }
     }
     await timeout(delay)
     retries--

--- a/src/lib/generate-starterpack.ts
+++ b/src/lib/generate-starterpack.ts
@@ -141,7 +141,10 @@ function createListItem({
 async function whenAppViewReady(
   client: Client,
   uri: string,
-  fn: (res?: app.bsky.graph.getStarterPack.$OutputBody) => boolean,
+  fn: (
+    res: app.bsky.graph.getStarterPack.$OutputBody | undefined,
+    err: unknown,
+  ) => boolean,
 ) {
   await until(
     5, // 5 tries

--- a/src/screens/Onboarding/util.ts
+++ b/src/screens/Onboarding/util.ts
@@ -43,7 +43,7 @@ export async function bulkWriteFollows(
       writes: chunk,
     })
   }
-  await whenFollowsIndexed(appviewClient, did, res => !!res.follows.length)
+  await whenFollowsIndexed(appviewClient, did, res => !!res?.follows.length)
 
   const followUris = new Map<string, string>()
   for (const r of followWrites) {
@@ -58,7 +58,10 @@ export async function bulkWriteFollows(
 async function whenFollowsIndexed(
   appviewClient: Client,
   actor: string,
-  fn: (res: app.bsky.graph.getFollows.$OutputBody) => boolean,
+  fn: (
+    res: app.bsky.graph.getFollows.$OutputBody | undefined,
+    err: unknown,
+  ) => boolean,
 ) {
   await until(
     5, // 5 tries

--- a/src/screens/Profile/components/GermButton.tsx
+++ b/src/screens/Profile/components/GermButton.tsx
@@ -137,7 +137,11 @@ function GermSelfButton({did}: {did: string}) {
         rkey: 'self',
       })
 
-      await whenAppViewReady(appviewClient, did, res => !res.associated?.germ)
+      await whenAppViewReady(
+        appviewClient,
+        did,
+        res => !!res && !res.associated?.germ,
+      )
 
       return previousRecord
     },
@@ -154,7 +158,7 @@ function GermSelfButton({did}: {did: string}) {
           await whenAppViewReady(
             appviewClient,
             did,
-            res => !!res.associated?.germ,
+            res => !!res?.associated?.germ,
           )
           await queryClient.refetchQueries({queryKey: RQKEY(did)})
 
@@ -326,7 +330,10 @@ function platform() {
 async function whenAppViewReady(
   appviewClient: Client,
   actor: string,
-  fn: (res: app.bsky.actor.getProfile.$OutputBody) => boolean,
+  fn: (
+    res: app.bsky.actor.getProfile.$OutputBody | undefined,
+    err: unknown,
+  ) => boolean,
 ) {
   await until(
     5, // 5 tries

--- a/src/screens/Settings/AutomationLabelSettings.tsx
+++ b/src/screens/Settings/AutomationLabelSettings.tsx
@@ -80,6 +80,7 @@ export function AutomationLabelSettingsScreen({}: Props) {
           return existing
         },
         checkCommitted: profile => {
+          if (!profile) return false
           const exists = !!profile.labels?.some(l => l.val === 'bot')
           return exists === wasAdded
         },

--- a/src/screens/Settings/components/PwiOptOut.tsx
+++ b/src/screens/Settings/components/PwiOptOut.tsx
@@ -70,6 +70,7 @@ export function PwiOptOut() {
         return existing
       },
       checkCommitted: profile => {
+        if (!profile) return false
         const exists = !!profile.labels?.some(
           l => l.val === '!no-unauthenticated',
         )

--- a/src/state/queries/list.ts
+++ b/src/state/queries/list.ts
@@ -152,9 +152,9 @@ export function useListMetadataMutation() {
 
       // wait for the appview to update
       await whenAppViewReady(appviewClient, res.uri, v => {
-        const list = v.list
+        const list = v?.list
         return (
-          list.name === record.name && list.description === record.description
+          list?.name === record.name && list.description === record.description
         )
       })
       return res
@@ -228,14 +228,10 @@ export function useListDeleteMutation() {
       }
 
       /*
-       * Wait for the appview to update. Once the list is deleted `getList`
-       * throws, `until` catches it and passes `undefined` here, so an absent
-       * body signals a completed delete - the old check read `!v.success` on
-       * the legacy response envelope, which lex does not expose.
+       * Once the deletion is indexed, `getList` throws and `until` passes the
+       * error to this predicate with an undefined response.
        */
-      await whenAppViewReady(appviewClient, uri, v => {
-        return !v
-      })
+      await whenAppViewReady(appviewClient, uri, v => !v)
     },
     onSuccess() {
       invalidateMyLists(queryClient)
@@ -299,7 +295,10 @@ export function useListBlockMutation() {
 async function whenAppViewReady(
   client: Client,
   uri: string,
-  fn: (res: app.bsky.graph.getList.$OutputBody) => boolean,
+  fn: (
+    res: app.bsky.graph.getList.$OutputBody | undefined,
+    err: unknown,
+  ) => boolean,
 ) {
   await until(
     5, // 5 tries

--- a/src/state/queries/pinned-post.ts
+++ b/src/state/queries/pinned-post.ts
@@ -79,10 +79,12 @@ export function usePinnedPostMutation() {
               : undefined
             return existing
           },
-          checkCommitted: profile =>
-            pinCurrentPost
+          checkCommitted: profile => {
+            if (!profile) return false
+            return pinCurrentPost
               ? profile.pinnedPost?.uri === postUri
-              : !profile.pinnedPost,
+              : !profile.pinnedPost
+          },
         })
 
         if (pinCurrentPost) {

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -146,7 +146,10 @@ interface ProfileUpdateParams {
       ) => Un$Typed<app.bsky.actor.profile.Main>)
   newUserAvatar?: ImageMeta | undefined | null
   newUserBanner?: ImageMeta | undefined | null
-  checkCommitted?: (profile: app.bsky.actor.getProfile.$OutputBody) => boolean
+  checkCommitted?: (
+    profile: app.bsky.actor.getProfile.$OutputBody | undefined,
+    err: unknown,
+  ) => boolean
 }
 export function useProfileUpdateMutation() {
   const queryClient = useQueryClient()
@@ -207,6 +210,7 @@ export function useProfileUpdateMutation() {
         profile.did,
         checkCommitted ||
           (fresh => {
+            if (!fresh) return false
             if (typeof newUserAvatar !== 'undefined') {
               if (newUserAvatar === null && fresh.avatar) {
                 // url hasn't cleared yet
@@ -678,7 +682,10 @@ function useProfileUnblockMutation() {
 async function whenAppViewReady(
   client: Client,
   actor: string,
-  fn: (profile: app.bsky.actor.getProfile.$OutputBody) => boolean,
+  fn: (
+    profile: app.bsky.actor.getProfile.$OutputBody | undefined,
+    err: unknown,
+  ) => boolean,
 ) {
   await until(
     5, // 5 tries

--- a/src/state/queries/starter-packs.ts
+++ b/src/state/queries/starter-packs.ts
@@ -325,9 +325,12 @@ export function useDeleteStarterPackMutation({
       })
 
       if (uri) {
-        await whenAppViewReady(appviewClient, uri, v => {
-          return Boolean(v?.starterPack) === false
-        })
+        /* Once the deletion is indexed, `getStarterPack` throws. */
+        await whenAppViewReady(
+          appviewClient,
+          uri,
+          v => Boolean(v?.starterPack) === false,
+        )
       }
 
       if (listUri) {
@@ -353,7 +356,10 @@ export function useDeleteStarterPackMutation({
 async function whenAppViewReady(
   client: Client,
   uri: string,
-  fn: (res?: app.bsky.graph.getStarterPack.$OutputBody) => boolean,
+  fn: (
+    res: app.bsky.graph.getStarterPack.$OutputBody | undefined,
+    err: unknown,
+  ) => boolean,
 ) {
   await until(
     5, // 5 tries

--- a/src/state/queries/verification/useVerificationCreateMutation.tsx
+++ b/src/state/queries/verification/useVerificationCreateMutation.tsx
@@ -31,7 +31,8 @@ export function useVerificationCreateMutation() {
       await until(
         5,
         1e3,
-        (profile: app.bsky.actor.getProfile.$OutputBody) => {
+        profile => {
+          if (!profile) return false
           if (
             profile.verification &&
             profile.verification.verifications.find(v => v.uri === uri)

--- a/src/state/queries/verification/useVerificationsRemoveMutation.tsx
+++ b/src/state/queries/verification/useVerificationsRemoveMutation.tsx
@@ -40,7 +40,8 @@ export function useVerificationsRemoveMutation() {
       await until(
         5,
         1e3,
-        (profile: app.bsky.actor.getProfile.$OutputBody) => {
+        profile => {
+          if (!profile) return false
           if (
             !profile.verification?.verifications.some(v => uris.includes(v.uri))
           ) {

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -2482,6 +2482,7 @@ async function whenAppViewReady(
   uri: string,
   fn: (
     res: app.bsky.unspecced.getPostThreadV2.$OutputBody | undefined,
+    err: unknown,
   ) => boolean,
 ) {
   await until(


### PR DESCRIPTION
## Summary

- make the until predicate type accurately reflect its existing undefined-response and error behavior
- audit every until callsite and guard predicates that assumed a successful response
- preserve deletion polls that intentionally complete when AppView starts returning an error
- add regression coverage for retries and error-aware completion

## Test plan

- Temporarily reject an AppView follow lookup during onboarding and confirm polling retries without throwing.
- Delete a list or starter pack and confirm the flow completes once AppView begins returning an error for it.

Fixes APP-2977
Fixes APP-T4QA

Sentry: https://blueskyweb.sentry.io/issues/7692780353/?project=4508807082278912