### PR TITLE
APP-2974: Fix scrolling in the composer

### DIFF
--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -229,7 +229,7 @@ export function TextInput({
           style={[
             inputTextStyle,
             a.w_full,
-            !autocompletePrefix && a.h_full,
+            !autocompletePrefix && a.flex_grow,
             {
               textAlignVertical: 'top',
               minHeight: 60,


### PR DESCRIPTION
## Summary

- allow the native composer text input to grow beyond the available viewport
- preserve the expanded tap target for short posts without fixing the input to `height: 100%`
- restore outer composer scrolling when long text overflows, including at large accessibility font sizes

## Test plan

- [x] `pnpm prettier`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] Verify long posts and replies remain scrollable on iOS
- [ ] Verify behavior with large accessibility font sizes and media attachments
- [ ] Smoke test Android composer scrolling
