### PR TITLE
docs: fix typo unecessary -> unnecessary

### DIFF
--- a/src/state/gallery.ts
+++ b/src/state/gallery.ts
@@ -230,7 +230,7 @@ export async function compressImage(
 
     /*
      * In the event the image doesn't compress well, we want to avoid
-     * unecessary iterations. In this case, binary search will check 51, 26,
+     * unnecessary iterations. In this case, binary search will check 51, 26,
      * 13(rounded). We don't want to go below 25, so if we've halved to 13,
      * reset the loop and reduce the image dimensions instead.
      */


### PR DESCRIPTION
Corrects the misspelling `unecessary` -> `unnecessary` in `src/state/gallery.ts`.

Documentation only, no behaviour change.