### PR TITLE
Enable Sentry tombstones

### DIFF
--- a/src/logger/sentry/setup/index.ts
+++ b/src/logger/sentry/setup/index.ts
@@ -5,6 +5,7 @@ import * as env from '#/env'
 init({
   enabled: !env.IS_DEV && !!env.SENTRY_DSN,
   enableAutoSessionTracking: false,
+  enableTombstone: true,
   dsn: env.SENTRY_DSN,
   debug: false, // If `true`, Sentry will try to print out useful debugging information if something goes wrong with sending the event. Set it to `false` in production
   environment: env.ENV,


### PR DESCRIPTION
## Summary

- enable Sentry tombstone capture for native Android crashes
- provide additional diagnostics for crashes such as APP-T5KH

## Test plan

No manual testing; configuration-only change.