### PR TITLE
Stabilize native composer focus

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1681,6 +1681,8 @@ let ComposerPost = memo(function ComposerPost({
 
   return (
     <View
+      // Keep focused inputs attached while active-state opacity changes.
+      collapsable={false}
       style={[
         a.mx_lg,
         a.mb_sm,


### PR DESCRIPTION
Prevents Fabric from reparenting focused thread inputs when active-state opacity changes on iOS and Android.