### PR TITLE
APP-3022: enable R8 minification for Android releases

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -269,6 +269,9 @@ module.exports = function (_config) {
                   organization: 'blueskyweb',
                   project: 'app',
                   url: 'https://sentry.io',
+                  experimental_android: {
+                    enableAndroidGradlePlugin: true,
+                  },
                 },
               ]),
             ]
@@ -294,6 +297,7 @@ module.exports = function (_config) {
               targetSdkVersion: 36,
               buildToolsVersion: '36.0.0',
               buildReactNativeFromSource: IS_PRODUCTION,
+              enableMinifyInReleaseBuilds: true,
             },
           },
         ],


### PR DESCRIPTION
## Summary

- enable R8 minification for Android release builds through expo-build-properties
- enable the Sentry Android Gradle plugin so ProGuard mappings and native symbols are uploaded during Sentry-enabled release builds
- leave resource shrinking disabled because it saved only 0.09 MB in testing

## Size impact

For the arm64 release APK, Android download size drops from 75.27 MB to 62.34 MB: 12.93 MB (17.2%) smaller.

Google Play receives the deobfuscation mapping automatically through the submitted AAB. I verified that the bundle contains BUNDLE-METADATA/com.android.tools.build.obfuscation/proguard.map and that it is byte-for-byte identical to Gradle’s generated mapping.txt. The AAB also contains native debug symbols.

## Test plan

- Install the internal Android release build and smoke-test launch, timeline navigation, posting, and media selection.
- Confirm the release has an uploaded ProGuard mapping in Sentry.
- Confirm Play Console recognizes the deobfuscation file from the submitted app bundle.