### PR TITLE
APP-2996: clean up Expo fetch network errors

### DIFF
--- a/src/lib/hooks/useCleanError.ts
+++ b/src/lib/hooks/useCleanError.ts
@@ -86,6 +86,7 @@ const NETWORK_ERRORS = [
   'Abort',
   'Network request failed',
   'Failed to fetch',
+  'fetch failed',
   'Load failed',
   'Upstream service unreachable',
 ]

--- a/src/lib/strings/__tests__/errors.test.ts
+++ b/src/lib/strings/__tests__/errors.test.ts
@@ -91,6 +91,15 @@ describe('cleanError', () => {
     )
   })
 
+  it('matches Expo fetch network errors', () => {
+    const e = new Error(
+      'Unexpected fetchHandler() error: fetch failed: UnexpectedException: The network connection was lost. (at ExpoModulesCore/Promise.swift:56)',
+    )
+    expect(cleanError(e)).toBe(
+      'Unable to connect. Please check your internet connection and try again.',
+    )
+  })
+
   it('surfaces the authentication-required code of a lex error', () => {
     /*
      * The lex client derives `AuthenticationRequired` from a 401 with no XRPC

--- a/src/lib/strings/errors.ts
+++ b/src/lib/strings/errors.ts
@@ -83,6 +83,7 @@ const NETWORK_ERRORS = [
   'Abort',
   'Network request failed',
   'Failed to fetch',
+  'fetch failed',
   'Load failed',
   'Upstream service unreachable',
   'NetworkError when attempting to fetch resource',


### PR DESCRIPTION
## Summary

- recognize the native `fetch failed` marker introduced by Expo 57
- apply it to both existing network-error cleanup paths
- cover the complete composer error with a regression test

## Test plan

- On iOS, lose the network connection while publishing a post and confirm the composer shows the friendly connection error instead of Expo and Swift implementation details.