### PR TITLE
APP-2997: Add age assurance outage screen

### DIFF
--- a/src/ageAssurance/components/DataUnavailableScreen.tsx
+++ b/src/ageAssurance/components/DataUnavailableScreen.tsx
@@ -1,0 +1,41 @@
+import {useState} from 'react'
+import {useLingui} from '@lingui/react/macro'
+
+import {usePdsClient, useSessionApi} from '#/state/session'
+import {Error} from '#/components/Error'
+import {refetchOtherRequiredData} from '#/ageAssurance/data'
+import {IS_WEB} from '#/env'
+
+export function DataUnavailableScreen() {
+  const {t: l} = useLingui()
+  const {logoutCurrentAccount} = useSessionApi()
+  const accountClient = usePdsClient()
+  const [isRetrying, setIsRetrying] = useState(false)
+
+  const onRetry = async () => {
+    setIsRetrying(true)
+    try {
+      await refetchOtherRequiredData({accountClient})
+    } catch {
+      // The error screen remains mounted so the user can retry again.
+    } finally {
+      setIsRetrying(false)
+    }
+  }
+
+  return (
+    <Error
+      title={l`Unable to load your account`}
+      message={l`We couldn't load your account settings. Check your internet connection and try again.`}
+      onRetry={onRetry}
+      isRetrying={isRetrying}
+      secondaryAction={{
+        label: l`Sign out`,
+        onPress: () => {
+          if (IS_WEB) history.pushState(null, '', '/')
+          logoutCurrentAccount('AgeAssuranceDataUnavailableScreen')
+        },
+      }}
+    />
+  )
+}

--- a/src/ageAssurance/components/DataUnavailableScreen.tsx
+++ b/src/ageAssurance/components/DataUnavailableScreen.tsx
@@ -3,6 +3,7 @@ import {useLingui} from '@lingui/react/macro'
 
 import {usePdsClient, useSessionApi} from '#/state/session'
 import {Error} from '#/components/Error'
+import {EmojiSad_Stroke2_Corner0_Rounded as EmojiSad} from '#/components/icons/Emoji'
 import {refetchOtherRequiredData} from '#/ageAssurance/data'
 import {IS_WEB} from '#/env'
 
