### PR TITLE
Handle push token fetch failures

### DIFF
--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -120,7 +120,11 @@ async function getPushToken() {
   const granted = (await Notifications.getPermissionsAsync()).granted
   notyLogger.debug(`getPushToken`, {granted})
   if (granted) {
-    return Notifications.getDevicePushTokenAsync()
+    try {
+      return await Notifications.getDevicePushTokenAsync()
+    } catch (error) {
+      notyLogger.debug(`getPushToken: failed`, {safeMessage: error})
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- catch failures while fetching a native push token
- log the failure at debug level and continue without a token
- prevent expected FCM failures from becoming unhandled promise rejections

## Test plan

Not manually tested; reproducing this requires FCM token acquisition to fail.