### PR TITLE
Fix Android thread number alignment across font scales

### DIFF
--- a/src/screens/PostThread/components/ThreadItemPostNumber.tsx
+++ b/src/screens/PostThread/components/ThreadItemPostNumber.tsx
@@ -5,10 +5,6 @@ import {atoms as a, ios, platform, useTheme} from '#/alf'
 import {useNativeFontScale} from '#/alf/util/dimensions'
 import {type app} from '#/lexicons'
 
-/**
- * How far the inline badge is nudged below the text baseline. Android's
- * containing `RichText` reserves matching room via `suffixOffset`.
- */
 const ANDROID_INLINE_OFFSETS = [
   [0.85, 2],
   [1, 4],
@@ -20,7 +16,8 @@ const ANDROID_INLINE_OFFSETS = [
 ] as const
 
 /**
- * Maximum Android inline offset, reserved by `RichText` to avoid clipping.
+ * Max amount the inline badge is nudged below the text baseline. Android's
+ * containing `RichText` reserves matching room via `suffixOffset`.
  */
 export const POST_NUMBER_INLINE_OFFSET = 14
 
@@ -85,16 +82,21 @@ export function ThreadItemPostNumber({
         inline
           ? platform({
               android: {
+                /*
+                 * Android aligns the inline view's bottom to the surrounding
+                 * text baseline.
+                 * We want it to align the inline view's child/text baseline.
+                 */
                 transform: [
-                  /*
-                   * Android aligns the inline view's bottom to the surrounding
-                   * text baseline.
-                   * We want it to align the inline view's child/text baseline.
-                   */
                   {translateY: getAndroidInlineOffset(nativeFontScale)},
                 ],
               },
-              ios: {transform: [{translateY: a.py_2xs.paddingBottom}]},
+              ios: {
+                /*
+                 * For iOS, we just need to offset the padding we applied.
+                 */
+                transform: [{translateY: a.py_2xs.paddingBottom}],
+              },
               web: {
                 /*
                  * Inline views inherit the surrounding line height on web. Keep

--- a/src/screens/PostThread/components/ThreadItemPostNumber.tsx
+++ b/src/screens/PostThread/components/ThreadItemPostNumber.tsx
@@ -5,6 +5,9 @@ import {atoms as a, ios, platform, useTheme} from '#/alf'
 import {useNativeFontScale} from '#/alf/util/dimensions'
 import {type app} from '#/lexicons'
 
+/**
+ * Map of Android font scale values to inline offsets.
+ */
 const ANDROID_INLINE_OFFSETS = [
   [0.85, 2],
   [1, 4],

--- a/src/screens/PostThread/components/ThreadItemPostNumber.tsx
+++ b/src/screens/PostThread/components/ThreadItemPostNumber.tsx
@@ -2,13 +2,35 @@ import {Text, View} from 'react-native'
 import {Trans, useLingui} from '@lingui/react/macro'
 
 import {atoms as a, ios, platform, useTheme} from '#/alf'
+import {useNativeFontScale} from '#/alf/util/dimensions'
 import {type app} from '#/lexicons'
 
 /**
  * How far the inline badge is nudged below the text baseline. Android's
  * containing `RichText` reserves matching room via `suffixOffset`.
  */
-export const POST_NUMBER_INLINE_OFFSET = 6
+const ANDROID_INLINE_OFFSETS = [
+  [0.85, 2],
+  [1, 4],
+  [1.15, 6],
+  [1.3, 8],
+  [1.5, 10],
+  [1.8, 12],
+  [2, 14],
+] as const
+
+/**
+ * Maximum Android inline offset, reserved by `RichText` to avoid clipping.
+ */
+export const POST_NUMBER_INLINE_OFFSET = 14
+
+function getAndroidInlineOffset(fontScale: number) {
+  return ANDROID_INLINE_OFFSETS.reduce((nearest, candidate) =>
+    Math.abs(candidate[0] - fontScale) < Math.abs(nearest[0] - fontScale)
+      ? candidate
+      : nearest,
+  )[1]
+}
 
 export type ThreadItemPostNumbering = Pick<
   app.bsky.unspecced.defs.ThreadItemPost,
@@ -39,6 +61,7 @@ export function ThreadItemPostNumber({
 }) {
   const t = useTheme()
   const {t: l} = useLingui()
+  const nativeFontScale = useNativeFontScale()
   const shouldRender = useHasThreadItemPostNumber(value)
   const index = value?.opThreadPostIndex
   const count = value?.opThreadPostCount
@@ -61,11 +84,22 @@ export function ThreadItemPostNumber({
         },
         inline
           ? platform({
-              android: {transform: [{translateY: POST_NUMBER_INLINE_OFFSET}]},
+              android: {
+                transform: [
+                  /*
+                   * Android aligns the inline view's bottom to the surrounding
+                   * text baseline.
+                   * We want it to align the inline view's child/text baseline.
+                   */
+                  {translateY: getAndroidInlineOffset(nativeFontScale)},
+                ],
+              },
               ios: {transform: [{translateY: a.py_2xs.paddingBottom}]},
               web: {
-                // Inline views inherit the surrounding line height on web. Keep
-                // the badge at its usual size when emoji-only text enlarges it.
+                /*
+                 * Inline views inherit the surrounding line height on web. Keep
+                 * the badge at its usual size when emoji-only text enlarges it.
+                 */
                 lineHeight: a.text_xs.fontSize * a.leading_normal.lineHeight,
               },
             })


### PR DESCRIPTION
Calibrates Android’s inline thread-number offset for every supported font-size preset so numeral baselines remain aligned with post text.

Font-size values were read from a Pixel 6 running Android 17.