@@ -25,6 +26,7 @@ export function DataUnavailableScreen() {
 
   return (
     <Error
+      icon={EmojiSad}
       title={l`Unable to load your account`}
       message={l`We couldn't load your account settings. Check your internet connection and try again.`}
       onRetry={onRetry}

--- a/src/ageAssurance/components/DataUnavailableScreen.tsx
+++ b/src/ageAssurance/components/DataUnavailableScreen.tsx
@@ -1,36 +1,23 @@
-import {useState} from 'react'
 import {useLingui} from '@lingui/react/macro'
 
-import {usePdsClient, useSessionApi} from '#/state/session'
+import {useSessionApi} from '#/state/session'
 import {Error} from '#/components/Error'
 import {EmojiSad_Stroke2_Corner0_Rounded as EmojiSadIcon} from '#/components/icons/Emoji'
-import {refetchOtherRequiredData} from '#/ageAssurance/data'
+import {useOtherRequiredDataQuery} from '#/ageAssurance/data'
 import {IS_WEB} from '#/env'
 
 export function DataUnavailableScreen() {
   const {t: l} = useLingui()
   const {logoutCurrentAccount} = useSessionApi()
-  const accountClient = usePdsClient()
-  const [isRetrying, setIsRetrying] = useState(false)
-
-  const onRetry = async () => {
-    setIsRetrying(true)
-    try {
-      await refetchOtherRequiredData({accountClient})
-    } catch {
-      // The error screen remains mounted so the user can retry again.
-    } finally {
-      setIsRetrying(false)
-    }
-  }
+  const {isFetching, refetch} = useOtherRequiredDataQuery()
 
   return (
     <Error
       icon={EmojiSadIcon}
       title={l`Unable to load your account`}
       message={l`We couldn't load your account settings. Check your internet connection and try again.`}
-      onRetry={onRetry}
-      isRetrying={isRetrying}
+      onRetry={() => void refetch()}
+      isRetrying={isFetching}
       secondaryAction={{
         label: l`Sign out`,
         onPress: () => {

--- a/src/ageAssurance/components/DataUnavailableScreen.tsx
+++ b/src/ageAssurance/components/DataUnavailableScreen.tsx
@@ -3,7 +3,7 @@ import {useLingui} from '@lingui/react/macro'
 
 import {usePdsClient, useSessionApi} from '#/state/session'
 import {Error} from '#/components/Error'
-import {EmojiSad_Stroke2_Corner0_Rounded as EmojiSad} from '#/components/icons/Emoji'
+import {EmojiSad_Stroke2_Corner0_Rounded as EmojiSadIcon} from '#/components/icons/Emoji'
 import {refetchOtherRequiredData} from '#/ageAssurance/data'
 import {IS_WEB} from '#/env'
 
@@ -26,7 +26,7 @@ export function DataUnavailableScreen() {
 
   return (
     <Error
-      icon={EmojiSad}
+      icon={EmojiSadIcon}
       title={l`Unable to load your account`}
       message={l`We couldn't load your account settings. Check your internet connection and try again.`}
       onRetry={onRetry}

--- a/src/ageAssurance/data.tsx
+++ b/src/ageAssurance/data.tsx
@@ -7,7 +7,7 @@ import {focusManager, QueryClient, useQuery} from '@tanstack/react-query'
 import {persistQueryClient} from '@tanstack/react-query-persist-client'
 import debounce from 'lodash.debounce'
 
-import {networkRetry} from '#/lib/async/retry'
+import {networkRetry, requestRetry} from '#/lib/async/retry'
 import {createPersistedQueryStorage} from '#/lib/persisted-query-storage'
 import {getAge} from '#/lib/strings/time'
 import {
@@ -359,7 +359,7 @@ async function getOtherRequiredData({
   if (debug.enabled) return debug.resolve(debug.otherRequiredData)
   const did = accountClient.did
   const [prefs, actorDeclaration] = await Promise.all([
-    accountClient.call(getPreferences),
+    requestRetry(3, () => accountClient.call(getPreferences)),
     fetchActorDeclarationRecord({did, client: accountClient}),
   ])
   const data: OtherRequiredData = {
@@ -456,10 +456,10 @@ export async function prefetchOtherRequiredData({
 
   try {
     logger.debug(`prefetchOtherRequiredData: resolving...`)
-    const res = await networkRetry(3, () =>
-      getOtherRequiredData({accountClient}),
-    )
-    qc.setQueryData<OtherRequiredData>(qk, res)
+    await qc.fetchQuery({
+      queryKey: qk,
+      queryFn: () => getOtherRequiredData({accountClient}),
+    })
   } catch (err) {
     const e = err as Error
     logger.warn(`prefetchOtherRequiredData: failed`, {
@@ -486,6 +486,20 @@ export function usePatchOtherRequiredData() {
     [currentAccount],
   )
 }
+export async function refetchOtherRequiredData({
+  accountClient,
+}: {
+  accountClient: Client
+}) {
+  const did = accountClient.did
+  if (!did) return
+  const data = await getOtherRequiredData({accountClient})
+  qc.setQueryData<OtherRequiredData>(
+    createOtherRequiredDataQueryKey({did}),
+    data,
+  )
+  return data
+}
 export function useOtherRequiredDataQuery() {
   const accountClient = usePdsClient()
   const did = accountClient.did
@@ -497,6 +511,8 @@ export function useOtherRequiredDataQuery() {
         return getOtherRequiredDataFromCache({did})
       },
       queryKey: createOtherRequiredDataQueryKey({did: did!}),
+      retry: false,
+      retryOnMount: false,
       async queryFn() {
         return getOtherRequiredData({accountClient})
       },

--- a/src/ageAssurance/data.tsx
+++ b/src/ageAssurance/data.tsx
@@ -7,7 +7,7 @@ import {focusManager, QueryClient, useQuery} from '@tanstack/react-query'
 import {persistQueryClient} from '@tanstack/react-query-persist-client'
 import debounce from 'lodash.debounce'
 
-import {networkRetry, requestRetry} from '#/lib/async/retry'
+import {isRetryableRequestError, networkRetry} from '#/lib/async/retry'
 import {createPersistedQueryStorage} from '#/lib/persisted-query-storage'
 import {getAge} from '#/lib/strings/time'
 import {
@@ -348,9 +348,14 @@ export type OtherRequiredData = {
   actorDeclaration?: chat.bsky.actor.declaration.Main
 }
 export type OtherRequiredDataStatus = 'pending' | 'error' | 'success'
+const otherRequiredDataRetryOptions = {
+  retry: (failureCount: number, error: unknown) =>
+    failureCount < 2 && isRetryableRequestError(error),
+}
 export function createOtherRequiredDataQueryKey({did}: {did: string}) {
   return ['otherRequiredData', did]
 }
+
 async function getOtherRequiredData({
   accountClient,
 }: {
@@ -359,7 +364,7 @@ async function getOtherRequiredData({
   if (debug.enabled) return debug.resolve(debug.otherRequiredData)
   const did = accountClient.did
   const [prefs, actorDeclaration] = await Promise.all([
-    requestRetry(3, () => accountClient.call(getPreferences)),
+    accountClient.call(getPreferences),
     fetchActorDeclarationRecord({did, client: accountClient}),
   ])
   const data: OtherRequiredData = {
@@ -457,6 +462,7 @@ export async function prefetchOtherRequiredData({
   try {
     logger.debug(`prefetchOtherRequiredData: resolving...`)
     await qc.fetchQuery({
+      ...otherRequiredDataRetryOptions,
       queryKey: qk,
       queryFn: () => getOtherRequiredData({accountClient}),
     })
@@ -486,32 +492,18 @@ export function usePatchOtherRequiredData() {
     [currentAccount],
   )
 }
-export async function refetchOtherRequiredData({
-  accountClient,
-}: {
-  accountClient: Client
-}) {
-  const did = accountClient.did
-  if (!did) return
-  const data = await getOtherRequiredData({accountClient})
-  qc.setQueryData<OtherRequiredData>(
-    createOtherRequiredDataQueryKey({did}),
-    data,
-  )
-  return data
-}
 export function useOtherRequiredDataQuery() {
   const accountClient = usePdsClient()
   const did = accountClient.did
   return useQuery(
     {
+      ...otherRequiredDataRetryOptions,
       enabled: !!did,
       initialData: () => {
         if (!did) return
         return getOtherRequiredDataFromCache({did})
       },
       queryKey: createOtherRequiredDataQueryKey({did: did!}),
-      retry: false,
       retryOnMount: false,
       async queryFn() {
         return getOtherRequiredData({accountClient})
@@ -775,9 +767,18 @@ export function AgeAssuranceServerDataProvider({
   const {data: config} = useConfigQuery()
   const serverState = useServerStateQuery()
   const {state, metadata} = serverState.data || {}
-  const {data, status} = useOtherRequiredDataQuery()
+  const {data, errorUpdatedAt, status} = useOtherRequiredDataQuery()
+  /*
+   * A data-less query returns to `pending` and clears `error` while refetching,
+   * but retains `errorUpdatedAt`. Keep the error screen mounted until data
+   * loads successfully.
+   */
   const otherRequiredDataStatus: OtherRequiredDataStatus =
-    data === undefined ? status : 'success'
+    data !== undefined
+      ? 'success'
+      : status === 'error' || errorUpdatedAt > 0
+        ? 'error'
+        : 'pending'
   // `select` resolves the cached region-keyed map to the current region.
   const {data: deviceSignals} = useDeviceSignalsQuery()
   const ctx = useMemo(

--- a/src/analytics/metrics/types.ts
+++ b/src/analytics/metrics/types.ts
@@ -44,6 +44,7 @@ export type Events = {
       | 'SignupQueued'
       | 'Deactivated'
       | 'Takendown'
+      | 'AgeAssuranceDataUnavailableScreen'
       | 'AgeAssuranceNoAccessScreen'
     scope: 'current' | 'every'
   }

--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -4,11 +4,13 @@ import {Trans, useLingui} from '@lingui/react/macro'
 import {useGoBack} from '#/lib/hooks/useGoBack'
 import {atoms as a, useBreakpoints, useTheme} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
+import {type Props as SVGIconProps} from '#/components/icons/common'
 import * as Layout from '#/components/Layout'
 import {Loader} from '#/components/Loader'
 import {Text} from '#/components/Typography'
 
 export function Error({
+  icon: Icon,
   title,
   message,
   onRetry,
@@ -17,6 +19,7 @@ export function Error({
   secondaryAction,
   isRetrying,
 }: {
+  icon?: React.ComponentType<SVGIconProps>
   title?: string
   message?: string
   onRetry?: () => unknown
@@ -44,6 +47,7 @@ export function Error({
         {paddingTop: 175, paddingBottom: 110},
       ]}>
       <View style={[a.w_full, a.align_center, a.gap_lg]}>
+        {Icon && <Icon size="4xl" fill={t.atoms.text_contrast_medium.color} />}
         <Text style={[a.font_semi_bold, a.text_3xl]}>{title}</Text>
         <Text
           style={[

--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -46,9 +46,11 @@ export function Error({
         t.atoms.border_contrast_low,
         {paddingTop: 175, paddingBottom: 110},
       ]}>
-      <View style={[a.w_full, a.align_center, a.gap_lg]}>
+      <View style={[a.w_full, a.align_center, a.gap_lg, a.px_md]}>
         {Icon && <Icon size="4xl" fill={t.atoms.text_contrast_medium.color} />}
-        <Text style={[a.font_semi_bold, a.text_3xl]}>{title}</Text>
+        <Text style={[a.font_semi_bold, a.text_3xl, a.text_center]}>
+          {title}
+        </Text>
         <Text
           style={[
             a.text_md,
@@ -63,7 +65,6 @@ export function Error({
       <View style={[a.gap_md, gtMobile ? {width: 350} : [a.w_full, a.px_lg]]}>
         {onRetry && (
           <Button
-            variant="solid"
             color="primary"
             label={l`Press to retry`}
             onPress={onRetry}
@@ -77,7 +78,6 @@ export function Error({
         )}
         {!hideBackButton && secondaryAction ? (
           <Button
-            variant="solid"
             color={onRetry ? 'secondary' : 'primary'}
             label={secondaryAction.accessibilityLabel ?? secondaryAction.label}
             onPress={secondaryAction.onPress}

--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -3,8 +3,9 @@ import {Trans, useLingui} from '@lingui/react/macro'
 
 import {useGoBack} from '#/lib/hooks/useGoBack'
 import {atoms as a, useBreakpoints, useTheme} from '#/alf'
-import {Button, ButtonText} from '#/components/Button'
+import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import * as Layout from '#/components/Layout'
+import {Loader} from '#/components/Loader'
 import {Text} from '#/components/Typography'
 
 export function Error({
@@ -13,12 +14,20 @@ export function Error({
   onRetry,
   onGoBack,
   hideBackButton,
+  secondaryAction,
+  isRetrying,
 }: {
   title?: string
   message?: string
   onRetry?: () => unknown
   onGoBack?: () => unknown
   hideBackButton?: boolean
+  isRetrying?: boolean
+  secondaryAction?: {
+    label: string
+    accessibilityLabel?: string
+    onPress: () => unknown
+  }
 }) {
   const {t: l} = useLingui()
   const t = useTheme()
@@ -55,21 +64,28 @@ export function Error({
             color="primary"
             label={l`Press to retry`}
             onPress={onRetry}
+            disabled={isRetrying}
             size="large">
             <ButtonText>
               <Trans>Retry</Trans>
             </ButtonText>
+            {isRetrying && <ButtonIcon icon={Loader} />}
           </Button>
         )}
         {!hideBackButton && (
           <Button
             variant="solid"
             color={onRetry ? 'secondary' : 'primary'}
-            label={l`Return to previous page`}
-            onPress={goBack}
+            label={
+              secondaryAction?.accessibilityLabel ??
+              secondaryAction?.label ??
+              l`Return to previous page`
+            }
+            onPress={secondaryAction?.onPress ?? goBack}
+            disabled={isRetrying}
             size="large">
             <ButtonText>
-              <Trans>Go Back</Trans>
+              {secondaryAction?.label ?? <Trans>Go Back</Trans>}
             </ButtonText>
           </Button>
         )}

--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -32,7 +32,6 @@ export function Error({
   const {t: l} = useLingui()
   const t = useTheme()
   const {gtMobile} = useBreakpoints()
-  const goBack = useGoBack(onGoBack)
 
   return (
     <Layout.Center
@@ -72,24 +71,51 @@ export function Error({
             {isRetrying && <ButtonIcon icon={Loader} />}
           </Button>
         )}
-        {!hideBackButton && (
+        {!hideBackButton && secondaryAction ? (
           <Button
             variant="solid"
             color={onRetry ? 'secondary' : 'primary'}
-            label={
-              secondaryAction?.accessibilityLabel ??
-              secondaryAction?.label ??
-              l`Return to previous page`
-            }
-            onPress={secondaryAction?.onPress ?? goBack}
+            label={secondaryAction.accessibilityLabel ?? secondaryAction.label}
+            onPress={secondaryAction.onPress}
             disabled={isRetrying}
             size="large">
-            <ButtonText>
-              {secondaryAction?.label ?? <Trans>Go Back</Trans>}
-            </ButtonText>
+            <ButtonText>{secondaryAction.label}</ButtonText>
           </Button>
-        )}
+        ) : !hideBackButton ? (
+          <GoBackButton
+            hasRetry={Boolean(onRetry)}
+            isRetrying={isRetrying}
+            onGoBack={onGoBack}
+          />
+        ) : null}
       </View>
     </Layout.Center>
+  )
+}
+
+function GoBackButton({
+  hasRetry,
+  isRetrying,
+  onGoBack,
+}: {
+  hasRetry: boolean
+  isRetrying?: boolean
+  onGoBack?: () => unknown
+}) {
+  const {t: l} = useLingui()
+  const goBack = useGoBack(onGoBack)
+
+  return (
+    <Button
+      variant="solid"
+      color={hasRetry ? 'secondary' : 'primary'}
+      label={l`Return to previous page`}
+      onPress={goBack}
+      disabled={isRetrying}
+      size="large">
+      <ButtonText>
+        <Trans>Go Back</Trans>
+      </ButtonText>
+    </Button>
   )
 }

--- a/src/lib/async/retry.test.ts
+++ b/src/lib/async/retry.test.ts
@@ -1,0 +1,21 @@
+import {exponentialBackoffRetryDelay, retry} from '#/lib/async/retry'
+
+describe('retry', () => {
+  it('calculates capped exponential backoff delays', () => {
+    expect([0, 1, 2, 3, 10].map(exponentialBackoffRetryDelay)).toEqual([
+      1000, 2000, 4000, 8000, 30_000,
+    ])
+  })
+
+  it('applies the delay between attempts, but not after the last one', async () => {
+    const action = jest
+      .fn<Promise<string>, []>()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValue('ok')
+    const delay = jest.fn(() => 0)
+
+    await expect(retry(3, () => true, action, delay)).resolves.toBe('ok')
+    expect(delay.mock.calls).toEqual([[0], [1]])
+  })
+})

--- a/src/lib/async/retry.test.ts
+++ b/src/lib/async/retry.test.ts
@@ -1,21 +1,8 @@
-import {exponentialBackoffRetryDelay, retry} from '#/lib/async/retry'
+import {isRetryableRequestError} from '#/lib/async/retry'
 
 describe('retry', () => {
-  it('calculates capped exponential backoff delays', () => {
-    expect([0, 1, 2, 3, 10].map(exponentialBackoffRetryDelay)).toEqual([
-      1000, 2000, 4000, 8000, 30_000,
-    ])
-  })
-
-  it('applies the delay between attempts, but not after the last one', async () => {
-    const action = jest
-      .fn<Promise<string>, []>()
-      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
-      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
-      .mockResolvedValue('ok')
-    const delay = jest.fn(() => 0)
-
-    await expect(retry(3, () => true, action, delay)).resolves.toBe('ok')
-    expect(delay.mock.calls).toEqual([[0], [1]])
+  it('identifies retryable request errors', () => {
+    expect(isRetryableRequestError(new TypeError('Failed to fetch'))).toBe(true)
+    expect(isRetryableRequestError(new Error('Invalid request'))).toBe(false)
   })
 })

--- a/src/lib/async/retry.ts
+++ b/src/lib/async/retry.ts
@@ -1,23 +1,35 @@
 import {timeout} from '#/lib/async/timeout'
-import {isNetworkError} from '#/lib/strings/errors'
+import {isNetworkError, shouldRetryError} from '#/lib/strings/errors'
+
+type RetryDelay = number | ((attempt: number) => number)
+
+export function exponentialBackoffRetryDelay(attempt: number) {
+  return Math.min(1000 * 2 ** attempt, 30_000)
+}
+
+export function isRetryableRequestError(error: unknown) {
+  return isNetworkError(error) || shouldRetryError(error)
+}
 
 export async function retry<P>(
   retries: number,
   shouldRetry: (err: any) => boolean,
   action: () => Promise<P>,
-  delay?: number,
+  delay?: RetryDelay,
 ): Promise<P> {
   let lastErr
+  let attempt = 0
   while (retries > 0) {
     try {
       return await action()
     } catch (e: any) {
       lastErr = e
       if (shouldRetry(e)) {
-        if (delay) {
-          await timeout(delay)
-        }
         retries--
+        if (retries === 0) throw e
+        const delayMs = typeof delay === 'function' ? delay(attempt) : delay
+        if (delayMs) await timeout(delayMs)
+        attempt++
         continue
       }
       throw e
@@ -29,7 +41,19 @@ export async function retry<P>(
 export async function networkRetry<P>(
   retries: number,
   fn: () => Promise<P>,
-  delay?: number,
+  delay?: RetryDelay,
 ): Promise<P> {
   return retry(retries, isNetworkError, fn, delay)
+}
+
+export async function requestRetry<P>(
+  retries: number,
+  fn: () => Promise<P>,
+): Promise<P> {
+  return retry(
+    retries,
+    isRetryableRequestError,
+    fn,
+    exponentialBackoffRetryDelay,
+  )
 }

--- a/src/lib/async/retry.ts
+++ b/src/lib/async/retry.ts
@@ -1,12 +1,6 @@
 import {timeout} from '#/lib/async/timeout'
 import {isNetworkError, shouldRetryError} from '#/lib/strings/errors'
 
-type RetryDelay = number | ((attempt: number) => number)
-
-export function exponentialBackoffRetryDelay(attempt: number) {
-  return Math.min(1000 * 2 ** attempt, 30_000)
-}
-
 export function isRetryableRequestError(error: unknown) {
   return isNetworkError(error) || shouldRetryError(error)
 }
@@ -15,21 +9,19 @@ export async function retry<P>(
   retries: number,
   shouldRetry: (err: any) => boolean,
   action: () => Promise<P>,
-  delay?: RetryDelay,
+  delay?: number,
 ): Promise<P> {
   let lastErr
-  let attempt = 0
   while (retries > 0) {
     try {
       return await action()
     } catch (e: any) {
       lastErr = e
       if (shouldRetry(e)) {
+        if (delay) {
+          await timeout(delay)
+        }
         retries--
-        if (retries === 0) throw e
-        const delayMs = typeof delay === 'function' ? delay(attempt) : delay
-        if (delayMs) await timeout(delayMs)
-        attempt++
         continue
       }
       throw e
@@ -41,19 +33,7 @@ export async function retry<P>(
 export async function networkRetry<P>(
   retries: number,
   fn: () => Promise<P>,
-  delay?: RetryDelay,
+  delay?: number,
 ): Promise<P> {
   return retry(retries, isNetworkError, fn, delay)
-}
-
-export async function requestRetry<P>(
-  retries: number,
-  fn: () => Promise<P>,
-): Promise<P> {
-  return retry(
-    retries,
-    isRetryableRequestError,
-    fn,
-    exponentialBackoffRetryDelay,
-  )
 }

--- a/src/state/queries/preferences/index.ts
+++ b/src/state/queries/preferences/index.ts
@@ -24,6 +24,7 @@ import {
 import {type LabelPreference} from '@bsky/sdk/moderation'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 
+import {requestRetry} from '#/lib/async/retry'
 import {PROD_DEFAULT_FEED} from '#/lib/constants'
 import {replaceEqualDeep} from '#/lib/functions'
 import {getAge} from '#/lib/strings/time'
@@ -71,7 +72,7 @@ export function usePreferencesQuery() {
       if (!client.did) {
         return DEFAULT_LOGGED_OUT_PREFERENCES
       } else {
-        const res = await client.call(getPreferences)
+        const res = await requestRetry(3, () => client.call(getPreferences))
 
         const labelerDids = res.moderationPrefs.labelers.map(l => l.did)
 

--- a/src/state/queries/preferences/index.ts
+++ b/src/state/queries/preferences/index.ts
@@ -24,7 +24,6 @@ import {
 import {type LabelPreference} from '@bsky/sdk/moderation'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 
-import {requestRetry} from '#/lib/async/retry'
 import {PROD_DEFAULT_FEED} from '#/lib/constants'
 import {replaceEqualDeep} from '#/lib/functions'
 import {getAge} from '#/lib/strings/time'
@@ -72,7 +71,7 @@ export function usePreferencesQuery() {
       if (!client.did) {
         return DEFAULT_LOGGED_OUT_PREFERENCES
       } else {
-        const res = await requestRetry(3, () => client.call(getPreferences))
+        const res = await client.call(getPreferences)
 
         const labelerDids = res.moderationPrefs.labelers.map(l => l.did)
 

--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -40,6 +40,7 @@ import {
 } from '#/components/PolicyUpdateOverlay'
 import {Outlet as PortalOutlet} from '#/components/Portal'
 import {useAgeAssurance} from '#/ageAssurance'
+import {DataUnavailableScreen} from '#/ageAssurance/components/DataUnavailableScreen'
 import {NoAccessScreen} from '#/ageAssurance/components/NoAccessScreen'
 import {RedirectOverlay} from '#/ageAssurance/components/RedirectOverlay'
 import {PassiveAnalytics} from '#/analytics/PassiveAnalytics'
@@ -245,7 +246,9 @@ export function Shell() {
         <Deactivated />
       ) : (
         <>
-          {aa.state.access === aa.Access.None ? (
+          {aa.state.error === 'account-data' ? (
+            <DataUnavailableScreen />
+          ) : aa.state.access === aa.Access.None ? (
             <NoAccessScreen />
           ) : (
             <RoutesContainer>

--- a/src/view/shell/index.web.tsx
+++ b/src/view/shell/index.web.tsx
@@ -30,6 +30,7 @@ import {
 import {Outlet as PortalOutlet} from '#/components/Portal'
 import {WelcomeModal} from '#/components/WelcomeModal'
 import {useAgeAssurance} from '#/ageAssurance'
+import {DataUnavailableScreen} from '#/ageAssurance/components/DataUnavailableScreen'
 import {NoAccessScreen} from '#/ageAssurance/components/NoAccessScreen'
 import {RedirectOverlay} from '#/ageAssurance/components/RedirectOverlay'
 import {PassiveAnalytics} from '#/analytics/PassiveAnalytics'
@@ -167,7 +168,9 @@ export function Shell() {
         <Deactivated />
       ) : (
         <>
-          {aa.state.access === aa.Access.None ? (
+          {aa.state.error === 'account-data' ? (
+            <DataUnavailableScreen />
+          ) : aa.state.access === aa.Access.None ? (
             <NoAccessScreen />
           ) : (
             <RoutesContainer>


### PR DESCRIPTION
## Summary

- show a full-screen error when age-assurance account data cannot be loaded, with Retry and Sign out actions
- retry the age-assurance account-data query up to three total attempts for network and retryable server failures, covering both prefetch and hook-driven fetches
- keep the outage screen visible while a manual retry is pending
- leave the non-age-assurance preferences query unchanged

## Video

This is rigged to start working after the 5th attempt

https://github.com/user-attachments/assets/b1ccc5dc-87e0-4bf6-a0fb-9cdb67c5c9f6



## Test plan

- Force the age-assurance `getPreferences` call to fail with a retryable error, then sign in or reload and confirm three attempts occur before the outage screen appears.
- Press Retry while the failure remains and confirm the outage screen stays visible with both actions disabled until the request settles.
- Remove the forced failure, press Retry, and confirm the app opens normally.
- Force the failure again, press Sign out, and confirm the logged-out view opens at the root route.

Linear: https://linear.app/blueskyweb/issue/APP-2997/show-an-outage-screen-when-age-assurance-data-fails-to-load