### PR TITLE
Remove native Reanimated dependency array

### DIFF
--- a/src/screens/Profile/Header/GrowableBanner.tsx
+++ b/src/screens/Profile/Header/GrowableBanner.tsx
@@ -229,7 +229,6 @@ function useShouldAnimateSpinner({
         scheduleOnRN(setIsOverscrolled, value)
       }
     },
-    [scrollY],
   )
 
   const [isAnimating, setIsAnimating] = useState(isFetching)


### PR DESCRIPTION
## Summary

Remove the dependency array from the profile header's animated reaction. Reanimated tracks the captured shared value through its worklet on native, and warns that explicit dependencies are web-only.

## Test plan

- Open a profile in the native app and confirm the Reanimated dependency warning is absent.
- Pull down to refresh and confirm the profile header spinner still animates as expected.