### PR TITLE
Remove Live Now new-feature nudge

### DIFF
--- a/src/state/queries/nuxs/definitions.ts
+++ b/src/state/queries/nuxs/definitions.ts
@@ -13,7 +13,6 @@ export enum Nux {
   FindContactsAnnouncement = 'FindContactsAnnouncement',
   FindContactsDismissibleBanner = 'FindContactsDismissibleBanner',
   LiveNowBetaDialog = 'LiveNowBetaDialog',
-  LiveNowBetaNudge = 'LiveNowBetaNudge',
   DraftsAnnouncement = 'DraftsAnnouncement',
   GroupChatsAnnouncement = 'GroupChatsAnnouncement',
   InviteFriendsAnnouncement = 'InviteFriendsAnnouncement',
@@ -72,10 +71,6 @@ export type AppNux = BaseNux<
       data: undefined
     }
   | {
-      id: Nux.LiveNowBetaNudge
-      data: undefined
-    }
-  | {
       id: Nux.DraftsAnnouncement
       data: undefined
     }
@@ -101,7 +96,6 @@ export const NuxSchemas: Record<Nux, zod.ZodObject<any> | undefined> = {
   [Nux.FindContactsAnnouncement]: undefined,
   [Nux.FindContactsDismissibleBanner]: undefined,
   [Nux.LiveNowBetaDialog]: undefined,
-  [Nux.LiveNowBetaNudge]: undefined,
   [Nux.DraftsAnnouncement]: undefined,
   [Nux.GroupChatsAnnouncement]: undefined,
   [Nux.InviteFriendsAnnouncement]: undefined,

--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -8,7 +8,6 @@ import {type NavigationProp} from '#/lib/routes/types'
 import {shareText, shareUrl} from '#/lib/sharing'
 import {toShareUrl} from '#/lib/strings/url-helpers'
 import {type Shadow} from '#/state/cache/types'
-import {Nux, useNux, useSaveNux} from '#/state/queries/nuxs'
 import {
   RQKEY as profileQueryKey,
   useProfileBlockMutationQueue,
@@ -18,7 +17,6 @@ import {
 } from '#/state/queries/profile'
 import {useSession} from '#/state/session'
 import {EventStopper} from '#/view/com/util/EventStopper'
-import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonIcon} from '#/components/Button'
 import {useDialogControl} from '#/components/Dialog'
 import {UserAddRemoveListsDialog} from '#/components/dialogs/lists/UserAddRemoveListsDialog'
@@ -63,8 +61,6 @@ import {useActorStatus, useLiveNowConfig} from '#/features/liveNow'
 import {EditLiveDialog} from '#/features/liveNow/components/EditLiveDialog'
 import {GoLiveDialog} from '#/features/liveNow/components/GoLiveDialog'
 import {GoLiveDisabledDialog} from '#/features/liveNow/components/GoLiveDisabledDialog'
-import {Dot} from '#/features/nuxs/components/Dot'
-import {Gradient} from '#/features/nuxs/components/Gradient'
 import {type app} from '#/lexicons'
 import {useDevMode} from '#/storage/hooks/dev-mode'
 
@@ -73,7 +69,6 @@ let ProfileMenu = ({
 }: {
   profile: Shadow<app.bsky.actor.defs.ProfileViewDetailed>
 }): React.ReactNode => {
-  const t = useTheme()
   const ax = useAnalytics()
   const {t: l} = useLingui()
   const {currentAccount, hasSession} = useSession()
@@ -89,13 +84,6 @@ let ProfileMenu = ({
   const verification = useFullVerificationState({profile})
   const {canGoLive} = useLiveNowConfig()
   const status = useActorStatus(profile)
-  const statusNudge = useNux(Nux.LiveNowBetaNudge)
-  const statusNudgeActive =
-    isSelf &&
-    canGoLive &&
-    statusNudge.status === 'ready' &&
-    !statusNudge.nux?.completed
-  const {mutate: saveNux} = useSaveNux()
 
   const [queueMute, queueUnmute] = useProfileMuteMutationQueue(profile)
   const [queueMuteReposts, queueUnmuteReposts] =
@@ -292,24 +280,20 @@ let ProfileMenu = ({
         <Menu.Trigger label={l`More options`}>
           {({props}) => {
             return (
-              <>
-                <Button
-                  {...props}
-                  testID="profileHeaderDropdownBtn"
-                  label={l`More options`}
-                  // hitSlop reaches outside parent views on iOS, so the
-                  // left inset must stay within half of the 4pt row gap or
-                  // it steals taps from the adjacent header button
-                  hitSlop={{top: 6, bottom: 6, left: 2, right: 12}}
-                  variant="solid"
-                  color="secondary"
-                  size="small"
-                  shape="round">
-                  {statusNudgeActive && <Gradient style={[a.rounded_full]} />}
-                  <ButtonIcon icon={EllipsisIcon} size="sm" />
-                </Button>
-                {statusNudgeActive && <Dot top={1} right={1} />}
-              </>
+              <Button
+                {...props}
+                testID="profileHeaderDropdownBtn"
+                label={l`More options`}
+                // hitSlop reaches outside parent views on iOS, so the
+                // left inset must stay within half of the 4pt row gap or
+                // it steals taps from the adjacent header button
+                hitSlop={{top: 6, bottom: 6, left: 2, right: 12}}
+                variant="solid"
+                color="secondary"
+                size="small"
+                shape="round">
+                <ButtonIcon icon={EllipsisIcon} size="sm" />
+              </Button>
             )
           }}
         </Menu.Trigger>
@@ -413,13 +397,7 @@ let ProfileMenu = ({
                       } else {
                         goLiveDialogControl.open()
                       }
-                      saveNux({
-                        id: Nux.LiveNowBetaNudge,
-                        data: undefined,
-                        completed: true,
-                      })
                     }}>
-                    {statusNudgeActive && <Gradient />}
                     <Menu.ItemText>
                       {status.isDisabled ? (
                         <Trans>Go live (disabled)</Trans>
@@ -429,26 +407,7 @@ let ProfileMenu = ({
                         <Trans>Go live</Trans>
                       )}
                     </Menu.ItemText>
-                    {statusNudgeActive && (
-                      <Menu.ItemText
-                        style={[
-                          a.flex_0,
-                          {
-                            color: t.palette.primary_500,
-                            right: IS_WEB ? -8 : -4,
-                          },
-                        ]}>
-                        <Trans>New</Trans>
-                      </Menu.ItemText>
-                    )}
-                    <Menu.ItemIcon
-                      icon={LiveIcon}
-                      fill={
-                        statusNudgeActive
-                          ? () => t.palette.primary_500
-                          : undefined
-                      }
-                    />
+                    <Menu.ItemIcon icon={LiveIcon} />
                   </Menu.Item>
                 )}
                 {verification.viewer.role === 'verifier' &&


### PR DESCRIPTION
## Summary

- remove the Live Now notification dot and promotional styling from the profile menu
- remove the obsolete LiveNowBetaNudge state and dismissal write
- preserve the existing Go Live entry point and dialogs

[APP-2994](https://linear.app/blueskyweb/issue/APP-2994/remove-the-live-now-new-feature-nudge)

## Test plan

- Open your profile and confirm the overflow button has no Live Now notification dot.
- Open the overflow menu and confirm Go live uses standard styling and still opens the existing Live Now flow.