### PR TITLE
Fix nightly Maestro app launch

### DIFF
--- a/__e2e__/setupApp.yml
+++ b/__e2e__/setupApp.yml
@@ -9,18 +9,17 @@ appId: xyz.blueskyweb.app
     when:
       platform: iOS
     commands:
-      - extendedWaitUntil:
-          visible: "http://localhost:8081"
-          timeout: 60000
-      - tapOn: "http://localhost:8081"
+      - openLink: "exp+bluesky://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081"
+      - runFlow:
+          when:
+            visible: 'Open in "Bluesky"'
+          commands:
+            - tapOn: Open
 - runFlow:
     when:
       platform: Android
     commands:
-      - extendedWaitUntil:
-          visible: "http://10.0.2.2:8081"
-          timeout: 60000
-      - tapOn: "http://10.0.2.2:8081"
+      - openLink: "exp+bluesky://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8081"
       - extendedWaitUntil:
           visible: "Continue"
           timeout: 180000


### PR DESCRIPTION
## Summary

- open the Expo development client directly through its deep link
- avoid relying on automatic Metro discovery in the dev-launcher UI
- preserve the iOS confirmation and Android onboarding handling

## Test plan

- Dispatch the Nightly Maestro E2E workflow from this branch and confirm both platforms load the app past the development launcher.