### PR TITLE
APP-3031: Fix contact imports after Expo 57

### DIFF
--- a/src/components/contacts/screens/GetContacts.tsx
+++ b/src/components/contacts/screens/GetContacts.tsx
@@ -1,7 +1,7 @@
 import {useContext} from 'react'
 import {Alert, View} from 'react-native'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
-import * as Contacts from 'expo-contacts'
+import * as Contacts from 'expo-contacts/legacy'
 import {type Un$Typed} from '@atproto/lex'
 import {type Client} from '@atproto/lex'
 import {toDatetimeString} from '@atproto/syntax'

--- a/src/components/contacts/state.ts
+++ b/src/components/contacts/state.ts
@@ -1,6 +1,6 @@
 import {createContext, useContext, useReducer} from 'react'
 import {type GestureResponderEvent} from 'react-native'
-import {type ExistingContact} from 'expo-contacts'
+import {type ExistingContact} from 'expo-contacts/legacy'
 
 import {type CountryCode} from '#/lib/international-telephone-codes'
 import type * as bsky from '#/types/bsky'

--- a/src/screens/Onboarding/StepFindContactsIntro/index.tsx
+++ b/src/screens/Onboarding/StepFindContactsIntro/index.tsx
@@ -1,5 +1,5 @@
 import {View} from 'react-native'
-import * as Contacts from 'expo-contacts'
+import * as Contacts from 'expo-contacts/legacy'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'

--- a/src/screens/Settings/FindContactsSettings.tsx
+++ b/src/screens/Settings/FindContactsSettings.tsx
@@ -1,6 +1,6 @@
 import {useCallback, useEffect, useState} from 'react'
 import {type ListRenderItemInfo, View} from 'react-native'
-import * as Contacts from 'expo-contacts'
+import * as Contacts from 'expo-contacts/legacy'
 import {type DidString} from '@atproto/syntax'
 import {type ModerationOpts} from '@bsky/sdk/moderation'
 import {msg} from '@lingui/core/macro'


### PR DESCRIPTION
## Summary

- restore contact availability checks and address-book reads after Expo 57 by importing the existing API from `expo-contacts/legacy`
- preserve the current contact shape and phone-number normalization behavior

Fixes APP-3031.

## Test plan

- On iOS or Android, open Find Contacts settings and confirm the Import contacts action is available.
- Complete phone verification, tap Find my friends, and confirm the address book is read and the flow advances to contact matches.
