### PR TITLE
Preserve composer focus when adding thread posts

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1700,7 +1700,7 @@ let ComposerPost = memo(function ComposerPost({
           style={[a.pt_xs]}
           richtext={richtext}
           placeholder={selectTextInputPlaceholder}
-          autoFocus={isLastPost}
+          autoFocus={isActive}
           webForceMinHeight={forceMinHeight}
           // To avoid overlap with the close button:
           hasRightPadding={isPartOfThread}

--- a/src/view/com/composer/state/composer.test.ts
+++ b/src/view/com/composer/state/composer.test.ts
@@ -1,0 +1,60 @@
+import {composerReducer, createComposerState} from './composer'
+
+jest.mock('#/state/gallery', () => ({
+  createInitialImages: jest.fn(),
+}))
+jest.mock('#/logger', () => ({
+  logger: {
+    warn: jest.fn(),
+  },
+}))
+jest.mock('#/state/queries/postgate/util', () => ({
+  createPostgateRecord: jest.fn(() => ({})),
+}))
+jest.mock('#/state/queries/threadgate', () => ({
+  threadgateRecordToAllowUISetting: jest.fn(() => []),
+}))
+
+function createState() {
+  return createComposerState({
+    initText: undefined,
+    initMention: undefined,
+    initImageUris: undefined,
+    initQuoteUri: undefined,
+    initInteractionSettings: undefined,
+  })
+}
+
+describe('composerReducer', () => {
+  describe('add_post', () => {
+    it('selects the appended post and requests focus', () => {
+      const state = createState()
+
+      const nextState = composerReducer(state, {type: 'add_post'})
+
+      expect(nextState.thread.posts).toHaveLength(2)
+      expect(nextState.activePostIndex).toBe(1)
+      expect(nextState.mutableNeedsFocusActive).toBe(true)
+    })
+
+    it('selects a post inserted in the middle of a thread', () => {
+      let state = createState()
+      state = composerReducer(state, {type: 'add_post'})
+      state = composerReducer(state, {type: 'add_post'})
+
+      const lastPostId = state.thread.posts[2].id
+      state = composerReducer(state, {
+        type: 'focus_post',
+        postId: state.thread.posts[0].id,
+      })
+
+      const nextState = composerReducer(state, {type: 'add_post'})
+
+      expect(nextState.thread.posts).toHaveLength(4)
+      expect(nextState.activePostIndex).toBe(1)
+      expect(nextState.thread.posts[2].id).not.toBe(lastPostId)
+      expect(nextState.thread.posts[3].id).toBe(lastPostId)
+      expect(nextState.mutableNeedsFocusActive).toBe(true)
+    })
+  })
+})

--- a/src/view/com/composer/state/composer.ts
+++ b/src/view/com/composer/state/composer.ts
@@ -253,6 +253,8 @@ export function composerReducer(
       return {
         ...state,
         isDirty: true,
+        activePostIndex: activePostIndex + 1,
+        mutableNeedsFocusActive: true,
         thread: {
           ...state.thread,
           posts: nextPosts,


### PR DESCRIPTION
Adding a post relied on mount-time autofocus to update the composer’s active state. When that autofocus failed, the new input remained inactive and required another tap.

This PR makes the intended post active immediately, keeping focus behavior consistent across platforms.

https://github.com/user-attachments/assets/46e5d07a-3c8e-478a-a1f0-a37b9ffb7009

https://github.com/user-attachments/assets/ceb96eec-c583-4c04-8fbf-b59d78c6f99c