### PR TITLE
APP-2974: Avoid composer layout animations

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -29,7 +29,6 @@ import Animated, {
   FadeOut,
   interpolateColor,
   LayoutAnimationConfig,
-  LinearTransition,
   scrollTo,
   useAnimatedRef,
   useAnimatedScrollHandler,
@@ -1461,7 +1460,6 @@ export const ComposePost = ({
 
           <Animated.ScrollView
             ref={scrollViewRef}
-            layout={native(LinearTransition)}
             onScroll={scrollHandler}
             contentContainerStyle={a.flex_grow}
             style={[
@@ -1825,9 +1823,7 @@ function ComposerTopBar({
   const {t: l} = useLingui()
 
   return (
-    <Animated.View
-      style={topBarAnimatedStyle}
-      layout={native(LinearTransition)}>
+    <Animated.View style={topBarAnimatedStyle}>
       <View
         style={[
           a.flex_row,
@@ -2600,10 +2596,7 @@ function ErrorBanner({
   if (!error) return null
 
   return (
-    <Animated.View
-      style={[a.px_lg, a.pb_sm]}
-      entering={FadeIn}
-      exiting={FadeOut}>
+    <View style={[a.px_lg, a.pb_sm]}>
       <View
         style={[
           a.px_md,
@@ -2641,7 +2634,7 @@ function ErrorBanner({
           </Text>
         )}
       </View>
-    </Animated.View>
+    </View>
   )
 }
 


### PR DESCRIPTION
## Summary

This is intentionally a devil’s-advocate experiment for [APP-2974](https://linear.app/blueskyweb/issue/APP-2974/cant-scroll-in-the-composer).

We have not been able to reproduce the original scrolling failure internally. The initial theory focused on the text input’s sizing, but screenshots from affected users show the inline error/admonition and the composer’s scroll content occupying the same visual space. That points instead to stale native layout geometry while Reanimated layout and entering transitions are running.

This change removes the nonessential Reanimated transitions around that layout boundary:

- remove `LinearTransition` from `ComposerTopBar`
- remove `LinearTransition` from the composer `Animated.ScrollView`
- render `ErrorBanner` as a plain `View` without entering/exiting animations

The scroll view and top bar remain animated components where required by their animated styles and scroll handling; only their automatic layout transitions are removed. The goal is to let React Native/Yoga apply the final geometry directly and see whether that eliminates the overlap and stale scroll bounds reported by affected users.

## Potentially related

- [APP-2989](https://linear.app/blueskyweb/issue/APP-2989) — duplicate report of overlapping composer UI
- [Reanimated #10161](https://github.com/software-mansion/react-native-reanimated/issues/10161) — a growing view during an entering animation leaves visible content outside stale native hit-testing bounds
- [Reanimated #10200](https://github.com/software-mansion/react-native-reanimated/issues/10200) — layout-animated views can stop at incorrect final positions and overlap on iOS
- [Reanimated #10382](https://github.com/software-mansion/react-native-reanimated/pull/10382) — proposed fix for stale `finalView` snapshots overwriting layout updates during entering animations
- [Reanimated #10171](https://github.com/software-mansion/react-native-reanimated/pull/10171) — preserves exact final native layout updates when animations settle
- [social-app #11411](https://github.com/bluesky-social/social-app/pull/11411) — an existing Bluesky workaround for the Reanimated behavior described in #10161

These upstream reports are not confirmed as the cause of APP-2974, but their failure modes closely match the screenshots: pixels move to the new layout while native geometry remains at an older state.

## Test plan

- [x] `pnpm prettier`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `git diff --check`
- [ ] Verify that inline errors and missing-alt reminders push composer content down without overlap on an affected iOS 26.6.1 device
- [ ] Verify scrolling after an error appears, disappears, and is dismissed
- [ ] Verify long replies with images and videos remain scrollable
- [ ] Smoke-test Android composer scrolling and error presentation

> [!NOTE]
> The original issue remains unreproduced internally, so this PR is intentionally draft/experimental pending validation from an affected configuration.
