### PR TITLE
Fix notification feed truncation and group dropping (#11609)

### DIFF
--- a/src/state/queries/notifications/__tests__/util.test.ts
+++ b/src/state/queries/notifications/__tests__/util.test.ts
@@ -1,8 +1,12 @@
-import {type DidString} from '@atproto/syntax'
+import {
+  type AtUriString,
+  type DatetimeString,
+  type DidString,
+} from '@atproto/syntax'
 import {describe, expect, it, jest} from '@jest/globals'
 
 import {type Notification} from '../types'
-import {groupNotifications} from '../util'
+import {groupNotifications, mergeGroupedNotifications} from '../util'
 
 jest.mock('#/state/queries/profile', () => ({precacheProfile: jest.fn()}))
 
@@ -79,5 +83,130 @@ describe('groupNotifications', () => {
       ['did:plc:b', 'did:plc:e'],
       ['did:plc:d', 'did:plc:f'],
     ])
+  })
+})
+
+function makeLikeNotification(
+  authorDid: DidString,
+  subjectUri: string,
+  indexedAt = '2026-07-28T12:00:00.000Z',
+): Notification {
+  return {
+    uri: `at://${authorDid}/app.bsky.feed.like/like-${authorDid}`,
+    cid: `cid-${authorDid}`,
+    author: {
+      did: authorDid,
+      handle: `${authorDid}.test`,
+      displayName: authorDid,
+      avatar: undefined,
+      associated: undefined,
+      viewer: {},
+      labels: [],
+      createdAt: '2026-07-28T12:00:00.000Z',
+    },
+    reason: 'like',
+    record: {
+      $type: 'app.bsky.feed.like',
+      subject: {uri: subjectUri, cid: 'cid-post'},
+      createdAt: indexedAt,
+    },
+    reasonSubject: subjectUri as AtUriString,
+    isRead: false,
+    indexedAt: indexedAt as DatetimeString,
+  }
+}
+
+function makeSubscribedPostNotification(
+  authorDid: DidString,
+  postRkey: string,
+  indexedAt = '2026-07-28T12:00:00.000Z',
+): Notification {
+  return {
+    uri: `at://${authorDid}/app.bsky.feed.post/${postRkey}`,
+    cid: `cid-${postRkey}`,
+    author: {
+      did: authorDid,
+      handle: `${authorDid}.test`,
+      displayName: authorDid,
+      avatar: undefined,
+      associated: undefined,
+      viewer: {},
+      labels: [],
+      createdAt: '2026-07-28T12:00:00.000Z',
+    },
+    reason: 'subscribed-post',
+    record: {
+      $type: 'app.bsky.feed.post',
+      text: `Post ${postRkey}`,
+      createdAt: indexedAt,
+    },
+    isRead: false,
+    indexedAt: indexedAt as DatetimeString,
+  }
+}
+
+describe('mergeGroupedNotifications', () => {
+  it('merges notification groups across page boundaries for the same post like', () => {
+    const postUri = 'at://did:plc:author/app.bsky.feed.post/post1'
+    const page0 = groupNotifications([
+      makeLikeNotification('did:plc:alice', postUri),
+      makeLikeNotification('did:plc:bob', postUri),
+    ])
+    const page1 = groupNotifications([
+      makeLikeNotification('did:plc:charlie', postUri),
+      makeLikeNotification('did:plc:dave', postUri),
+    ])
+
+    expect(page0).toHaveLength(1)
+    expect(page1).toHaveLength(1)
+
+    const merged = mergeGroupedNotifications([...page0, ...page1])
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0].notification.author.did).toBe('did:plc:alice')
+    expect(merged[0].additional?.map(n => n.author.did)).toEqual([
+      'did:plc:bob',
+      'did:plc:charlie',
+      'did:plc:dave',
+    ])
+  })
+
+  it('merges subscribed-post notifications across page boundaries', () => {
+    const page0 = groupNotifications([
+      makeSubscribedPostNotification('did:plc:alice', 'post1'),
+      makeSubscribedPostNotification('did:plc:alice', 'post2'),
+    ])
+    const page1 = groupNotifications([
+      makeSubscribedPostNotification('did:plc:alice', 'post3'),
+    ])
+
+    expect(page0).toHaveLength(1)
+    expect(page1).toHaveLength(1)
+
+    const merged = mergeGroupedNotifications([...page0, ...page1])
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0].notification.uri).toBe(
+      'at://did:plc:alice/app.bsky.feed.post/post1',
+    )
+    expect(merged[0].additional?.map(n => n.uri)).toEqual([
+      'at://did:plc:alice/app.bsky.feed.post/post2',
+      'at://did:plc:alice/app.bsky.feed.post/post3',
+    ])
+  })
+
+  it('does not merge likes on different posts', () => {
+    const post1 = 'at://did:plc:author/app.bsky.feed.post/post1'
+    const post2 = 'at://did:plc:author/app.bsky.feed.post/post2'
+    const page0 = groupNotifications([
+      makeLikeNotification('did:plc:alice', post1),
+    ])
+    const page1 = groupNotifications([
+      makeLikeNotification('did:plc:bob', post2),
+    ])
+
+    const merged = mergeGroupedNotifications([...page0, ...page1])
+
+    expect(merged).toHaveLength(2)
   })
 })

