### PR TITLE
Fix DMs sending duplicate messages on rapid send-button taps

### DIFF
--- a/src/screens/Messages/components/MessageComposer.tsx
+++ b/src/screens/Messages/components/MessageComposer.tsx
@@ -104,6 +104,15 @@ export function MessageComposer({
   const submitDisabled =
     !editable || (!messageEmbed && text.trim().length === 0)
 
+  /*
+   * Guards against a second `onSubmit` firing (a fast double-tap, or a
+   * native double-dispatch of onPress) before React has re-rendered with
+   * the cleared input. `submitDisabled`/`text` are state, so they lag a
+   * frame behind the synchronous `.clear()` call below - a ref is needed
+   * to block re-entry within that window.
+   */
+  const isSubmittingRef = useRef(false)
+
   const onSubmit = (
     message: string,
     embed: MessageEmbedState | undefined,
@@ -111,6 +120,7 @@ export function MessageComposer({
   ) => {
     if (!editable) return
     if (!embed && message.trim() === '') return
+    if (isSubmittingRef.current) return
     const graphemeCount = countGraphemes(message)
     if (graphemeCount > MAX_DM_GRAPHEME_LENGTH) {
       Toast.show(
@@ -120,6 +130,7 @@ export function MessageComposer({
       return
     }
 
+    isSubmittingRef.current = true
     clearDraft()
     playHaptic()
     setEmbed(undefined)
@@ -132,6 +143,7 @@ export function MessageComposer({
 
     // defer send by a frame so that the textinput resizes before we send the message
     requestAnimationFrame(() => {
+      isSubmittingRef.current = false
       onSendMessage(
         message,
         embed,


### PR DESCRIPTION
## Summary

Fixes #11501

- `MessageComposer`'s `onSubmit` reads the composer's `text`/`messageEmbed` React state and imperatively clears the input, but nothing blocked a second `onSubmit` invocation from running before React re-rendered with that cleared state.
- Two presses landing within the same frame - a fast human double-tap, or (as the report calls out) a native double-dispatch of `onPress` on Android/Fabric - both read the same not-yet-cleared state, both passed validation, and each independently called `onSendMessage`, producing two identical outgoing messages via `ConvoAgent.sendMessage()` (which has no dedup of its own).
- Added a synchronous `useRef` re-entrancy guard in `onSubmit`: set before the deferred send is scheduled, cleared once it fires. This closes the race window (a single frame, ~16ms) without throttling legitimate distinct sends made moments apart.

## Test plan

- [ ] On Android, open a DM, type a message, tap send rapidly several times in a row - confirm only one message is sent.
- [ ] Confirm normal single-tap sending still works on iOS, Android, and web.
- [ ] Confirm sending several different messages back-to-back (typing new text between sends) still works normally and isn't delayed/blocked.