### PR TITLE
Fix ALT badge text clipping on Android when large badges enabled

### DIFF
--- a/src/components/AltBadgeWithDialog.tsx
+++ b/src/components/AltBadgeWithDialog.tsx
@@ -72,7 +72,14 @@ export function AltBadgeWithDialog({
         ]}>
         <Text
           accessible={false}
-          style={[a.font_bold, large ? a.text_xs : {fontSize: 8}]}>
+          numberOfLines={1}
+          ellipsizeMode="clip"
+          textBreakStrategy="simple"
+          style={[
+            a.font_bold,
+            large ? a.text_xs : {fontSize: 8},
+            {includeFontPadding: false},
+          ]}>
           <Trans>ALT</Trans>
         </Text>
       </Pressable>

--- a/src/components/Post/Embed/VideoEmbed/GifPresentationControls.tsx
+++ b/src/components/Post/Embed/VideoEmbed/GifPresentationControls.tsx
@@ -89,7 +89,15 @@ export function GifPresentationControls({
               opacity: 0.8,
             },
           ]}>
-          <Text style={[a.font_bold, largeBadge ? a.text_xs : {fontSize: 8}]}>
+          <Text
+            numberOfLines={1}
+            ellipsizeMode="clip"
+            textBreakStrategy="simple"
+            style={[
+              a.font_bold,
+              largeBadge ? a.text_xs : {fontSize: 8},
+              {includeFontPadding: false},
+            ]}>
             <Trans>GIF</Trans>
           </Text>
         </View>

--- a/src/components/images/AutoSizedImage.tsx
+++ b/src/components/images/AutoSizedImage.tsx
@@ -201,7 +201,15 @@ export function AutoSizedImage({
                   },
                 ],
               ]}>
-              <Text style={[a.font_bold, largeAlt ? a.text_xs : {fontSize: 8}]}>
+              <Text
+                numberOfLines={1}
+                ellipsizeMode="clip"
+                textBreakStrategy="simple"
+                style={[
+                  a.font_bold,
+                  largeAlt ? a.text_xs : {fontSize: 8},
+                  {includeFontPadding: false},
+                ]}>
                 <Trans>ALT</Trans>
               </Text>
             </View>

--- a/src/components/images/Gallery/index.tsx
+++ b/src/components/images/Gallery/index.tsx
@@ -527,9 +527,13 @@ function GalleryImage({
                 },
               ]}>
               <Text
+                numberOfLines={1}
+                ellipsizeMode="clip"
+                textBreakStrategy="simple"
                 style={[
                   a.font_bold,
                   largeAltBadge ? a.text_xs : {fontSize: 8},
+                  {includeFontPadding: false},
                 ]}>
                 <Trans
                   context="gallery-badge-image-position-numbers"
@@ -591,9 +595,13 @@ function GalleryImage({
                     },
                   ]}>
                   <Text
+                    numberOfLines={1}
+                    ellipsizeMode="clip"
+                    textBreakStrategy="simple"
                     style={[
                       a.font_bold,
                       largeAltBadge ? a.text_xs : {fontSize: 8},
+                      {includeFontPadding: false},
                     ]}>
                     <Trans>ALT</Trans>
                   </Text>

--- a/src/components/images/ImageLayoutGridItem.tsx
+++ b/src/components/images/ImageLayoutGridItem.tsx
@@ -131,7 +131,14 @@ export function GalleryItem({
             ],
           ]}>
           <Text
-            style={[a.font_bold, largeAltBadge ? a.text_xs : {fontSize: 8}]}>
+            numberOfLines={1}
+            ellipsizeMode="clip"
+            textBreakStrategy="simple"
+            style={[
+              a.font_bold,
+              largeAltBadge ? a.text_xs : {fontSize: 8},
+              {includeFontPadding: false},
+            ]}>
             <Trans>ALT</Trans>
           </Text>
         </View>


### PR DESCRIPTION
## Description
Fixes #11607

On Android, enabling "Display larger alt text badges" in Accessibility Settings can cause the letter "T" in "ALT" to be clipped or wrapped onto an invisible second line due to font padding and text break calculation with `Inter-Bold`.

## Changes
- Add `numberOfLines={1}`, `ellipsizeMode="clip"`, `textBreakStrategy="simple"`, and `{includeFontPadding: false}` to badge `<Text>` components in:
  - `src/components/images/AutoSizedImage.tsx`
  - `src/components/images/Gallery/index.tsx`
  - `src/components/images/ImageLayoutGridItem.tsx`
  - `src/components/AltBadgeWithDialog.tsx`
  - `src/components/Post/Embed/VideoEmbed/GifPresentationControls.tsx`