### PR TITLE
Fix post view attribution for feed replies

### DIFF
--- a/src/analytics/metrics/types.ts
+++ b/src/analytics/metrics/types.ts
@@ -450,6 +450,7 @@ export type Events = {
   'post:view': {
     uri: string
     authorDid: string
+    isReply: boolean
     logContext:
       | 'FeedItem'
       | 'PostThreadItem'

--- a/src/lib/hooks/usePostViewTracking.ts
+++ b/src/lib/hooks/usePostViewTracking.ts
@@ -24,6 +24,7 @@ export function usePostViewTracking(
       ax.metric('post:view', {
         uri: post.uri,
         authorDid: post.author.did,
+        isReply: !!post.record.reply,
         logContext,
       })
     },

--- a/src/screens/PostThread/index.tsx
+++ b/src/screens/PostThread/index.tsx
@@ -104,6 +104,7 @@ export function PostThread({uri}: {uri: string}) {
       ax.metric('post:view', {
         uri: post.uri,
         authorDid: post.author.did,
+        isReply: !!post.record.reply,
         logContext: 'Post',
         feedDescriptor: feedFeedback.feedDescriptor,
       })

--- a/src/screens/VideoFeed/index.tsx
+++ b/src/screens/VideoFeed/index.tsx
@@ -508,6 +508,7 @@ let VideoItem = ({
         ax.metric('post:view', {
           uri: post.uri,
           authorDid: post.author.did,
+          isReply: !!post.record.reply,
           logContext: 'ImmersiveVideo',
           feedDescriptor,
         })

--- a/src/view/com/posts/PostFeed.tsx
+++ b/src/view/com/posts/PostFeed.tsx
@@ -1077,23 +1077,22 @@ let PostFeed = ({
 
         onPostSeen(post)
 
-        // Track one view per slice, attributed to the post selected by the feed.
-        const feedPostItem = slice.items.find(
-          item => item.uri === slice.feedPostUri,
-        )
+        // Track the post selected by the feed once it is actually visible.
         if (
-          indexInSlice === 0 &&
-          feedPostItem &&
-          !seenPostUrisRef.current.has(feedPostItem.uri)
+          post.uri === slice.feedPostUri &&
+          !seenPostUrisRef.current.has(post.uri)
         ) {
-          seenPostUrisRef.current.add(feedPostItem.uri)
+          seenPostUrisRef.current.add(post.uri)
 
-          const position = getPostPosition('sliceItem', item.key)
+          const position = getPostPosition(
+            'sliceItem',
+            slice.items[0]._reactKey,
+          )
 
           ax.metric('post:view', {
-            uri: feedPostItem.uri,
-            authorDid: feedPostItem.post.author.did,
-            isReply: !!feedPostItem.record.reply,
+            uri: post.uri,
+            authorDid: post.author.did,
+            isReply: !!postItem.record.reply,
             logContext: 'FeedItem',
             feedDescriptor: feedFeedback.feedDescriptor || feed,
             position,

--- a/src/view/com/posts/PostFeed.tsx
+++ b/src/view/com/posts/PostFeed.tsx
@@ -1077,15 +1077,23 @@ let PostFeed = ({
 
         onPostSeen(post)
 
-        // Only track the root post of each slice (index 0) to avoid double-counting thread items
-        if (indexInSlice === 0 && !seenPostUrisRef.current.has(post.uri)) {
-          seenPostUrisRef.current.add(post.uri)
+        // Track one view per slice, attributed to the post selected by the feed.
+        const feedPostItem = slice.items.find(
+          item => item.uri === slice.feedPostUri,
+        )
+        if (
+          indexInSlice === 0 &&
+          feedPostItem &&
+          !seenPostUrisRef.current.has(feedPostItem.uri)
+        ) {
+          seenPostUrisRef.current.add(feedPostItem.uri)
 
           const position = getPostPosition('sliceItem', item.key)
 
           ax.metric('post:view', {
-            uri: post.uri,
-            authorDid: post.author.did,
+            uri: feedPostItem.uri,
+            authorDid: feedPostItem.post.author.did,
+            isReply: !!feedPostItem.record.reply,
             logContext: 'FeedItem',
             feedDescriptor: feedFeedback.feedDescriptor || feed,
             position,
@@ -1121,6 +1129,7 @@ let PostFeed = ({
             ax.metric('post:view', {
               uri: post.uri,
               authorDid: post.author.did,
+              isReply: !!postItem.record.reply,
               logContext: 'FeedItem',
               feedDescriptor: feedFeedback.feedDescriptor || feed,
               position,


### PR DESCRIPTION
Reply slices render root and parent context before the feed-selected reply, causing views to be misattributed and replies to be missed.

This PR tracks the selected post when its own row becomes visible and includes `isReply` on every `post:view`, making reply reach directly measurable.

> [!NOTE]
> Historical root/reply trends will show an instrumentation step at rollout.