### PR TITLE
APP-3049: Fix scrolling in oversized Android sheets

### DIFF
--- a/modules/bottom-sheet/src/BottomSheetNativeComponent.tsx
+++ b/modules/bottom-sheet/src/BottomSheetNativeComponent.tsx
@@ -182,6 +182,11 @@ function BottomSheetNativeComponentInner({
           },
           maxHeight != null && {maxHeight},
           Platform.OS === 'android' && {
+            /*
+             * The native canvas is sized after the first layout. Allow content
+             * measured without a height constraint to shrink to that canvas.
+             */
+            flexShrink: 1,
             borderTopLeftRadius: cornerRadius,
             borderTopRightRadius: cornerRadius,
             overflow: 'hidden',


### PR DESCRIPTION
When the Android account switcher contains more accounts than fit on screen, the list is clipped and cannot scroll. Allow the bottom-sheet content wrapper to shrink to the native canvas height so the ScrollView has a bounded viewport.

#11396 changed Android sheets to receive their canvas size after the initial layout. In a reduced reproduction using the bundled Yoga and default flags, a 1,200-point list retains a 1,200-point viewport after the canvas becomes 800 points tall. Adding Android-only `flexShrink: 1` restores a viewport of 800 points and 400 points of scroll range; short content retains its natural height.

Fixes APP-3049.

https://github.com/user-attachments/assets/544de787-d9ea-47fe-81fb-3a283b3d4dc1




Device testing:

- [x] On Android, open the account switcher with enough accounts to exceed the screen height. Confirm all accounts and “Add account” can be reached by scrolling.
- [x] Open a sheet with a short account list. Confirm it stays at its natural height and can still be dismissed.
- [ ] Check a sheet with a text input: open and dismiss the keyboard, then rotate the device. Confirm the sheet resizes and its content remains reachable.
