### PR TITLE
Make Discover opt-out and login gate title consistent

### DIFF
--- a/src/locale/locales/en/messages.po
+++ b/src/locale/locales/en/messages.po
@@ -1974,8 +1974,8 @@ msgstr "Ask apps and sites not to show my account to logged-out users"
 
 #: src/screens/Settings/components/AlgoVisibilityOptOut.tsx:32
 #: src/screens/Settings/components/AlgoVisibilityOptOut.tsx:35
-msgid "Ask apps to hide my posts from algorithmic recommendations"
-msgstr "Ask apps to hide my posts from algorithmic recommendations"
+msgid "Ask apps and sites to hide my posts from algorithmic recommendations"
+msgstr "Ask apps and sites to hide my posts from algorithmic recommendations"
 
 #: src/components/PostControls/PostMenu/PostMenuItems.tsx:616
 #: src/components/PostControls/PostMenu/PostMenuItems.tsx:618


### PR DESCRIPTION
I noticed that the text in the toggle for opting out of discover says just “Ask apps to-“ when right below that toggle is the toggle for login-gating your account which says “Ask apps and sites to-“ This kinda annoyed me so I’m doing this to fix it