--- a/src/state/queries/notifications/feed.ts
+++ b/src/state/queries/notifications/feed.ts
@@ -45,7 +45,7 @@ import {fetchPage} from './util'
 
 export type {FeedNotification, FeedPage, NotificationType} from './types'
 
-const PAGE_SIZE = 30
+export const PAGE_SIZE = 30
 
 type RQPageParam = string | undefined
 

--- a/src/state/queries/notifications/unread.tsx
+++ b/src/state/queries/notifications/unread.tsx
@@ -21,7 +21,7 @@ import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {truncateAndInvalidate} from '#/state/queries/util'
 import {useAppviewClient, useSession} from '#/state/session'
 import {app} from '#/lexicons'
-import {RQKEY as RQKEY_NOTIFS} from './feed'
+import {PAGE_SIZE, RQKEY as RQKEY_NOTIFS} from './feed'
 import {type CachedFeedPage, type FeedPage} from './types'
 import {fetchPage} from './util'
 
@@ -146,7 +146,10 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           // reduce polling if unread count is set
           if (isPoll && cacheRef.current?.unreadCount !== 0) {
             // if hit 30+ then don't poll, otherwise reduce polling by 50%
-            if (cacheRef.current?.unreadCount >= 30 || Math.random() >= 0.5) {
+            if (
+              cacheRef.current?.unreadCount >= PAGE_SIZE ||
+              Math.random() >= 0.5
+            ) {
               return
             }
           }
@@ -161,7 +164,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           const {page, indexedAt: lastIndexed} = await fetchPage({
             client,
             cursor: undefined,
-            limit: 40,
+            limit: PAGE_SIZE,
             queryClient,
             moderationOpts,
             reasons: [],
@@ -172,8 +175,8 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           })
           const unreadCount = countUnread(page)
           const unreadCountStr =
-            unreadCount >= 30
-              ? '30+'
+            unreadCount >= PAGE_SIZE
+              ? `${PAGE_SIZE}+`
               : unreadCount === 0
                 ? ''
                 : String(unreadCount)

--- a/src/state/queries/notifications/util.ts
+++ b/src/state/queries/notifications/util.ts
@@ -197,6 +197,91 @@ export function groupNotifications(notifs: Notification[]): FeedNotification[] {
   return groupedNotifs
 }
 
+export function canMergeGroupedNotifications(
+  groupedNotif: FeedNotification,
+  incoming: FeedNotification,
+): boolean {
+  if (!GROUPABLE_REASONS.includes(incoming.notification.reason)) {
+    return false
+  }
+  if (groupedNotif.notification.reason !== incoming.notification.reason) {
+    return false
+  }
+  if (
+    groupedNotif.notification.reasonSubject !==
+    incoming.notification.reasonSubject
+  ) {
+    return false
+  }
+  const ts = +new Date(incoming.notification.indexedAt)
+  const ts2 = +new Date(groupedNotif.notification.indexedAt)
+  if (Math.abs(ts2 - ts) >= MS_2DAY) {
+    return false
+  }
+  if (incoming.notification.reason === 'follow') {
+    if (
+      incoming.notification.starterPack?.uri !==
+      groupedNotif.notification.starterPack?.uri
+    ) {
+      return false
+    }
+    const nextIsFollowBack = !!incoming.notification.author.viewer?.following
+    const prevIsFollowBack =
+      !!groupedNotif.notification.author.viewer?.following
+    if (nextIsFollowBack || prevIsFollowBack) {
+      return false
+    }
+  }
+  return true
+}
+
+export function mergeGroupedNotifications(
+  items: FeedNotification[],
+): FeedNotification[] {
+  const result: FeedNotification[] = []
+  for (const item of items) {
+    let merged = false
+    if (GROUPABLE_REASONS.includes(item.notification.reason)) {
+      for (let i = 0; i < result.length; i++) {
+        if (canMergeGroupedNotifications(result[i], item)) {
+          const prev = result[i]
+          if (prev.type === 'starterpack-joined') {
+            result[i] = {
+              ...prev,
+              subject:
+                prev.subject ??
+                (item.type === 'starterpack-joined' ? item.subject : undefined),
+              additional: [
+                ...(prev.additional || []),
+                item.notification,
+                ...(item.additional || []),
+              ],
+            }
+          } else {
+            result[i] = {
+              ...prev,
+              subject:
+                prev.subject ??
+                (item.type !== 'starterpack-joined' ? item.subject : undefined),
+              additional: [
+                ...(prev.additional || []),
+                item.notification,
+                ...(item.additional || []),
+              ],
+            }
+          }
+          merged = true
+          break
+        }
+      }
+    }
+    if (!merged) {
+      result.push(item)
+    }
+  }
+  return result
+}
+
 async function fetchSubjects(
   client: Client,
   groupedNotifs: FeedNotification[],

--- a/src/view/com/notifications/NotificationFeed.tsx
+++ b/src/view/com/notifications/NotificationFeed.tsx
@@ -11,6 +11,7 @@ import {
   type FeedNotification,
   useNotificationFeedQuery,
 } from '#/state/queries/notifications/feed'
+import {mergeGroupedNotifications} from '#/state/queries/notifications/util'
 import {EmptyState} from '#/view/com/util/EmptyState'
 import {ErrorMessage} from '#/view/com/util/error/ErrorMessage'
 import {List, type ListProps, type ListRef} from '#/view/com/util/List'
@@ -82,9 +83,11 @@ export function NotificationFeed({
       if (isEmpty) {
         arr = arr.concat([EMPTY_FEED_ITEM])
       } else if (data) {
-        for (const page of data?.pages) {
-          arr = arr.concat(page.items)
+        let feedNotifications: FeedNotification[] = []
+        for (const page of data.pages) {
+          feedNotifications = feedNotifications.concat(page.items)
         }
+        arr = arr.concat(mergeGroupedNotifications(feedNotifications))
       }
       if (isError && !isEmpty) {
         arr = arr.concat([LOAD_MORE_ERROR_ITEM])

--- a/src/view/screens/Notifications.tsx
+++ b/src/view/screens/Notifications.tsx
@@ -220,17 +220,9 @@ function NotificationsTab({
   ])
 
   const onFocusCheckLatest = useNonReactiveCallback(() => {
-    // on focus, check for latest, but only invalidate if the user
-    // isnt scrolled down to avoid moving content underneath them
-    let currentIsScrolledDown
-    if (IS_NATIVE) {
-      currentIsScrolledDown = isScrolledDown
-    } else {
-      // On the web, this isn't always updated in time so
-      // we're just going to look it up synchronously.
-      currentIsScrolledDown = window.scrollY > 200
-    }
-    checkUnread({invalidate: !currentIsScrolledDown})
+    // On focus, check for latest unread in the background so we don't
+    // truncate pages or shift content underneath the user (e.g. when navigating back)
+    checkUnread({invalidate: false})
   })
 
   // on-visible setup


### PR DESCRIPTION
Fixes #11609

### Problem
When navigating back from a notification detail/activity view to the Notifications tab on web:
1. `onFocusCheckLatest` in `Notifications.tsx` synchronously checked `window.scrollY > 200` inside `useFocusEffect`. When returning from a child route, `window.scrollY` is evaluated before scroll restoration, evaluating `!currentIsScrolledDown` as `true` and calling `checkUnread({invalidate: true})`.
2. `checkUnread({invalidate: true})` invoked `truncateAndInvalidate`, which truncated the query cache to only Page 0 (`data.pages.slice(0, 1)`), causing all subsequent paginated groups to disappear until an end-reached or height change re-triggered pagination.
3. `unread.tsx` fetched with `limit: 40` while `feed.ts` uses `PAGE_SIZE = 30`. When `usableInFeed` was true, Page 0 was injected with 40 items, shifting subsequent page boundaries.
4. Notifications were grouped per-page inside `fetchPage`. When a group of notifications crossed a 30-item page boundary, it split into two separate cards (the second starting from the 10th notification).

### Solution
1. **Notifications Screen**: In `src/view/screens/Notifications.tsx`, updated `onFocusCheckLatest` to call `checkUnread({invalidate: false})`. Unread status is synced in the background without truncating loaded feed pages. Explicit user actions like pull-to-refresh, pressing `LoadLatestBtn`, and soft-resets continue to refresh and truncate as intended.
2. **Page Size Consistency**: Exported `PAGE_SIZE = 30` from `src/state/queries/notifications/feed.ts` and used it in `src/state/queries/notifications/unread.tsx` (`limit: PAGE_SIZE`) and polling thresholds.
3. **Cross-Page Notification Group Merging**: Added `mergeGroupedNotifications` in `src/state/queries/notifications/util.ts` and wrapped concatenated page items in `src/view/com/notifications/NotificationFeed.tsx` so groupable items spanning pagination boundaries are consolidated into unified cards.
4. **Unit Tests**: Added test coverage in `src/state/queries/notifications/__tests__/util.test.ts` for cross-page group merging (post likes and subscribed posts).
