### PR TITLE
APP-3021: use static AppView DID for E2E

### DIFF
--- a/__e2e__/setupApp.yml
+++ b/__e2e__/setupApp.yml
@@ -4,21 +4,6 @@ appId: xyz.blueskyweb.app
     appId: "xyz.blueskyweb.app"
     clearState: true
 - extendedWaitUntil:
-    visible:
-      id: e2eProxyHeaderInput
-    timeout: 180000
-- extendedWaitUntil:
     visible: "Sign in"
     timeout: 180000
-- retry:
-    maxRetries: 3
-    commands:
-      - tapOn:
-          id: e2eProxyHeaderInput
-      - eraseText
-      - inputText: ${output.result}
-      - pressKey: Enter
-      - extendedWaitUntil:
-          visible:
-            id: e2eSignInAlice
-          timeout: 10000
+- waitForAnimationToEnd

--- a/__e2e__/setupServer.js
+++ b/__e2e__/setupServer.js
@@ -1,8 +1,5 @@
-// eslint-disable-next-line no-undef
-var res = http.post('http://localhost:1986/' + SERVER_PATH, {
+// eslint-disable-next-line no-undef, typescript/no-unsafe-call, typescript/no-unsafe-member-access
+http.post('http://localhost:1986/' + SERVER_PATH, {
   headers: {'Content-Type': 'text/plain'},
   body: '',
 })
-
-// eslint-disable-next-line no-undef
-output.result = json(res.body).appviewDid

--- a/dev-env/constants.ts
+++ b/dev-env/constants.ts
@@ -1,0 +1,1 @@
+export const E2E_APPVIEW_DID = 'did:plc:bw7ad3erl7btq6qwf66yqiov'

--- a/dev-env/test-pds.ts
+++ b/dev-env/test-pds.ts
@@ -5,6 +5,8 @@ import path from 'node:path'
 import {AtUri, BskyAgent} from '@atproto/api'
 import {type TestBsky, TestNetwork} from '@atproto/dev-env'
 
+import {E2E_APPVIEW_DID} from './constants.ts'
+
 export interface TestUser {
   email: string
   did: string
@@ -82,6 +84,13 @@ export async function createServer(
     },
     plc: {port: port2},
   })
+
+  if (testNet.bsky.serverDid !== E2E_APPVIEW_DID) {
+    await testNet.close()
+    throw new Error(
+      `E2E AppView DID changed from ${E2E_APPVIEW_DID} to ${testNet.bsky.serverDid}. Update E2E_APPVIEW_DID in dev-env/constants.ts.`,
+    )
+  }
 
   // DISABLED - looks like dev-env added this and now it conflicts
   // add the test mod authority

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -234,7 +234,6 @@ export const PUBLIC_APPVIEW_DID = 'did:web:api.bsky.app'
 export const PUBLIC_STAGING_APPVIEW_DID = 'did:web:api.staging.bsky.dev'
 
 export const DEV_ENV_APPVIEW = `http://localhost:2584` // always the same
-export const DEV_ENV_APPVIEW_DID = `did:plc:dw4kbjf5mn7nhenabiqpkyh3` // always the same
 
 // temp hack for e2e - esb
 export const BLUESKY_PROXY_HEADER = {

--- a/src/view/com/testing/TestCtrls.e2e.tsx
+++ b/src/view/com/testing/TestCtrls.e2e.tsx
@@ -1,7 +1,7 @@
-import {useState} from 'react'
-import {LogBox, Pressable, TextInput, View} from 'react-native'
+import {LogBox, Pressable, View} from 'react-native'
 import {useQueryClient} from '@tanstack/react-query'
 
+import {E2E_APPVIEW_DID} from '../../../../dev-env/constants'
 import {BLUESKY_PROXY_HEADER} from '#/lib/constants'
 import {useSessionApi} from '#/state/session'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
@@ -18,24 +18,13 @@ LogBox.ignoreAllLogs()
 
 const BTN = {height: 1, width: 1, backgroundColor: 'red'}
 
-/*
- * This component is mounted inside <Fragment key={currentAccount?.did}> in
- * App.tsx, so it fully remounts whenever the account changes (sign-in /
- * sign-out). If the "proxy configured" flag lived only in React state it would
- * reset to false on every remount, hiding the sign-in buttons. Keeping it at
- * module level lets it survive remounts so the sign-in buttons stay visible
- * across sign-out during multi-account flows. Module state still resets when
- * the app relaunches with cleared state at the start of each flow, which is the
- * desired gating behavior.
- */
-let hasConfiguredProxy = false
+BLUESKY_PROXY_HEADER.set(`${E2E_APPVIEW_DID}#bsky_appview`)
 
 export function TestCtrls() {
   const queryClient = useQueryClient()
   const {logoutEveryAccount, login} = useSessionApi()
   const onboardingDispatch = useOnboardingDispatch()
   const {setShowLoggedOut} = useLoggedOutViewControls()
-  const [isProxyConfigured, setIsProxyConfigured] = useState(hasConfiguredProxy)
   const onPressSignInAlice = async () => {
     console.info('[E2E] Signing in as Alice')
     await login(
@@ -60,47 +49,20 @@ export function TestCtrls() {
     )
     setShowLoggedOut(false)
   }
-  const [proxyHeader, setProxyHeader] = useState('')
   return (
     <View style={{position: 'absolute', top: 100, right: 0, zIndex: 100}}>
-      <TextInput
-        accessibilityLabel="Text input field"
-        accessibilityHint="Enter proxy header"
-        testID="e2eProxyHeaderInput"
-        onChangeText={val => setProxyHeader(val)}
-        autoComplete="off"
-        autoCorrect={false}
-        autoCapitalize="none"
-        onSubmitEditing={() => {
-          const header = `${proxyHeader}#bsky_appview`
-          /*
-           * The appview client reads `BLUESKY_PROXY_HEADER.get()` when the
-           * bundle builds it (see clients.ts), so setting the mutable constant
-           * retargets the proxy for the sign-ins below without reconfiguring
-           * anything: the gate above means no bundle exists yet.
-           */
-          BLUESKY_PROXY_HEADER.set(header)
-          hasConfiguredProxy = true
-          setIsProxyConfigured(true)
-        }}
+      <Pressable
+        testID="e2eSignInAlice"
+        onPress={onPressSignInAlice}
+        accessibilityRole="button"
         style={BTN}
       />
-      {isProxyConfigured && (
-        <>
-          <Pressable
-            testID="e2eSignInAlice"
-            onPress={onPressSignInAlice}
-            accessibilityRole="button"
-            style={BTN}
-          />
-          <Pressable
-            testID="e2eSignInBob"
-            onPress={onPressSignInBob}
-            accessibilityRole="button"
-            style={BTN}
-          />
-        </>
-      )}
+      <Pressable
+        testID="e2eSignInBob"
+        onPress={onPressSignInBob}
+        accessibilityRole="button"
+        style={BTN}
+      />
       <Pressable
         testID="e2eSignOut"
         onPress={() => logoutEveryAccount('Settings')}


### PR DESCRIPTION
## Summary

- configure the E2E app to use the dev environment’s fixed AppView DID
- fail dev environment startup with an actionable error if that DID changes
- remove the dynamic DID input and its associated Maestro setup

## Test plan

- Run the `home-screen` Maestro flow and confirm it signs in as Alice without entering an AppView DID.