### PR TITLE
Fix Starter Pack share link on iOS

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -317,14 +317,6 @@
       "count": 4
     }
   },
-  "src/components/StarterPack/ShareDialog.tsx": {
-    "typescript/no-floating-promises": {
-      "count": 1
-    },
-    "typescript/require-await": {
-      "count": 1
-    }
-  },
   "src/components/StarterPack/Wizard/WizardEditListDialog.tsx": {
     "typescript/no-explicit-any": {
       "count": 1

--- a/src/components/StarterPack/ShareDialog.tsx
+++ b/src/components/StarterPack/ShareDialog.tsx
@@ -53,14 +53,15 @@ function ShareDialogInner({
 
   const imageUrl = getStarterPackOgCard(starterPack)
 
-  const onShareLink = async () => {
+  const onShareLink = () => {
     if (!link) return
-    shareUrl(link)
     ax.metric('starterPack:share', {
       starterPack: starterPack.uri,
       shareType: 'link',
     })
-    control.close()
+    control.close(() => {
+      void shareUrl(link)
+    })
   }
 
   const saveImageToAlbum = useSaveImageToMediaLibrary()


### PR DESCRIPTION
## Summary

- close the Starter Pack dialog before presenting the native share sheet
- remove obsolete lint suppressions

[APP-3009](https://linear.app/blueskyweb/issue/APP-3009/fix-starter-pack-share-link-on-ios)

## Test plan

- On iOS, open another user’s Starter Pack, choose Share via… from the overflow menu, then tap Share link and confirm the native share sheet opens.