### PR TITLE
Persist draft media before server save

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -1253,22 +1253,6 @@
       "count": 1
     }
   },
-  "src/view/com/composer/drafts/state/queries.ts": {
-    "typescript/no-explicit-any": {
-      "count": 2
-    },
-    "typescript/no-floating-promises": {
-      "count": 2
-    },
-    "typescript/no-unsafe-member-access": {
-      "count": 2
-    }
-  },
-  "src/view/com/composer/drafts/state/storage.ts": {
-    "typescript/require-await": {
-      "count": 2
-    }
-  },
   "src/view/com/composer/photos/Gallery.tsx": {
     "typescript/no-floating-promises": {
       "count": 1

--- a/src/state/gallery.ts
+++ b/src/state/gallery.ts
@@ -35,8 +35,8 @@ export type ImageSource = ImageMeta & {
 type ComposerImageBase = {
   alt: string
   source: ImageSource
-  /** Original localRef path from draft, if editing an existing draft. Used to reuse the same storage key. */
-  localRefPath?: string
+  /** Stable attachment ref used for every draft-save retry. */
+  localRefPath: string
 }
 type ComposerImageWithoutTransformation = ComposerImageBase & {
   transformed?: undefined
@@ -65,6 +65,7 @@ export async function createComposerImage(
 ): Promise<ComposerImageWithoutTransformation> {
   return {
     alt: '',
+    localRefPath: `image:${nanoid()}`,
     source: {
       id: nanoid(),
       // Copy to cache to ensure file survives OS temporary file cleanup
@@ -89,6 +90,7 @@ export function createInitialImages(
   return uris.map(({uri, width, height, altText = ''}) => {
     return {
       alt: altText,
+      localRefPath: `image:${nanoid()}`,
       source: {
         id: nanoid(),
         path: uri,
@@ -108,6 +110,7 @@ export async function pasteImage(
 
   return {
     alt: '',
+    localRefPath: `image:${nanoid()}`,
     source: {
       id: nanoid(),
       path: uri,
@@ -134,6 +137,7 @@ export async function cropImage(img: ComposerImage): Promise<ComposerImage> {
 
     return {
       alt: img.alt,
+      localRefPath: img.localRefPath,
       source: source,
       transformed: {
         path: await moveIfNecessary(cropped.path),
@@ -162,7 +166,11 @@ export async function manipulateImage(
       return img
     }
 
-    return {alt: img.alt, source: img.source}
+    return {
+      alt: img.alt,
+      localRefPath: img.localRefPath,
+      source: img.source,
+    }
   }
 
   const source = img.source
@@ -172,6 +180,7 @@ export async function manipulateImage(
 
   return {
     alt: img.alt,
+    localRefPath: img.localRefPath,
     source: img.source,
     transformed: {
       path: await moveIfNecessary(result.uri),
@@ -187,7 +196,11 @@ export function resetImageManipulation(
   img: ComposerImage,
 ): ComposerImageWithoutTransformation {
   if (img.transformed !== undefined) {
-    return {alt: img.alt, source: img.source}
+    return {
+      alt: img.alt,
+      localRefPath: img.localRefPath,
+      source: img.source,
+    }
   }
 
   return img

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -572,6 +572,7 @@ export const ComposePost = ({
             asset,
             abortController,
             telemetry,
+            localRefPath: videoInfo.localRefPath,
           },
         })
 

--- a/src/view/com/composer/drafts/state/api.test.ts
+++ b/src/view/com/composer/drafts/state/api.test.ts
@@ -1,0 +1,102 @@
+import {RichText} from '@bsky/sdk/richtext'
+
+import {type ComposerState} from '#/view/com/composer/state/composer'
+import {createVideoState, videoReducer} from '#/view/com/composer/state/video'
+import {composerStateToDraft} from './api'
+
+jest.mock('#/lib/api/resolve', () => ({resolveLink: jest.fn()}))
+jest.mock('#/lib/media/manip', () => ({getImageDim: jest.fn()}))
+jest.mock('#/state/queries/threadgate/util', () => ({
+  threadgateAllowUISettingToAllowRecordValue: jest.fn(() => []),
+}))
+jest.mock('#/view/com/composer/state/composer', () => ({
+  LEGACY_IMAGES_EMBED_MAX: 4,
+}))
+jest.mock('./storage', () => ({mediaExists: jest.fn()}))
+
+jest.mock('#/analytics/identifiers', () => ({
+  getDeviceId: jest.fn(() => 'device-id'),
+}))
+
+jest.mock('#/lib/deviceName', () => ({
+  getDeviceName: jest.fn(() => 'Test device'),
+}))
+
+jest.mock('./logger', () => ({
+  logger: {debug: jest.fn(), error: jest.fn(), warn: jest.fn()},
+}))
+
+function composerState(
+  media: ComposerState['thread']['posts'][number]['embed']['media'],
+): ComposerState {
+  return {
+    activePostIndex: 0,
+    mutableNeedsFocusActive: false,
+    isDirty: true,
+    thread: {
+      posts: [
+        {
+          id: 'post',
+          richtext: new RichText({text: ''}),
+          shortenedGraphemeLength: 0,
+          labels: [],
+          embed: {media, quote: undefined, link: undefined},
+        },
+      ],
+      postgate: {
+        $type: 'app.bsky.feed.postgate',
+        post: 'at://did:plc:test/app.bsky.feed.post/test',
+        createdAt: new Date(0).toISOString(),
+      },
+      threadgate: [],
+    },
+  } as ComposerState
+}
+
+test('image serialization reuses the ref assigned when the image entered the composer', async () => {
+  const image = {
+    alt: '',
+    localRefPath: 'image:assigned-on-entry',
+    source: {
+      id: 'source',
+      path: 'file:///image.jpg',
+      width: 100,
+      height: 100,
+      mime: 'image/jpeg',
+    },
+  }
+  const state = composerState({type: 'images', images: [image]})
+
+  const first = await composerStateToDraft({} as never, state)
+  const second = await composerStateToDraft({} as never, state)
+
+  expect(Array.from(first.localRefPaths.keys())).toEqual([image.localRefPath])
+  expect(Array.from(second.localRefPaths.keys())).toEqual([image.localRefPath])
+})
+
+test('video serialization reuses the ref assigned when the video entered the composer', async () => {
+  const abortController = new AbortController()
+  const initial = createVideoState(
+    {uri: 'file:///video.mp4', mimeType: 'video/mp4'} as never,
+    abortController,
+    {} as never,
+  )
+  const video = videoReducer(initial, {
+    type: 'compressing_to_uploading',
+    video: {
+      uri: 'file:///compressed.mp4',
+      mimeType: 'video/mp4',
+    } as never,
+    compressionSkipped: false,
+    signal: abortController.signal,
+  })
+  const state = composerState({type: 'video', video})
+
+  const first = await composerStateToDraft({} as never, state)
+  const second = await composerStateToDraft({} as never, state)
+
+  expect(Array.from(first.localRefPaths.keys())).toEqual([initial.localRefPath])
+  expect(Array.from(second.localRefPaths.keys())).toEqual([
+    initial.localRefPath,
+  ])
+})

--- a/src/view/com/composer/drafts/state/api.ts
+++ b/src/view/com/composer/drafts/state/api.ts
@@ -9,7 +9,6 @@ import {nanoid} from 'nanoid/non-secure'
 import {type LinkResolvers, resolveLink} from '#/lib/api/resolve'
 import {getDeviceName} from '#/lib/deviceName'
 import {getImageDim} from '#/lib/media/manip'
-import {mimeToExt} from '#/lib/media/video/util'
 import {shortenLinks} from '#/lib/strings/rich-text-manip'
 import {type ComposerImage} from '#/state/gallery'
 import {threadgateAllowUISettingToAllowRecordValue} from '#/state/queries/threadgate/util'
@@ -173,8 +172,7 @@ async function postDraftToServerPost(
 
 /**
  * Serialize images to server format with localRef paths.
- * Reuses existing localRefPath if present (when editing a draft),
- * otherwise generates a new one.
+ * Uses the stable localRefPath assigned when the attachment entered the composer.
  */
 function serializeImages(
   images: ComposerImage[],
@@ -182,16 +180,10 @@ function serializeImages(
 ): app.bsky.draft.defs.DraftEmbedGalleryItems {
   return images.map(image => {
     const sourcePath = image.transformed?.path || image.source.path
-    // Reuse existing localRefPath if present (editing draft), otherwise generate new
-    const isReusing = !!image.localRefPath
-    const localRefPath = image.localRefPath || `image:${nanoid()}`
+    const localRefPath = image.localRefPath
     localRefPaths.set(localRefPath, sourcePath)
 
-    logger.debug('serializing image', {
-      localRefPath,
-      isReusing,
-      sourcePath,
-    })
+    logger.debug('serializing image', {localRefPath})
 
     return {
       $type: 'app.bsky.draft.defs#draftEmbedImage' as const,
@@ -217,10 +209,7 @@ async function serializeVideo(
     return undefined
   }
 
-  // Encode mime type in the path for restoration
-  const mimeType = videoState.video.mimeType || 'video/mp4'
-  const ext = mimeToExt(mimeType)
-  const localRefPath = `video:${mimeType}:${nanoid()}.${ext}`
+  const localRefPath = videoState.localRefPath
   localRefPaths.set(localRefPath, videoState.video.uri)
 
   // Read caption file contents as text

--- a/src/view/com/composer/drafts/state/mediaLock.ts
+++ b/src/view/com/composer/drafts/state/mediaLock.ts
@@ -1,0 +1,37 @@
+let queue: Promise<void> = Promise.resolve()
+const protectedRefs = new Map<string, number>()
+
+/** Serialize media lifecycle operations so a sweep cannot race a save touch. */
+export function serializeDraftMediaOperation<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  const result = queue.then(operation, operation)
+  queue = result.then(
+    () => undefined,
+    () => undefined,
+  )
+  return result
+}
+
+/** Protect refs synchronously while their pending metadata touch waits on the lock. */
+export function prepareDraftMediaOperation<T>(
+  refs: Iterable<string>,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const protectedByOperation = Array.from(new Set(refs))
+  for (const ref of protectedByOperation) {
+    protectedRefs.set(ref, (protectedRefs.get(ref) ?? 0) + 1)
+  }
+
+  return serializeDraftMediaOperation(operation).finally(() => {
+    for (const ref of protectedByOperation) {
+      const count = protectedRefs.get(ref) ?? 0
+      if (count <= 1) protectedRefs.delete(ref)
+      else protectedRefs.set(ref, count - 1)
+    }
+  })
+}
+
+export function isDraftMediaRefProtected(localRefPath: string): boolean {
+  return protectedRefs.has(localRefPath)
+}

--- a/src/view/com/composer/drafts/state/queries.test.tsx
+++ b/src/view/com/composer/drafts/state/queries.test.tsx
@@ -1,0 +1,113 @@
+import {type PropsWithChildren} from 'react'
+import {
+  notifyManager,
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query'
+import {act, renderHook} from '@testing-library/react-native'
+
+import {useAppviewClient, useChatClient} from '#/state/session'
+import {type ComposerState} from '#/view/com/composer/state/composer'
+import {composerStateToDraft} from './api'
+import {useSaveDraftMutation} from './queries'
+import * as storage from './storage'
+
+jest.mock('#/analytics', () => ({
+  useAnalytics: jest.fn(),
+}))
+
+jest.mock('#/state/session', () => ({
+  useAppviewClient: jest.fn(),
+  useChatClient: jest.fn(),
+}))
+
+jest.mock('./api', () => ({
+  composerStateToDraft: jest.fn(),
+  draftViewToSummary: jest.fn(),
+}))
+
+jest.mock('./logger', () => ({
+  logger: {
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}))
+
+jest.mock('./storage', () => ({
+  deleteMediaFromLocal: jest.fn(),
+  ensureMediaCachePopulated: jest.fn(),
+  loadMediaFromLocal: jest.fn(),
+  mediaExists: jest.fn(),
+  saveMediaToLocal: jest.fn(),
+}))
+
+const composerState = {} as ComposerState
+const localRefPath = 'image:local-ref'
+const sourcePath = 'file:///cache/bsky-composer/source'
+
+function setup() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {gcTime: Infinity, retry: false},
+      mutations: {gcTime: Infinity, retry: false},
+    },
+  })
+  const appviewClient = {call: jest.fn().mockResolvedValue({id: 'draft-id'})}
+
+  jest.mocked(useAppviewClient).mockReturnValue(appviewClient as never)
+  jest.mocked(useChatClient).mockReturnValue({} as never)
+  jest.mocked(composerStateToDraft).mockResolvedValue({
+    draft: {} as never,
+    localRefPaths: new Map([[localRefPath, sourcePath]]),
+  })
+  jest.mocked(storage.ensureMediaCachePopulated).mockResolvedValue()
+  jest.mocked(storage.mediaExists).mockReturnValue(false)
+  jest.mocked(storage.saveMediaToLocal).mockResolvedValue()
+
+  const wrapper = ({children}: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+  const hook = renderHook(() => useSaveDraftMutation(), {wrapper})
+
+  return {appviewClient, hook}
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+beforeAll(() => {
+  notifyManager.setNotifyFunction(callback => {
+    act(callback)
+  })
+})
+
+describe('useSaveDraftMutation', () => {
+  it('persists new media before creating the server draft', async () => {
+    const {appviewClient, hook} = setup()
+
+    await act(() => hook.result.current.mutateAsync({composerState}))
+
+    expect(storage.ensureMediaCachePopulated).toHaveBeenCalledTimes(1)
+    expect(storage.saveMediaToLocal).toHaveBeenCalledWith(
+      localRefPath,
+      sourcePath,
+    )
+    expect(
+      jest.mocked(storage.saveMediaToLocal).mock.invocationCallOrder[0],
+    ).toBeLessThan(appviewClient.call.mock.invocationCallOrder[0])
+  })
+
+  it('does not create a server draft when local media cannot be persisted', async () => {
+    const {appviewClient, hook} = setup()
+    const error = new Error('Source media is missing')
+    jest.mocked(storage.saveMediaToLocal).mockRejectedValue(error)
+
+    await expect(
+      act(() => hook.result.current.mutateAsync({composerState})),
+    ).rejects.toBe(error)
+
+    expect(appviewClient.call).not.toHaveBeenCalled()
+  })
+})

--- a/src/view/com/composer/drafts/state/queries.test.tsx
+++ b/src/view/com/composer/drafts/state/queries.test.tsx
@@ -6,19 +6,28 @@ import {
 } from '@tanstack/react-query'
 import {act, renderHook} from '@testing-library/react-native'
 
-import {useAppviewClient, useChatClient} from '#/state/session'
+import {useAppviewClient, useChatClient, useSession} from '#/state/session'
 import {type ComposerState} from '#/view/com/composer/state/composer'
+import {app} from '#/lexicons'
 import {composerStateToDraft} from './api'
-import {useSaveDraftMutation} from './queries'
+import {
+  fetchCompleteDraftInventory,
+  reconcileCompleteInventory,
+  saveDraft,
+  useSaveDraftMutation,
+} from './queries'
+import {reconcileDraftMedia} from './reconciliation'
 import * as storage from './storage'
 
-jest.mock('#/analytics', () => ({
-  useAnalytics: jest.fn(),
+jest.mock('#/analytics', () => ({useAnalytics: jest.fn()}))
+jest.mock('#/analytics/identifiers', () => ({
+  getDeviceId: jest.fn(() => 'device-id'),
 }))
 
 jest.mock('#/state/session', () => ({
   useAppviewClient: jest.fn(),
   useChatClient: jest.fn(),
+  useSession: jest.fn(),
 }))
 
 jest.mock('./api', () => ({
@@ -27,24 +36,32 @@ jest.mock('./api', () => ({
 }))
 
 jest.mock('./logger', () => ({
-  logger: {
-    debug: jest.fn(),
-    error: jest.fn(),
-    warn: jest.fn(),
-  },
+  logger: {debug: jest.fn(), error: jest.fn(), warn: jest.fn()},
+}))
+
+jest.mock('./reconciliation', () => ({
+  reconcileDraftMedia: jest.fn().mockResolvedValue({
+    migrated: 0,
+    retained: 0,
+    deleted: 0,
+  }),
 }))
 
 jest.mock('./storage', () => ({
   deleteMediaFromLocal: jest.fn(),
   ensureMediaCachePopulated: jest.fn(),
+  getMediaMetadata: jest.fn(),
+  listMediaArtifacts: jest.fn(),
   loadMediaFromLocal: jest.fn(),
   mediaExists: jest.fn(),
   saveMediaToLocal: jest.fn(),
+  touchMediaMetadata: jest.fn(),
 }))
 
 const composerState = {} as ComposerState
-const localRefPath = 'image:local-ref'
+const localRefPath = 'image:stable-local-ref'
 const sourcePath = 'file:///cache/bsky-composer/source'
+const accountDid = 'did:plc:alice'
 
 function setup() {
   const queryClient = new QueryClient({
@@ -53,10 +70,21 @@ function setup() {
       mutations: {gcTime: Infinity, retry: false},
     },
   })
-  const appviewClient = {call: jest.fn().mockResolvedValue({id: 'draft-id'})}
+  const appviewClient = {
+    did: accountDid,
+    call: jest.fn(method => {
+      if (method === app.bsky.draft.getDrafts) {
+        return Promise.resolve({drafts: []})
+      }
+      return Promise.resolve({id: 'draft-id'})
+    }),
+  }
 
   jest.mocked(useAppviewClient).mockReturnValue(appviewClient as never)
   jest.mocked(useChatClient).mockReturnValue({} as never)
+  jest.mocked(useSession).mockReturnValue({
+    currentAccount: {did: accountDid},
+  } as never)
   jest.mocked(composerStateToDraft).mockResolvedValue({
     draft: {} as never,
     localRefPaths: new Map([[localRefPath, sourcePath]]),
@@ -64,6 +92,7 @@ function setup() {
   jest.mocked(storage.ensureMediaCachePopulated).mockResolvedValue()
   jest.mocked(storage.mediaExists).mockReturnValue(false)
   jest.mocked(storage.saveMediaToLocal).mockResolvedValue()
+  jest.mocked(storage.touchMediaMetadata).mockResolvedValue()
 
   const wrapper = ({children}: PropsWithChildren) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
@@ -75,6 +104,11 @@ function setup() {
 
 beforeEach(() => {
   jest.clearAllMocks()
+  jest.mocked(reconcileDraftMedia).mockResolvedValue({
+    migrated: 0,
+    retained: 0,
+    deleted: 0,
+  })
 })
 
 beforeAll(() => {
@@ -84,30 +118,149 @@ beforeAll(() => {
 })
 
 describe('useSaveDraftMutation', () => {
-  it('persists new media before creating the server draft', async () => {
+  test('persists and marks media pending before the server write', async () => {
     const {appviewClient, hook} = setup()
 
     await act(() => hook.result.current.mutateAsync({composerState}))
 
-    expect(storage.ensureMediaCachePopulated).toHaveBeenCalledTimes(1)
     expect(storage.saveMediaToLocal).toHaveBeenCalledWith(
       localRefPath,
       sourcePath,
+      {
+        accountDid,
+        deviceId: 'device-id',
+        state: 'pending',
+      },
     )
+    const createCallOrder = appviewClient.call.mock.invocationCallOrder.find(
+      (_, index) =>
+        appviewClient.call.mock.calls[index][0] === app.bsky.draft.createDraft,
+    )!
     expect(
       jest.mocked(storage.saveMediaToLocal).mock.invocationCallOrder[0],
-    ).toBeLessThan(appviewClient.call.mock.invocationCallOrder[0])
+    ).toBeLessThan(createCallOrder)
   })
 
-  it('does not create a server draft when local media cannot be persisted', async () => {
-    const {appviewClient, hook} = setup()
-    const error = new Error('Source media is missing')
+  test('does not write the server draft when durable persistence fails', async () => {
+    setup()
+    const error = new Error('source media is missing')
     jest.mocked(storage.saveMediaToLocal).mockRejectedValue(error)
+    const client = {call: jest.fn()}
+
+    await expect(
+      saveDraft({
+        client: client as never,
+        chatClient: {} as never,
+        accountDid,
+        composerState,
+      }),
+    ).rejects.toBe(error)
+
+    expect(client.call).not.toHaveBeenCalled()
+  })
+
+  test('reuses the same durable ref across retries', async () => {
+    const {hook} = setup()
+    jest
+      .mocked(storage.mediaExists)
+      .mockReturnValueOnce(false)
+      .mockReturnValue(true)
+
+    await act(() => hook.result.current.mutateAsync({composerState}))
+    await act(() => hook.result.current.mutateAsync({composerState}))
+
+    expect(composerStateToDraft).toHaveBeenCalledTimes(2)
+    expect(storage.saveMediaToLocal).toHaveBeenCalledTimes(1)
+    expect(storage.touchMediaMetadata).toHaveBeenCalledWith(
+      localRefPath,
+      expect.objectContaining({state: 'pending'}),
+    )
+  })
+
+  test('leaves pending media intact after an ambiguous server failure', async () => {
+    setup()
+    const ambiguousError = new Error('Connection closed without a response')
+    const events: string[] = []
+    jest.mocked(storage.saveMediaToLocal).mockImplementation(() => {
+      events.push('pending-media-persisted')
+      return Promise.resolve()
+    })
+    const client = {
+      call: jest.fn(() => {
+        events.push('server-write')
+        return Promise.reject(ambiguousError)
+      }),
+    }
+
+    await expect(
+      saveDraft({
+        client: client as never,
+        chatClient: {} as never,
+        accountDid,
+        composerState,
+      }),
+    ).rejects.toBe(ambiguousError)
+
+    expect(events).toEqual(['pending-media-persisted', 'server-write'])
+    expect(storage.deleteMediaFromLocal).not.toHaveBeenCalled()
+    expect(storage.touchMediaMetadata).not.toHaveBeenCalledWith(
+      localRefPath,
+      expect.objectContaining({state: 'committed'}),
+    )
+  })
+
+  test('does not report a successful server save as failed when metadata commit fails', async () => {
+    const {hook} = setup()
+    jest
+      .mocked(storage.touchMediaMetadata)
+      .mockRejectedValue(new Error('metadata write failed'))
 
     await expect(
       act(() => hook.result.current.mutateAsync({composerState})),
-    ).rejects.toBe(error)
+    ).resolves.toMatchObject({draftId: 'draft-id'})
+  })
+})
 
-    expect(appviewClient.call).not.toHaveBeenCalled()
+describe('complete draft inventory', () => {
+  test('fetches every page before returning', async () => {
+    const first = {id: 'first'} as never
+    const second = {id: 'second'} as never
+    const client = {
+      call: jest
+        .fn()
+        .mockResolvedValueOnce({drafts: [first], cursor: 'next'})
+        .mockResolvedValueOnce({drafts: [second]}),
+    }
+
+    await expect(fetchCompleteDraftInventory(client as never)).resolves.toEqual(
+      [first, second],
+    )
+    expect(client.call).toHaveBeenCalledTimes(2)
+  })
+
+  test('does not inventory or sweep after the active account changes', async () => {
+    const client = {did: 'did:plc:bob', call: jest.fn()}
+
+    await expect(
+      reconcileCompleteInventory(client as never, accountDid),
+    ).rejects.toThrow('Account changed during draft inventory')
+    expect(client.call).not.toHaveBeenCalled()
+    expect(reconcileDraftMedia).not.toHaveBeenCalled()
+  })
+
+  test('does not reconcile after a partial inventory fails', async () => {
+    const error = new Error('page two failed')
+    const client = {
+      did: accountDid,
+      call: jest
+        .fn()
+        .mockResolvedValueOnce({drafts: [], cursor: 'next'})
+        .mockRejectedValueOnce(error),
+    }
+
+    await expect(
+      reconcileCompleteInventory(client as never, accountDid),
+    ).rejects.toBe(error)
+    expect(reconcileDraftMedia).not.toHaveBeenCalled()
   })
 })

--- a/src/view/com/composer/drafts/state/queries.ts
+++ b/src/view/com/composer/drafts/state/queries.ts
@@ -1,3 +1,4 @@
+import {type Client} from '@atproto/lex'
 import {
   useInfiniteQuery,
   useMutation,
@@ -6,7 +7,7 @@ import {
 
 import {isNetworkError} from '#/lib/strings/errors'
 import {matchXrpcError} from '#/lib/xrpc-error'
-import {useAppviewClient, useChatClient} from '#/state/session'
+import {useAppviewClient, useChatClient, useSession} from '#/state/session'
 import {type ComposerState} from '#/view/com/composer/state/composer'
 import {useAnalytics} from '#/analytics'
 import {getDeviceId} from '#/analytics/identifiers'
@@ -14,28 +15,100 @@ import {app} from '#/lexicons'
 import * as bsky from '#/types/bsky'
 import {composerStateToDraft, draftViewToSummary} from './api'
 import {logger} from './logger'
+import {
+  prepareDraftMediaOperation,
+  serializeDraftMediaOperation,
+} from './mediaLock'
+import {reconcileDraftMedia} from './reconciliation'
 import * as storage from './storage'
 
-const DRAFTS_QUERY_KEY = ['drafts']
+function draftsQueryKey(accountDid: string | undefined) {
+  return ['drafts', accountDid]
+}
 
-/**
- * Hook to list all drafts for the current account
- */
+/** Fetch every server page before returning an authoritative inventory. */
+export async function fetchCompleteDraftInventory(
+  client: Client,
+  expectedAccountDid?: string,
+): Promise<app.bsky.draft.defs.DraftView[]> {
+  const drafts: app.bsky.draft.defs.DraftView[] = []
+  const seenCursors = new Set<string>()
+  let cursor: string | undefined
+
+  do {
+    if (expectedAccountDid && client.did !== expectedAccountDid) {
+      throw new Error('Account changed during draft inventory')
+    }
+    const data = await client.call(app.bsky.draft.getDrafts, {
+      cursor,
+      limit: 100,
+    })
+    if (expectedAccountDid && client.did !== expectedAccountDid) {
+      throw new Error('Account changed during draft inventory')
+    }
+    drafts.push(...data.drafts)
+    cursor = data.cursor || undefined
+    if (cursor) {
+      if (seenCursors.has(cursor)) {
+        throw new Error('Draft inventory returned a repeated cursor')
+      }
+      seenCursors.add(cursor)
+    }
+  } while (cursor)
+
+  return drafts
+}
+
+export async function reconcileCompleteInventory(
+  client: Client,
+  accountDid: string,
+) {
+  const drafts = await fetchCompleteDraftInventory(client, accountDid)
+  return reconcileDraftMedia({drafts, accountDid})
+}
+
+const scheduledReconciliations = new Map<string, Promise<void>>()
+
+function scheduleDraftMediaReconciliation(client: Client, accountDid: string) {
+  if (scheduledReconciliations.has(accountDid)) return
+
+  const operation = reconcileCompleteInventory(client, accountDid)
+    .then(() => undefined)
+    .catch(error => {
+      if (!isNetworkError(error)) {
+        logger.error('Failed to reconcile draft media', {safeMessage: error})
+      }
+    })
+    .finally(() => {
+      scheduledReconciliations.delete(accountDid)
+    })
+  scheduledReconciliations.set(accountDid, operation)
+}
+
+/** Hook to list all drafts for the current account. */
 export function useDraftsQuery() {
   const client = useAppviewClient()
+  const {currentAccount} = useSession()
   const ax = useAnalytics()
+  const accountDid = currentAccount?.did
 
   return useInfiniteQuery({
-    queryKey: DRAFTS_QUERY_KEY,
-    queryFn: async ({pageParam}) => {
-      // Ensure media cache is populated before checking which media exists
-      await storage.ensureMediaCachePopulated()
-      const data = await client.call(app.bsky.draft.getDrafts, {
-        cursor: pageParam,
-      })
+    queryKey: draftsQueryKey(accountDid),
+    queryFn: async () => {
+      if (!accountDid) throw new Error('Cannot load drafts without an account')
+
+      const drafts = await fetchCompleteDraftInventory(client, accountDid)
+      try {
+        await reconcileDraftMedia({drafts, accountDid})
+      } catch (error) {
+        logger.error('Failed to reconcile draft media after inventory', {
+          safeMessage: error,
+        })
+      }
+
       return {
-        cursor: data.cursor,
-        drafts: data.drafts.map(view =>
+        cursor: undefined,
+        drafts: drafts.map(view =>
           draftViewToSummary({
             view,
             analytics: ax,
@@ -44,69 +117,49 @@ export function useDraftsQuery() {
       }
     },
     initialPageParam: undefined as string | undefined,
-    getNextPageParam: page => page.cursor || undefined,
+    getNextPageParam: () => undefined,
+    enabled: !!accountDid,
   })
 }
 
-/**
- * Load a draft's local media for editing.
- * Takes the full Draft object (from DraftSummary) to avoid re-fetching.
- */
 export async function loadDraftMedia(
   draft: app.bsky.draft.defs.Draft,
-): Promise<{
-  loadedMedia: Map<string, string>
-}> {
-  // Load local media files
+): Promise<{loadedMedia: Map<string, string>}> {
   const loadedMedia = new Map<string, string>()
-
-  // can't load media from another device
   if (draft.deviceId && draft.deviceId !== getDeviceId()) {
     return {loadedMedia}
   }
 
   for (const post of draft.posts) {
-    // Load images
-    if (post.embedImages) {
-      for (const img of post.embedImages) {
-        try {
-          const url = await storage.loadMediaFromLocal(img.localRef.path)
-          loadedMedia.set(img.localRef.path, url)
-        } catch (e: any) {
-          logger.error('Failed to load draft image', {
-            path: img.localRef.path,
-            safeMessage: e.message,
-          })
-        }
+    for (const img of post.embedImages ?? []) {
+      try {
+        loadedMedia.set(
+          img.localRef.path,
+          await storage.loadMediaFromLocal(img.localRef.path),
+        )
+      } catch (error) {
+        logger.error('Failed to load draft image', {safeMessage: error})
       }
     }
-    // Load gallery
-    if (post.embedGallery) {
-      for (const item of post.embedGallery.items) {
-        if (!bsky.isType(app.bsky.draft.defs.draftEmbedImage, item)) continue
-        try {
-          const url = await storage.loadMediaFromLocal(item.localRef.path)
-          loadedMedia.set(item.localRef.path, url)
-        } catch (e) {
-          logger.error('Failed to load draft gallery image', {
-            path: item.localRef.path,
-            safeMessage: e instanceof Error ? e.message : String(e),
-          })
-        }
+    for (const item of post.embedGallery?.items ?? []) {
+      if (!bsky.isType(app.bsky.draft.defs.draftEmbedImage, item)) continue
+      try {
+        loadedMedia.set(
+          item.localRef.path,
+          await storage.loadMediaFromLocal(item.localRef.path),
+        )
+      } catch (error) {
+        logger.error('Failed to load draft gallery image', {safeMessage: error})
       }
     }
-    // Load videos
-    if (post.embedVideos) {
-      for (const vid of post.embedVideos) {
-        try {
-          const url = await storage.loadMediaFromLocal(vid.localRef.path)
-          loadedMedia.set(vid.localRef.path, url)
-        } catch (e: any) {
-          logger.error('Failed to load draft video', {
-            path: vid.localRef.path,
-            safeMessage: e.message,
-          })
-        }
+    for (const vid of post.embedVideos ?? []) {
+      try {
+        loadedMedia.set(
+          vid.localRef.path,
+          await storage.loadMediaFromLocal(vid.localRef.path),
+        )
+      } catch (error) {
+        logger.error('Failed to load draft video', {safeMessage: error})
       }
     }
   }
@@ -114,18 +167,65 @@ export async function loadDraftMedia(
   return {loadedMedia}
 }
 
-/**
- * Hook to save a draft.
- *
- * New media is copied to durable local storage before the server write. Composer
- * media lives in temporary cache directories that the OS may clear at any time,
- * so a server draft must not be created until all of its local refs are safe.
- * Destructive cleanup of replaced media still happens only after server success.
- */
+export async function saveDraft({
+  client,
+  chatClient,
+  accountDid,
+  composerState,
+  existingDraftId,
+}: {
+  client: Client
+  chatClient: Client
+  accountDid: string
+  composerState: ComposerState
+  existingDraftId?: string
+}): Promise<{draftId: string; localRefPaths: Map<string, string>}> {
+  const {draft, localRefPaths} = await composerStateToDraft(
+    {appviewClient: client, chatClient},
+    composerState,
+  )
+
+  logger.debug('saving draft', {
+    existingDraftId,
+    localRefPathCount: localRefPaths.size,
+  })
+
+  await prepareDraftMediaOperation(localRefPaths.keys(), async () => {
+    await storage.ensureMediaCachePopulated()
+    for (const [localRefPath, sourcePath] of localRefPaths) {
+      const ownership = {
+        accountDid,
+        deviceId: getDeviceId() ?? 'unknown',
+        state: 'pending' as const,
+      }
+      if (storage.mediaExists(localRefPath)) {
+        await storage.touchMediaMetadata(localRefPath, ownership)
+      } else {
+        await storage.saveMediaToLocal(localRefPath, sourcePath, ownership)
+      }
+    }
+  })
+
+  let draftId: string
+  if (existingDraftId) {
+    await client.call(app.bsky.draft.updateDraft, {
+      draft: {id: existingDraftId, draft},
+    })
+    draftId = existingDraftId
+  } else {
+    const data = await client.call(app.bsky.draft.createDraft, {draft})
+    draftId = data.id
+  }
+
+  return {draftId, localRefPaths}
+}
+
 export function useSaveDraftMutation() {
   const client = useAppviewClient()
   const chatClient = useChatClient()
+  const {currentAccount} = useSession()
   const queryClient = useQueryClient()
+  const accountDid = currentAccount?.did
 
   return useMutation({
     mutationFn: async ({
@@ -134,156 +234,77 @@ export function useSaveDraftMutation() {
     }: {
       composerState: ComposerState
       existingDraftId?: string
-    }): Promise<{
-      draftId: string
-      localRefPaths: Map<string, string>
-      originalLocalRefs: Set<string> | undefined
-    }> => {
-      // Convert composer state to server draft format
-      const {draft: apiDraft, localRefPaths} = await composerStateToDraft(
-        {appviewClient: client, chatClient},
+    }): Promise<{draftId: string; localRefPaths: Map<string, string>}> => {
+      if (!accountDid) throw new Error('Cannot save a draft without an account')
+      return saveDraft({
+        client,
+        chatClient,
+        accountDid,
         composerState,
-      )
-      const draft = apiDraft
-
-      logger.debug('saving draft', {
         existingDraftId,
-        localRefPathCount: localRefPaths.size,
-        originalLocalRefCount: composerState.originalLocalRefs?.size ?? 0,
       })
-
-      /*
-       * Persist media before the network request so a successful server draft
-       * never points at a temporary file that disappeared before we copied it.
-       */
-      if (localRefPaths.size > 0) {
-        await storage.ensureMediaCachePopulated()
-        for (const [localRefPath, sourcePath] of localRefPaths) {
-          // Reused refs from an existing draft are already in durable storage.
-          if (!storage.mediaExists(localRefPath)) {
-            logger.debug('saving new media file', {localRefPath})
-            await storage.saveMediaToLocal(localRefPath, sourcePath)
-          } else {
-            logger.debug('skipping existing media file', {localRefPath})
-          }
-        }
-      }
-
-      // Update/create the server draft only after its local media is safe.
-      let draftId: string
-      if (existingDraftId) {
-        // Update existing draft
-        logger.debug('updating existing draft on server', {
-          draftId: existingDraftId,
-        })
-        await client.call(app.bsky.draft.updateDraft, {
-          draft: {
-            id: existingDraftId,
-            draft,
-          },
-        })
-        draftId = existingDraftId
-      } else {
-        // Create new draft
-        logger.debug('creating new draft on server')
-        const data = await client.call(app.bsky.draft.createDraft, {draft})
-        draftId = data.id
-        logger.debug('created new draft', {draftId})
-      }
-
-      // Return data needed for onSuccess
-      return {
-        draftId,
-        localRefPaths,
-        originalLocalRefs: composerState.originalLocalRefs,
-      }
     },
-    onSuccess: async ({draftId, localRefPaths, originalLocalRefs}) => {
-      logger.debug('network save succeeded, processing local cleanup', {
-        draftId,
-      })
-
-      // Delete orphaned media (old refs not in new)
-      if (originalLocalRefs) {
-        const newLocalRefs = new Set(localRefPaths.keys())
-        for (const oldRef of originalLocalRefs) {
-          if (!newLocalRefs.has(oldRef)) {
-            logger.debug('deleting orphaned media file', {
-              localRefPath: oldRef,
+    onSuccess: async ({draftId, localRefPaths}) => {
+      if (!accountDid) return
+      try {
+        await serializeDraftMediaOperation(async () => {
+          for (const localRefPath of localRefPaths.keys()) {
+            await storage.touchMediaMetadata(localRefPath, {
+              accountDid,
+              deviceId: getDeviceId() ?? 'unknown',
+              state: 'committed',
             })
-            await storage.deleteMediaFromLocal(oldRef)
           }
-        }
+        })
+      } catch (error) {
+        logger.error('Failed to commit saved draft media metadata', {
+          safeMessage: error,
+        })
       }
 
-      await queryClient.invalidateQueries({queryKey: DRAFTS_QUERY_KEY})
+      logger.debug('draft save complete', {draftId})
+      await queryClient.invalidateQueries({
+        queryKey: draftsQueryKey(accountDid),
+      })
+      scheduleDraftMediaReconciliation(client, accountDid)
     },
     onError: error => {
-      // Check for draft limit error
       if (matchXrpcError(error, app.bsky.draft.createDraft)) {
         logger.error('Draft limit reached', {safeMessage: error.message})
-        // Error will be handled by caller
       } else if (!isNetworkError(error)) {
         logger.error('Could not create draft (reason unknown)', {
-          safeMessage: error.message,
+          safeMessage: error,
         })
       }
     },
   })
 }
 
-/**
- * Hook to delete a draft.
- * Takes the full draft data to avoid re-fetching for media cleanup.
- */
 export function useDeleteDraftMutation() {
   const client = useAppviewClient()
+  const {currentAccount} = useSession()
   const queryClient = useQueryClient()
+  const accountDid = currentAccount?.did
 
   return useMutation({
-    mutationFn: async ({
-      draftId,
-    }: {
-      draftId: string
-      draft: app.bsky.draft.defs.Draft
-    }) => {
-      // Delete from server first - if this fails, we keep local media for retry
+    mutationFn: async ({draftId}: {draftId: string; draft: unknown}) => {
       await client.call(app.bsky.draft.deleteDraft, {id: draftId})
     },
-    onSuccess: async (_, {draft}) => {
-      // Only delete local media after server deletion succeeds
-      for (const post of draft.posts) {
-        if (post.embedImages) {
-          for (const img of post.embedImages) {
-            await storage.deleteMediaFromLocal(img.localRef.path)
-          }
-        }
-        if (post.embedGallery) {
-          for (const item of post.embedGallery.items) {
-            if (!bsky.isType(app.bsky.draft.defs.draftEmbedImage, item))
-              continue
-            await storage.deleteMediaFromLocal(item.localRef.path)
-          }
-        }
-        if (post.embedVideos) {
-          for (const vid of post.embedVideos) {
-            await storage.deleteMediaFromLocal(vid.localRef.path)
-          }
-        }
-      }
-      queryClient.invalidateQueries({queryKey: DRAFTS_QUERY_KEY})
+    onSuccess: async () => {
+      if (!accountDid) return
+      await queryClient.invalidateQueries({
+        queryKey: draftsQueryKey(accountDid),
+      })
+      scheduleDraftMediaReconciliation(client, accountDid)
     },
   })
 }
 
-/**
- * Hook to clean up a draft after it has been published.
- * Deletes the draft from server and all associated local media.
- * Takes draftId and originalLocalRefs from composer state.
- */
 export function useCleanupPublishedDraftMutation() {
   const client = useAppviewClient()
+  const {currentAccount} = useSession()
   const queryClient = useQueryClient()
+  const accountDid = currentAccount?.did
 
   return useMutation({
     mutationFn: async ({
@@ -297,28 +318,21 @@ export function useCleanupPublishedDraftMutation() {
         draftId,
         mediaFileCount: originalLocalRefs.size,
       })
-      // Delete from server first
-      await client.call(app.bsky.draft.deleteDraft, {
-        id: draftId,
-      })
-      logger.debug('deleted draft from server', {draftId})
+      await client.call(app.bsky.draft.deleteDraft, {id: draftId})
     },
-    onSuccess: async (_, {originalLocalRefs}) => {
-      // Delete all local media files for this draft
-      for (const localRef of originalLocalRefs) {
-        logger.debug('deleting media file after publish', {
-          localRefPath: localRef,
-        })
-        await storage.deleteMediaFromLocal(localRef)
-      }
-      queryClient.invalidateQueries({queryKey: DRAFTS_QUERY_KEY})
-      logger.debug('cleanup after publish complete')
+    onSuccess: async () => {
+      if (!accountDid) return
+      await queryClient.invalidateQueries({
+        queryKey: draftsQueryKey(accountDid),
+      })
+      scheduleDraftMediaReconciliation(client, accountDid)
     },
     onError: error => {
-      // Log but don't throw - the post was already published successfully
-      logger.warn('Failed to clean up published draft', {
-        safeMessage: error instanceof Error ? error.message : String(error),
-      })
+      if (!isNetworkError(error)) {
+        logger.warn('Failed to clean up published draft', {
+          safeMessage: error,
+        })
+      }
     },
   })
 }

--- a/src/view/com/composer/drafts/state/queries.ts
+++ b/src/view/com/composer/drafts/state/queries.ts
@@ -117,9 +117,10 @@ export async function loadDraftMedia(
 /**
  * Hook to save a draft.
  *
- * IMPORTANT: Network operations happen first in mutationFn.
- * Local storage operations (save new media, delete orphaned media) happen in onSuccess.
- * This ensures we don't lose data if the network request fails.
+ * New media is copied to durable local storage before the server write. Composer
+ * media lives in temporary cache directories that the OS may clear at any time,
+ * so a server draft must not be created until all of its local refs are safe.
+ * Destructive cleanup of replaced media still happens only after server success.
  */
 export function useSaveDraftMutation() {
   const client = useAppviewClient()
@@ -151,7 +152,24 @@ export function useSaveDraftMutation() {
         originalLocalRefCount: composerState.originalLocalRefs?.size ?? 0,
       })
 
-      // 1. NETWORK FIRST - Update/create server draft
+      /*
+       * Persist media before the network request so a successful server draft
+       * never points at a temporary file that disappeared before we copied it.
+       */
+      if (localRefPaths.size > 0) {
+        await storage.ensureMediaCachePopulated()
+        for (const [localRefPath, sourcePath] of localRefPaths) {
+          // Reused refs from an existing draft are already in durable storage.
+          if (!storage.mediaExists(localRefPath)) {
+            logger.debug('saving new media file', {localRefPath})
+            await storage.saveMediaToLocal(localRefPath, sourcePath)
+          } else {
+            logger.debug('skipping existing media file', {localRefPath})
+          }
+        }
+      }
+
+      // Update/create the server draft only after its local media is safe.
       let draftId: string
       if (existingDraftId) {
         // Update existing draft
@@ -181,21 +199,9 @@ export function useSaveDraftMutation() {
       }
     },
     onSuccess: async ({draftId, localRefPaths, originalLocalRefs}) => {
-      // 2. LOCAL STORAGE ONLY AFTER NETWORK SUCCEEDS
-      logger.debug('network save succeeded, processing local storage', {
+      logger.debug('network save succeeded, processing local cleanup', {
         draftId,
       })
-
-      // Save new/changed media files
-      for (const [localRefPath, sourcePath] of localRefPaths) {
-        // Only save if this media doesn't already exist (reusing localRefPath)
-        if (!storage.mediaExists(localRefPath)) {
-          logger.debug('saving new media file', {localRefPath})
-          await storage.saveMediaToLocal(localRefPath, sourcePath)
-        } else {
-          logger.debug('skipping existing media file', {localRefPath})
-        }
-      }
 
       // Delete orphaned media (old refs not in new)
       if (originalLocalRefs) {

--- a/src/view/com/composer/drafts/state/reconciliation.test.ts
+++ b/src/view/com/composer/drafts/state/reconciliation.test.ts
@@ -1,0 +1,239 @@
+import {getDeviceId} from '#/analytics/identifiers'
+import {type app} from '#/lexicons'
+import {prepareDraftMediaOperation} from './mediaLock'
+import {
+  DRAFT_MEDIA_GRACE_PERIOD_MS,
+  reconcileDraftMedia,
+} from './reconciliation'
+import * as storage from './storage'
+import {type DraftMediaArtifact, type DraftMediaMetadata} from './storageTypes'
+
+jest.mock('#/analytics/identifiers', () => ({
+  getDeviceId: jest.fn(() => 'this-device'),
+}))
+
+jest.mock('./logger', () => ({
+  logger: {debug: jest.fn(), error: jest.fn(), warn: jest.fn()},
+}))
+
+jest.mock('./storage', () => ({
+  deleteMediaFromLocal: jest.fn(),
+  ensureMediaCachePopulated: jest.fn(),
+  getMediaMetadata: jest.fn(),
+  listMediaArtifacts: jest.fn(),
+  touchMediaMetadata: jest.fn(),
+}))
+
+const accountDid = 'did:plc:alice'
+const now = Date.parse('2026-09-12T12:00:00.000Z')
+let artifacts: Map<string, DraftMediaArtifact>
+
+function metadata(
+  localRefPath: string,
+  overrides: Partial<DraftMediaMetadata> = {},
+): DraftMediaMetadata {
+  return {
+    localRefPath,
+    accountDid,
+    deviceId: 'this-device',
+    createdAt: new Date(now - DRAFT_MEDIA_GRACE_PERIOD_MS * 2).toISOString(),
+    lastTouchedAt: new Date(
+      now - DRAFT_MEDIA_GRACE_PERIOD_MS * 2,
+    ).toISOString(),
+    state: 'committed',
+    ...overrides,
+  }
+}
+
+function draftView(
+  refs: string[],
+  deviceId: string | undefined = 'this-device',
+): app.bsky.draft.defs.DraftView {
+  return {
+    id: `draft-${refs.join('-')}`,
+    createdAt: new Date(now).toISOString(),
+    updatedAt: new Date(now).toISOString(),
+    draft: {
+      $type: 'app.bsky.draft.defs#draft',
+      deviceId,
+      posts: [
+        {
+          $type: 'app.bsky.draft.defs#draftPost',
+          text: '',
+          embedImages: refs.map(path => ({
+            $type: 'app.bsky.draft.defs#draftEmbedImage',
+            localRef: {
+              $type: 'app.bsky.draft.defs#draftEmbedLocalRef',
+              path,
+            },
+          })),
+        },
+      ],
+    },
+  } as app.bsky.draft.defs.DraftView
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest.mocked(getDeviceId).mockReturnValue('this-device')
+  artifacts = new Map()
+  jest.mocked(storage.ensureMediaCachePopulated).mockResolvedValue(undefined)
+  jest.mocked(storage.listMediaArtifacts).mockImplementation(() =>
+    Promise.resolve(
+      Array.from(artifacts.values()).map(artifact => ({
+        ...artifact,
+        metadata: artifact.metadata ? {...artifact.metadata} : undefined,
+      })),
+    ),
+  )
+  jest
+    .mocked(storage.getMediaMetadata)
+    .mockImplementation(ref =>
+      Promise.resolve(
+        artifacts.get(ref)?.metadata
+          ? {...artifacts.get(ref)!.metadata!}
+          : undefined,
+      ),
+    )
+  jest.mocked(storage.touchMediaMetadata).mockImplementation((ref, options) => {
+    const artifact = artifacts.get(ref)
+    if (!artifact) throw new Error('missing media')
+    const touchedAt = new Date(options.now ?? Date.now()).toISOString()
+    artifact.metadata = {
+      localRefPath: ref,
+      accountDid: options.accountDid,
+      deviceId: options.deviceId,
+      createdAt:
+        artifact.metadata?.createdAt ||
+        options.createdAt ||
+        artifact.fileCreatedAt ||
+        touchedAt,
+      lastTouchedAt: touchedAt,
+      state: options.state,
+    }
+    return Promise.resolve()
+  })
+  jest.mocked(storage.deleteMediaFromLocal).mockImplementation(ref => {
+    artifacts.delete(ref)
+    return Promise.resolve()
+  })
+})
+
+test('migrates referenced legacy media idempotently', async () => {
+  const ref = 'image:legacy'
+  const fileCreatedAt = new Date(now - 1000).toISOString()
+  artifacts.set(ref, {localRefPath: ref, fileCreatedAt})
+  const drafts = [draftView([ref])]
+
+  const first = await reconcileDraftMedia({drafts, accountDid, now})
+  const second = await reconcileDraftMedia({drafts, accountDid, now})
+
+  expect(first).toMatchObject({migrated: 1, retained: 1, deleted: 0})
+  expect(second).toMatchObject({migrated: 0, retained: 1, deleted: 0})
+  expect(artifacts.get(ref)?.metadata).toMatchObject({
+    accountDid,
+    createdAt: fileCreatedAt,
+    state: 'committed',
+  })
+})
+
+test('retains current-device and device-less roots but ignores other-device roots', async () => {
+  for (const ref of ['current', 'legacy', 'other-device']) {
+    artifacts.set(ref, {localRefPath: ref, metadata: metadata(ref)})
+  }
+
+  const result = await reconcileDraftMedia({
+    drafts: [
+      draftView(['current']),
+      draftView(['legacy'], undefined),
+      draftView(['other-device'], 'another-device'),
+    ],
+    accountDid,
+    now,
+  })
+
+  expect(result).toMatchObject({retained: 2, deleted: 1})
+  expect(artifacts.has('current')).toBe(true)
+  expect(artifacts.has('legacy')).toBe(true)
+  expect(artifacts.has('other-device')).toBe(false)
+})
+
+test('only deletes stale unreferenced media owned by the current account', async () => {
+  artifacts.set('other-account', {
+    localRefPath: 'other-account',
+    metadata: metadata('other-account', {accountDid: 'did:plc:bob'}),
+  })
+  artifacts.set('recent-pending', {
+    localRefPath: 'recent-pending',
+    metadata: metadata('recent-pending', {
+      lastTouchedAt: new Date(now - 1000).toISOString(),
+      state: 'pending',
+    }),
+  })
+  artifacts.set('unowned', {localRefPath: 'unowned'})
+  artifacts.set('stale-owned', {
+    localRefPath: 'stale-owned',
+    metadata: metadata('stale-owned'),
+  })
+
+  const result = await reconcileDraftMedia({drafts: [], accountDid, now})
+
+  expect(result).toMatchObject({migrated: 0, retained: 3, deleted: 1})
+  expect(storage.deleteMediaFromLocal).toHaveBeenCalledWith('stale-owned')
+  expect(artifacts.has('other-account')).toBe(true)
+  expect(artifacts.has('recent-pending')).toBe(true)
+  expect(artifacts.has('unowned')).toBe(true)
+})
+
+test('does not delete a ref whose pending touch is waiting on reconciliation', async () => {
+  const ref = 'image:retrying'
+  const artifact = {localRefPath: ref, metadata: metadata(ref)}
+  artifacts.set(ref, artifact)
+
+  let releaseInventory!: () => void
+  jest.mocked(storage.listMediaArtifacts).mockImplementationOnce(
+    () =>
+      new Promise(resolve => {
+        releaseInventory = () => resolve([artifact])
+      }),
+  )
+
+  const reconciliation = reconcileDraftMedia({drafts: [], accountDid, now})
+  while (!releaseInventory) await Promise.resolve()
+  const pendingTouch = prepareDraftMediaOperation([ref], () =>
+    Promise.resolve(),
+  )
+  releaseInventory()
+
+  await reconciliation
+  await pendingTouch
+
+  expect(storage.deleteMediaFromLocal).not.toHaveBeenCalled()
+  expect(artifacts.has(ref)).toBe(true)
+})
+
+test('keeps a shared ref until the final server reference is gone and grace expires', async () => {
+  const ref = 'image:shared'
+  artifacts.set(ref, {localRefPath: ref, metadata: metadata(ref)})
+
+  await reconcileDraftMedia({
+    drafts: [draftView([ref]), draftView([ref])],
+    accountDid,
+    now,
+  })
+  await reconcileDraftMedia({
+    drafts: [draftView([ref])],
+    accountDid,
+    now: now + DRAFT_MEDIA_GRACE_PERIOD_MS,
+  })
+
+  expect(artifacts.has(ref)).toBe(true)
+
+  await reconcileDraftMedia({
+    drafts: [],
+    accountDid,
+    now: now + DRAFT_MEDIA_GRACE_PERIOD_MS * 2,
+  })
+
+  expect(artifacts.has(ref)).toBe(false)
+})

--- a/src/view/com/composer/drafts/state/reconciliation.ts
+++ b/src/view/com/composer/drafts/state/reconciliation.ts
@@ -1,0 +1,141 @@
+import {getDeviceId} from '#/analytics/identifiers'
+import {app} from '#/lexicons'
+import * as bsky from '#/types/bsky'
+import {logger} from './logger'
+import {
+  isDraftMediaRefProtected,
+  serializeDraftMediaOperation,
+} from './mediaLock'
+import * as storage from './storage'
+
+export const DRAFT_MEDIA_GRACE_PERIOD_MS = 24 * 60 * 60 * 1000
+
+export type DraftMediaReconciliationResult = {
+  migrated: number
+  retained: number
+  deleted: number
+}
+
+function extractLocalRefs(draft: app.bsky.draft.defs.Draft): Set<string> {
+  const refs = new Set<string>()
+  for (const post of draft.posts) {
+    for (const image of post.embedImages ?? []) {
+      refs.add(image.localRef.path)
+    }
+    for (const item of post.embedGallery?.items ?? []) {
+      if (bsky.isType(app.bsky.draft.defs.draftEmbedImage, item)) {
+        refs.add(item.localRef.path)
+      }
+    }
+    for (const video of post.embedVideos ?? []) {
+      refs.add(video.localRef.path)
+    }
+  }
+  return refs
+}
+
+function isOldEnoughToDelete(lastTouchedAt: string, now: number): boolean {
+  const touchedAt = new Date(lastTouchedAt).getTime()
+  return (
+    Number.isFinite(touchedAt) && now - touchedAt >= DRAFT_MEDIA_GRACE_PERIOD_MS
+  )
+}
+
+/**
+ * Reconcile local media against a complete, authoritative server inventory.
+ * Callers must not pass a partial page of drafts.
+ */
+export function reconcileDraftMedia({
+  drafts,
+  accountDid,
+  now = Date.now(),
+}: {
+  drafts: app.bsky.draft.defs.DraftView[]
+  accountDid: string
+  now?: number
+}): Promise<DraftMediaReconciliationResult> {
+  return serializeDraftMediaOperation(async () => {
+    const currentDeviceId = getDeviceId()
+    const metadataDeviceId = currentDeviceId ?? 'unknown'
+    const roots = new Set<string>()
+
+    for (const view of drafts) {
+      if (!view.draft.deviceId || view.draft.deviceId === currentDeviceId) {
+        for (const ref of extractLocalRefs(view.draft)) {
+          roots.add(ref)
+        }
+      }
+    }
+
+    await storage.ensureMediaCachePopulated()
+    const artifacts = await storage.listMediaArtifacts()
+    const artifactsByRef = new Map(
+      artifacts.map(artifact => [artifact.localRefPath, artifact]),
+    )
+    let migrated = 0
+    let deleted = 0
+
+    for (const localRefPath of roots) {
+      const artifact = artifactsByRef.get(localRefPath)
+      if (!artifact) continue
+
+      if (!artifact.metadata) {
+        await storage.touchMediaMetadata(localRefPath, {
+          accountDid,
+          deviceId: metadataDeviceId,
+          state: 'committed',
+          now,
+          createdAt: artifact.fileCreatedAt,
+        })
+        migrated++
+      } else if (artifact.metadata.accountDid === accountDid) {
+        await storage.touchMediaMetadata(localRefPath, {
+          accountDid,
+          deviceId: artifact.metadata.deviceId || metadataDeviceId,
+          state: 'committed',
+          now,
+        })
+      }
+    }
+
+    for (const artifact of artifacts) {
+      if (roots.has(artifact.localRefPath)) continue
+      if (isDraftMediaRefProtected(artifact.localRefPath)) continue
+      if (!artifact.metadata) continue
+      if (artifact.metadata.accountDid !== accountDid) continue
+      if (!isOldEnoughToDelete(artifact.metadata.lastTouchedAt, now)) continue
+
+      /*
+       * Re-read immediately before deletion. A save may have touched the ref
+       * since the directory inventory was built; the shared lock also keeps
+       * save preparation from interleaving with this sweep.
+       */
+      const latest = await storage.getMediaMetadata(artifact.localRefPath)
+      if (
+        isDraftMediaRefProtected(artifact.localRefPath) ||
+        !latest ||
+        latest.accountDid !== accountDid ||
+        !isOldEnoughToDelete(latest.lastTouchedAt, now)
+      ) {
+        continue
+      }
+
+      try {
+        await storage.deleteMediaFromLocal(artifact.localRefPath)
+        deleted++
+      } catch (error) {
+        logger.error('Failed to delete unreferenced draft media', {
+          safeMessage: error,
+        })
+      }
+    }
+
+    const result = {
+      migrated,
+      retained: artifacts.length - deleted,
+      deleted,
+    }
+    logger.debug('Draft media reconciliation complete', result)
+    return result
+  })
+}

--- a/src/view/com/composer/drafts/state/storage.ts
+++ b/src/view/com/composer/drafts/state/storage.ts
@@ -1,48 +1,123 @@
-/**
- * Native file system storage for draft media.
- * Media is stored by localRefPath key (unique identifier stored in server draft).
- */
+/** Native file-system storage for draft media and account-owned metadata. */
 import {Directory, File, Paths} from 'expo-file-system'
 
 import {logger} from './logger'
+import {
+  type DraftMediaArtifact,
+  type DraftMediaMetadata,
+  type DraftMediaState,
+  isDraftMediaMetadata,
+} from './storageTypes'
 
 const MEDIA_DIR = 'bsky-draft-media'
+const METADATA_DIR = 'bsky-draft-media-metadata'
 
 function getMediaDirectory(): Directory {
   return new Directory(Paths.document, MEDIA_DIR)
 }
 
+function getMetadataDirectory(): Directory {
+  return new Directory(Paths.document, METADATA_DIR)
+}
+
+function getSafeFilename(localRefPath: string): string {
+  return encodeURIComponent(localRefPath)
+}
+
 function getMediaFile(localRefPath: string): File {
-  const safeFilename = encodeURIComponent(localRefPath)
-  return new File(getMediaDirectory(), safeFilename)
+  return new File(getMediaDirectory(), getSafeFilename(localRefPath))
 }
 
-let dirCreated = false
+function getMetadataFile(localRefPath: string): File {
+  return new File(getMetadataDirectory(), getSafeFilename(localRefPath))
+}
 
-/**
- * Ensure the media directory exists
- */
-function ensureDirectory(): void {
-  if (dirCreated) return
-  const dir = getMediaDirectory()
-  if (!dir.exists) {
-    dir.create()
+let directoriesCreated = false
+
+function ensureDirectories(): void {
+  if (directoriesCreated) return
+  for (const directory of [getMediaDirectory(), getMetadataDirectory()]) {
+    if (!directory.exists) {
+      directory.create({intermediates: true, idempotent: true})
+    }
   }
-  dirCreated = true
+  directoriesCreated = true
 }
 
-/**
- * Save a media file to local storage by localRefPath key
- */
+function fileTimestamp(file: File): string | undefined {
+  const timestamp = file.creationTime ?? file.lastModified
+  return timestamp ? new Date(timestamp).toISOString() : undefined
+}
+
+function writeMetadata(metadata: DraftMediaMetadata): Promise<void> {
+  ensureDirectories()
+  const file = getMetadataFile(metadata.localRefPath)
+  file.create({intermediates: true, overwrite: true})
+  file.write(JSON.stringify(metadata))
+  return Promise.resolve()
+}
+
+export async function getMediaMetadata(
+  localRefPath: string,
+): Promise<DraftMediaMetadata | undefined> {
+  const file = getMetadataFile(localRefPath)
+  if (!file.exists) return undefined
+
+  try {
+    const metadata: unknown = JSON.parse(await file.text())
+    return isDraftMediaMetadata(metadata) ? metadata : undefined
+  } catch (error) {
+    logger.warn('Failed to read draft media metadata', {safeMessage: error})
+    return undefined
+  }
+}
+
+export async function touchMediaMetadata(
+  localRefPath: string,
+  {
+    accountDid,
+    deviceId,
+    state,
+    now = Date.now(),
+    createdAt,
+  }: {
+    accountDid: string
+    deviceId: string
+    state: DraftMediaState
+    now?: number
+    createdAt?: string
+  },
+): Promise<void> {
+  const mediaFile = getMediaFile(localRefPath)
+  if (!mediaFile.exists) {
+    throw new Error('Cannot touch metadata for missing draft media')
+  }
+
+  const existing = await getMediaMetadata(localRefPath)
+  const touchedAt = new Date(now).toISOString()
+  await writeMetadata({
+    localRefPath,
+    accountDid,
+    deviceId,
+    createdAt:
+      existing?.createdAt || createdAt || fileTimestamp(mediaFile) || touchedAt,
+    lastTouchedAt: touchedAt,
+    state,
+  })
+}
+
 export async function saveMediaToLocal(
   localRefPath: string,
   sourcePath: string,
+  ownership: {
+    accountDid: string
+    deviceId: string
+    state: DraftMediaState
+    now?: number
+  },
 ): Promise<void> {
-  ensureDirectory()
-
+  ensureDirectories()
   const destFile = getMediaFile(localRefPath)
-
-  // Ensure source path has file:// prefix for expo-file-system
   let normalizedSource = sourcePath
   if (!sourcePath.startsWith('file://') && sourcePath.startsWith('/')) {
     normalizedSource = `file://${sourcePath}`
@@ -51,94 +126,79 @@ export async function saveMediaToLocal(
   try {
     const sourceFile = new File(normalizedSource)
     await sourceFile.copy(destFile)
-    // Update cache after successful save
     mediaExistsCache.set(localRefPath, true)
+    await touchMediaMetadata(localRefPath, ownership)
   } catch (error) {
     logger.error('Failed to save media to drafts storage', {
-      error,
-      localRefPath,
-      sourcePath: normalizedSource,
-      destPath: destFile.uri,
+      safeMessage: error,
     })
     throw error
   }
 }
 
-/**
- * Load a media file path from local storage
- * @returns The file URI for the saved media
- */
-export async function loadMediaFromLocal(
-  localRefPath: string,
-): Promise<string> {
+export function loadMediaFromLocal(localRefPath: string): Promise<string> {
   const file = getMediaFile(localRefPath)
-
-  if (!file.exists) {
-    throw new Error(`Media file not found: ${localRefPath}`)
-  }
-
-  return file.uri
+  return file.exists
+    ? Promise.resolve(file.uri)
+    : Promise.reject(new Error(`Media file not found: ${localRefPath}`))
 }
 
-/**
- * Delete a media file from local storage
- */
-export async function deleteMediaFromLocal(
-  localRefPath: string,
-): Promise<void> {
+export function deleteMediaFromLocal(localRefPath: string): Promise<void> {
   const file = getMediaFile(localRefPath)
-  // Idempotent: only delete if file exists
-  if (file.exists) {
-    file.delete()
-  }
+  if (file.exists) file.delete()
+  const metadataFile = getMetadataFile(localRefPath)
+  if (metadataFile.exists) metadataFile.delete()
   mediaExistsCache.delete(localRefPath)
+  return Promise.resolve()
 }
 
-/**
- * Check if a media file exists in local storage (synchronous check using cache)
- * Note: This uses a cached directory listing for performance
- */
+export async function listMediaArtifacts(): Promise<DraftMediaArtifact[]> {
+  ensureDirectories()
+  const artifacts: DraftMediaArtifact[] = []
+  for (const item of getMediaDirectory().list()) {
+    if (!(item instanceof File)) continue
+    const localRefPath = decodeURIComponent(item.name)
+    artifacts.push({
+      localRefPath,
+      metadata: await getMediaMetadata(localRefPath),
+      fileCreatedAt: fileTimestamp(item),
+    })
+  }
+  return artifacts
+}
+
 const mediaExistsCache = new Map<string, boolean>()
 let cachePopulated = false
+let populateCachePromise: Promise<void> | null = null
 
 export function mediaExists(localRefPath: string): boolean {
-  // For native, we need an async check but the API requires sync
-  // Use cached result if available, otherwise assume doesn't exist
   if (mediaExistsCache.has(localRefPath)) {
     return mediaExistsCache.get(localRefPath)!
   }
-  // If cache not populated yet, trigger async population
   if (!cachePopulated && !populateCachePromise) {
     populateCachePromise = populateCacheInternal()
   }
-  return false // Conservative: assume doesn't exist if not in cache
+  return false
 }
-
-let populateCachePromise: Promise<void> | null = null
 
 function populateCacheInternal(): Promise<void> {
   return new Promise(resolve => {
     try {
       const dir = getMediaDirectory()
       if (dir.exists) {
-        const items = dir.list()
-        for (const item of items) {
-          // Reverse the URL encoding to get the original localRefPath
-          const localRefPath = decodeURIComponent(item.name)
-          mediaExistsCache.set(localRefPath, true)
+        for (const item of dir.list()) {
+          if (!(item instanceof File)) continue
+          mediaExistsCache.set(decodeURIComponent(item.name), true)
         }
       }
       cachePopulated = true
-    } catch (e) {
-      logger.warn('Failed to populate media cache', {error: e})
+    } catch (error) {
+      logger.warn('Failed to populate media cache', {safeMessage: error})
     }
     resolve()
   })
 }
 
-/**
- * Ensure the media cache is populated. Call this before checking mediaExists.
- */
 export async function ensureMediaCachePopulated(): Promise<void> {
   if (cachePopulated) return
   if (!populateCachePromise) {
@@ -147,25 +207,12 @@ export async function ensureMediaCachePopulated(): Promise<void> {
   await populateCachePromise
 }
 
-/**
- * Clear the media exists cache (call when media is added/deleted)
- */
 export function clearMediaCache(): void {
   mediaExistsCache.clear()
   cachePopulated = false
   populateCachePromise = null
 }
 
-/**
- * Revoke a media URL (no-op on native - only needed for web blob URLs)
- */
-export function revokeMediaUrl(_url: string): void {
-  // No-op on native - file URIs don't need revocation
-}
+export function revokeMediaUrl(_url: string): void {}
 
-/**
- * Revoke all media URLs (no-op on native - only needed for web blob URLs)
- */
-export function revokeAllMediaUrls(): void {
-  // No-op on native - file URIs don't need revocation
-}
+export function revokeAllMediaUrls(): void {}

--- a/src/view/com/composer/drafts/state/storage.web.test.ts
+++ b/src/view/com/composer/drafts/state/storage.web.test.ts
@@ -1,0 +1,78 @@
+const mockRecords = new Map<IDBValidKey, unknown>()
+
+jest.mock('idb-keyval', () => ({
+  createStore: jest.fn(() => ({})),
+  del: jest.fn((key: IDBValidKey) => {
+    mockRecords.delete(key)
+    return Promise.resolve()
+  }),
+  get: jest.fn((key: IDBValidKey) => Promise.resolve(mockRecords.get(key))),
+  keys: jest.fn(() => Promise.resolve(Array.from(mockRecords.keys()))),
+  set: jest.fn((key: IDBValidKey, value: unknown) => {
+    mockRecords.set(key, value)
+    return Promise.resolve()
+  }),
+}))
+
+jest.mock('./logger', () => ({
+  logger: {debug: jest.fn(), error: jest.fn(), warn: jest.fn()},
+}))
+
+import {
+  getMediaMetadata,
+  listMediaArtifacts,
+  saveMediaToLocal,
+  touchMediaMetadata,
+} from './storage.web'
+
+beforeEach(() => {
+  mockRecords.clear()
+})
+
+test('saves account-owned pending metadata with web media', async () => {
+  const originalFetch = global.fetch
+  const fetchMock: jest.MockedFunction<typeof fetch> = jest
+    .fn()
+    .mockResolvedValueOnce(new Response(new Blob(['image']), {status: 200}))
+  global.fetch = fetchMock
+
+  try {
+    await saveMediaToLocal('image:new', 'blob:new', {
+      accountDid: 'did:plc:alice',
+      deviceId: 'device-id',
+      state: 'pending',
+      now: 1000,
+    })
+
+    await expect(getMediaMetadata('image:new')).resolves.toMatchObject({
+      localRefPath: 'image:new',
+      accountDid: 'did:plc:alice',
+      deviceId: 'device-id',
+      createdAt: new Date(1000).toISOString(),
+      lastTouchedAt: new Date(1000).toISOString(),
+      state: 'pending',
+    })
+    await expect(listMediaArtifacts()).resolves.toHaveLength(1)
+  } finally {
+    global.fetch = originalFetch
+  }
+})
+
+test('adds metadata to a legacy web record without replacing its blob', async () => {
+  const blob = new Blob(['legacy'])
+  const createdAt = new Date(500).toISOString()
+  mockRecords.set('image:legacy', {blob, createdAt})
+
+  await touchMediaMetadata('image:legacy', {
+    accountDid: 'did:plc:alice',
+    deviceId: 'device-id',
+    state: 'committed',
+    now: 1000,
+  })
+
+  expect(mockRecords.get('image:legacy')).toMatchObject({blob})
+  await expect(getMediaMetadata('image:legacy')).resolves.toMatchObject({
+    createdAt,
+    state: 'committed',
+  })
+})

--- a/src/view/com/composer/drafts/state/storage.web.ts
+++ b/src/view/com/composer/drafts/state/storage.web.ts
@@ -1,46 +1,27 @@
-/**
- * Web IndexedDB storage for draft media.
- * Media is stored by localRefPath key (unique identifier stored in server draft).
- */
+/** Web IndexedDB storage for draft media and account-owned metadata. */
 import {createStore, del, get, keys, set} from 'idb-keyval'
 
 import {logger} from './logger'
+import {
+  type DraftMediaArtifact,
+  type DraftMediaMetadata,
+  type DraftMediaState,
+  isDraftMediaMetadata,
+} from './storageTypes'
 
 const DB_NAME = 'bsky-draft-media'
 const STORE_NAME = 'media'
 
 type MediaRecord = {
   blob: Blob
-  createdAt: string
+  /** Present on records created before lifecycle metadata was introduced. */
+  createdAt?: string
+  metadata?: DraftMediaMetadata
 }
 
 const store = createStore(DB_NAME, STORE_NAME)
 
-/**
- * Convert a path/URL to a Blob
- */
 async function toBlob(sourcePath: string): Promise<Blob> {
-  // Handle data URIs directly
-  if (sourcePath.startsWith('data:')) {
-    const response = await fetch(sourcePath)
-    return response.blob()
-  }
-
-  // Handle blob URLs
-  if (sourcePath.startsWith('blob:')) {
-    try {
-      const response = await fetch(sourcePath)
-      return response.blob()
-    } catch (e) {
-      logger.error('Failed to fetch blob URL - it may have been revoked', {
-        error: e,
-        sourcePath,
-      })
-      throw e
-    }
-  }
-
-  // Handle regular URLs
   const response = await fetch(sourcePath)
   if (!response.ok) {
     throw new Error(`Failed to fetch media: ${response.status}`)
@@ -48,69 +29,106 @@ async function toBlob(sourcePath: string): Promise<Blob> {
   return response.blob()
 }
 
-/**
- * Save a media file to IndexedDB by localRefPath key
- */
+export async function getMediaMetadata(
+  localRefPath: string,
+): Promise<DraftMediaMetadata | undefined> {
+  const record = await get<MediaRecord>(localRefPath, store)
+  return isDraftMediaMetadata(record?.metadata) ? record.metadata : undefined
+}
+
+export async function touchMediaMetadata(
+  localRefPath: string,
+  {
+    accountDid,
+    deviceId,
+    state,
+    now = Date.now(),
+    createdAt,
+  }: {
+    accountDid: string
+    deviceId: string
+    state: DraftMediaState
+    now?: number
+    createdAt?: string
+  },
+): Promise<void> {
+  const record = await get<MediaRecord>(localRefPath, store)
+  if (!record) {
+    throw new Error('Cannot touch metadata for missing draft media')
+  }
+
+  const touchedAt = new Date(now).toISOString()
+  const existing = isDraftMediaMetadata(record.metadata)
+    ? record.metadata
+    : undefined
+  const metadata: DraftMediaMetadata = {
+    localRefPath,
+    accountDid,
+    deviceId,
+    createdAt:
+      existing?.createdAt || createdAt || record.createdAt || touchedAt,
+    lastTouchedAt: touchedAt,
+    state,
+  }
+  await set(localRefPath, {...record, metadata}, store)
+}
+
 export async function saveMediaToLocal(
   localRefPath: string,
   sourcePath: string,
+  {
+    accountDid,
+    deviceId,
+    state,
+    now = Date.now(),
+  }: {
+    accountDid: string
+    deviceId: string
+    state: DraftMediaState
+    now?: number
+  },
 ): Promise<void> {
-  let blob: Blob
   try {
-    blob = await toBlob(sourcePath)
-  } catch (error) {
-    logger.error('Failed to convert source to blob', {
-      error,
-      localRefPath,
-      sourcePath,
-    })
-    throw error
-  }
-
-  try {
+    const blob = await toBlob(sourcePath)
+    const createdAt = new Date(now).toISOString()
     await set(
       localRefPath,
       {
         blob,
-        createdAt: new Date().toISOString(),
-      },
+        createdAt,
+        metadata: {
+          localRefPath,
+          accountDid,
+          deviceId,
+          createdAt,
+          lastTouchedAt: createdAt,
+          state,
+        },
+      } satisfies MediaRecord,
       store,
     )
-    // Update cache
     mediaExistsCache.set(localRefPath, true)
   } catch (error) {
-    logger.error('Failed to save media to IndexedDB', {error, localRefPath})
+    logger.error('Failed to save media to IndexedDB', {safeMessage: error})
     throw error
   }
 }
 
-/**
- * Track blob URLs created by loadMediaFromLocal for cleanup
- */
 const createdBlobUrls = new Set<string>()
 
-/**
- * Load a media file from IndexedDB
- * @returns A blob URL for the saved media
- */
 export async function loadMediaFromLocal(
   localRefPath: string,
 ): Promise<string> {
   const record = await get<MediaRecord>(localRefPath, store)
-
   if (!record) {
     throw new Error(`Media file not found: ${localRefPath}`)
   }
 
   const url = URL.createObjectURL(record.blob)
-  logger.debug('Created blob URL', {url})
   createdBlobUrls.add(url)
   return url
 }
 
-/**
- * Delete a media file from IndexedDB
- */
 export async function deleteMediaFromLocal(
   localRefPath: string,
 ): Promise<void> {
@@ -118,9 +136,23 @@ export async function deleteMediaFromLocal(
   mediaExistsCache.delete(localRefPath)
 }
 
-/**
- * Check if a media file exists in IndexedDB (synchronous check using cache)
- */
+export async function listMediaArtifacts(): Promise<DraftMediaArtifact[]> {
+  const artifacts: DraftMediaArtifact[] = []
+  for (const key of await keys(store)) {
+    if (typeof key !== 'string') continue
+    const record = await get<MediaRecord>(key, store)
+    if (!record) continue
+    artifacts.push({
+      localRefPath: key,
+      metadata: isDraftMediaMetadata(record.metadata)
+        ? record.metadata
+        : undefined,
+      fileCreatedAt: record.createdAt,
+    })
+  }
+  return artifacts
+}
+
 const mediaExistsCache = new Map<string, boolean>()
 let cachePopulated = false
 let populateCachePromise: Promise<void> | null = null
@@ -129,28 +161,23 @@ export function mediaExists(localRefPath: string): boolean {
   if (mediaExistsCache.has(localRefPath)) {
     return mediaExistsCache.get(localRefPath)!
   }
-  // If cache not populated yet, trigger async population
   if (!cachePopulated && !populateCachePromise) {
     populateCachePromise = populateCacheInternal()
   }
-  return false // Conservative: assume doesn't exist if not in cache
+  return false
 }
 
 async function populateCacheInternal(): Promise<void> {
   try {
-    const allKeys = await keys(store)
-    for (const key of allKeys) {
-      mediaExistsCache.set(key as string, true)
+    for (const key of await keys(store)) {
+      if (typeof key === 'string') mediaExistsCache.set(key, true)
     }
     cachePopulated = true
-  } catch (e) {
-    logger.warn('Failed to populate media cache', {error: e})
+  } catch (error) {
+    logger.warn('Failed to populate media cache', {safeMessage: error})
   }
 }
 
-/**
- * Ensure the media cache is populated. Call this before checking mediaExists.
- */
 export async function ensureMediaCachePopulated(): Promise<void> {
   if (cachePopulated) return
   if (!populateCachePromise) {
@@ -159,32 +186,20 @@ export async function ensureMediaCachePopulated(): Promise<void> {
   await populateCachePromise
 }
 
-/**
- * Clear the media exists cache (call when media is added/deleted)
- */
 export function clearMediaCache(): void {
   mediaExistsCache.clear()
   cachePopulated = false
   populateCachePromise = null
 }
 
-/**
- * Revoke a blob URL when done with it (to prevent memory leaks)
- */
 export function revokeMediaUrl(url: string): void {
   if (url.startsWith('blob:')) {
-    logger.debug('Revoking blob URL', {url})
     URL.revokeObjectURL(url)
     createdBlobUrls.delete(url)
   }
 }
 
-/**
- * Revoke all blob URLs created by loadMediaFromLocal.
- * Call this when closing the drafts list dialog to prevent memory leaks.
- */
 export function revokeAllMediaUrls(): void {
-  logger.debug(`Revoking ${createdBlobUrls.size} blob URLs`)
   for (const url of createdBlobUrls) {
     URL.revokeObjectURL(url)
   }

--- a/src/view/com/composer/drafts/state/storageTypes.ts
+++ b/src/view/com/composer/drafts/state/storageTypes.ts
@@ -1,0 +1,32 @@
+export type DraftMediaState = 'pending' | 'committed'
+
+export type DraftMediaMetadata = {
+  localRefPath: string
+  accountDid: string
+  deviceId: string
+  createdAt: string
+  lastTouchedAt: string
+  state: DraftMediaState
+}
+
+export type DraftMediaArtifact = {
+  localRefPath: string
+  metadata?: DraftMediaMetadata
+  /** Best available timestamp from the underlying storage artifact. */
+  fileCreatedAt?: string
+}
+
+export function isDraftMediaMetadata(
+  value: unknown,
+): value is DraftMediaMetadata {
+  if (!value || typeof value !== 'object') return false
+  const metadata = value as Partial<DraftMediaMetadata>
+  return (
+    typeof metadata.localRefPath === 'string' &&
+    typeof metadata.accountDid === 'string' &&
+    typeof metadata.deviceId === 'string' &&
+    typeof metadata.createdAt === 'string' &&
+    typeof metadata.lastTouchedAt === 'string' &&
+    (metadata.state === 'pending' || metadata.state === 'committed')
+  )
+}

--- a/src/view/com/composer/state/composer.ts
+++ b/src/view/com/composer/state/composer.ts
@@ -93,6 +93,8 @@ export type PostAction =
       asset: ImagePickerAsset
       abortController: AbortController
       telemetry: VideoTelemetry
+      /** Existing ref when restoring a saved draft. */
+      localRefPath?: string
     }
   | {type: 'embed_remove_video'}
   | {type: 'embed_update_video'; videoAction: VideoAction}
@@ -468,6 +470,7 @@ function postReducer(state: PostDraft, action: PostAction): PostDraft {
             action.asset,
             action.abortController,
             action.telemetry,
+            action.localRefPath,
           ),
         }
       }

--- a/src/view/com/composer/state/video.ts
+++ b/src/view/com/composer/state/video.ts
@@ -2,6 +2,7 @@ import {type ImagePickerAsset} from 'expo-image-picker'
 import {type BlobRef, type Client} from '@atproto/lex'
 import {type I18n} from '@lingui/core'
 import {msg} from '@lingui/core/macro'
+import {nanoid} from 'nanoid/non-secure'
 
 import {AbortError} from '#/lib/async/cancelable'
 import {VIDEO_MAX_SIZE_MB} from '#/lib/constants'
@@ -11,7 +12,10 @@ import {MultipartUploadError} from '#/lib/media/video/multipart/api'
 import {type VideoTelemetry} from '#/lib/media/video/telemetry'
 import {type CompressedVideo} from '#/lib/media/video/types'
 import {uploadVideo} from '#/lib/media/video/upload'
-import {createTokenlessVideoServiceClient} from '#/lib/media/video/util'
+import {
+  createTokenlessVideoServiceClient,
+  mimeToExt,
+} from '#/lib/media/video/util'
 import {isNetworkError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
 import {app} from '#/lexicons'
@@ -22,6 +26,7 @@ import {
 } from './videoProgress'
 
 type CaptionsTrack = {lang: string; file: File}
+type VideoAttachment = {localRefPath: string}
 
 export type VideoAction =
   | {
@@ -76,7 +81,7 @@ export const NO_VIDEO = Object.freeze({
 
 export type NoVideoState = typeof NO_VIDEO
 
-type ErrorState = {
+type ErrorState = VideoAttachment & {
   status: 'error'
   progress: number
   abortController: AbortController
@@ -90,7 +95,7 @@ type ErrorState = {
   captions: CaptionsTrack[]
 }
 
-type CompressingState = {
+type CompressingState = VideoAttachment & {
   status: 'compressing'
   progress: number
   abortController: AbortController
@@ -103,7 +108,7 @@ type CompressingState = {
   captions: CaptionsTrack[]
 }
 
-type UploadingState = {
+type UploadingState = VideoAttachment & {
   status: 'uploading'
   progress: number
   compressionSkipped: boolean
@@ -117,7 +122,7 @@ type UploadingState = {
   captions: CaptionsTrack[]
 }
 
-type ProcessingState = {
+type ProcessingState = VideoAttachment & {
   status: 'processing'
   progress: number
   abortController: AbortController
@@ -131,7 +136,7 @@ type ProcessingState = {
   captions: CaptionsTrack[]
 }
 
-type DoneState = {
+type DoneState = VideoAttachment & {
   status: 'done'
   progress: 1
   abortController: AbortController
@@ -151,9 +156,13 @@ export function createVideoState(
   asset: ImagePickerAsset,
   abortController: AbortController,
   telemetry: VideoTelemetry,
+  localRefPath?: string,
 ): CompressingState {
+  const mimeType = asset.mimeType || 'video/mp4'
   return {
     status: 'compressing',
+    localRefPath:
+      localRefPath || `video:${mimeType}:${nanoid()}.${mimeToExt(mimeType)}`,
     progress: 0,
     abortController,
     asset,
@@ -174,6 +183,7 @@ export function videoReducer(
   if (action.type === 'to_error') {
     return {
       status: 'error',
+      localRefPath: state.localRefPath,
       progress: state.progress,
       abortController: state.abortController,
       error: action.error,
@@ -209,6 +219,7 @@ export function videoReducer(
     if (state.status === 'compressing') {
       return {
         status: 'uploading',
+        localRefPath: state.localRefPath,
         progress: videoProgressForPhase(
           action.compressionSkipped
             ? 'uploadingWithoutCompression'
@@ -229,6 +240,7 @@ export function videoReducer(
     if (state.status === 'uploading') {
       return {
         status: 'processing',
+        localRefPath: state.localRefPath,
         progress: videoProgressForPhase('processing', 0),
         abortController: state.abortController,
         asset: state.asset,
@@ -259,6 +271,7 @@ export function videoReducer(
     if (state.status === 'processing') {
       return {
         status: 'done',
+        localRefPath: state.localRefPath,
         progress: 1,
         abortController: state.abortController,
         asset: state.asset,


### PR DESCRIPTION
## What

- copy new draft media into durable local storage before creating or updating the server draft
- prevent a server draft from being written when its local media cannot be persisted
- keep destructive orphan cleanup after the server write succeeds
- add coverage for media/server ordering and local-persistence failures

## Why

Android may clear composer media from temporary cache directories before the app copies it into draft storage. Previously, the server write happened first, so a local copy failure could leave a server draft with missing media while the UI reported that saving failed.

Fixes APP-3063.

## Test plan

- `pnpm test src/view/com/composer/drafts/state/queries.test.tsx --runInBand`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm prettier --check src/view/com/composer/drafts/state/queries.ts src/view/com/composer/drafts/state/queries.test.tsx`