### PR TITLE
Fix notifications disappearing when navigating back to the tab

### DIFF
--- a/src/view/screens/Notifications.tsx
+++ b/src/view/screens/Notifications.tsx
@@ -220,17 +220,15 @@ function NotificationsTab({
   ])
 
   const onFocusCheckLatest = useNonReactiveCallback(() => {
-    // on focus, check for latest, but only invalidate if the user
-    // isnt scrolled down to avoid moving content underneath them
-    let currentIsScrolledDown
-    if (IS_NATIVE) {
-      currentIsScrolledDown = isScrolledDown
-    } else {
-      // On the web, this isn't always updated in time so
-      // we're just going to look it up synchronously.
-      currentIsScrolledDown = window.scrollY > 200
-    }
-    checkUnread({invalidate: !currentIsScrolledDown})
+    // On focus, only refresh the unread count/badge. Never truncate and
+    // reload the already-rendered list here: focus also fires when
+    // returning from a pushed child screen (e.g. a notification's detail
+    // view), and truncating+regrouping in that case can make already-visible
+    // notifications disappear, since the replacement page is built from an
+    // independently fetched window that may not line up with what's on
+    // screen. Refreshing the visible list is reserved for explicit user
+    // action (the "Load new notifications" button, or tapping the active tab).
+    checkUnread({invalidate: false})
   })
 
   // on-visible setup


### PR DESCRIPTION
## Summary

Fixes #11609

- Returning to the Notifications tab (including simply popping back from a notification's detail view) was calling `checkUnread({invalidate: true})` on every focus, which synchronously truncated the cached notification list down to a single page and rebuilt it from an independently-fetched, freshly-windowed request.
- That rebuild didn't necessarily match what was already rendered, so a group could shrink (missing members) and every page loaded beyond page one would disappear until re-fetched by scrolling.
- The focus handler now only refreshes the unread badge/count; truncating and refreshing the visible list is reserved for explicit user action (the "Load new notifications" button, or tapping the already-active tab).

## Test plan

- [ ] On web, open Notifications, click into a notification group with several members, click back, confirm the group and all notifications below it are unchanged.
- [ ] Repeat several times in a row (bug was described as intermittent).
- [ ] Confirm the "Load new notifications" button still refreshes the list when new notifications arrive.
- [ ] Confirm the unread badge still updates on focus.