### PR TITLE
Configure starter pack size limits remotely

### DIFF
--- a/src/analytics/features/types.ts
+++ b/src/analytics/features/types.ts
@@ -24,6 +24,7 @@ export enum Features {
   ModerationInboxEnable = 'moderation_inbox:enable',
 
   // values
+  StarterPacksConfig = 'starter_packs:config',
   TrendingDiscoverValues = 'trending_discover:values',
   TrendingExploreTopicsCountValue = 'trending_explore_topics_count:value',
 

--- a/src/components/StarterPack/Wizard/WizardListCard.tsx
+++ b/src/components/StarterPack/Wizard/WizardListCard.tsx
@@ -7,7 +7,7 @@ import {
 } from '@bsky/sdk/moderation'
 import {Trans, useLingui} from '@lingui/react/macro'
 
-import {DISCOVER_FEED_URI, STARTER_PACK_MAX_SIZE} from '#/lib/constants'
+import {DISCOVER_FEED_URI} from '#/lib/constants'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {useSession} from '#/state/session'
@@ -147,7 +147,7 @@ export function WizardProfileCard({
   const disabled =
     subjectOptedOut ||
     isTarget ||
-    (!included && state.profiles.length >= STARTER_PACK_MAX_SIZE)
+    (!included && state.profiles.length >= state.profileLimit)
   const moderationUi = moderateProfile(profile, moderationOpts).ui('avatar')
   const displayName = profile.displayName
     ? sanitizeDisplayName(profile.displayName)

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -18,7 +18,8 @@ export const CHAT_SERVICE = 'https://api.bsky.chat'
 export const EMBED_SERVICE = 'https://embed.bsky.app'
 export const EMBED_SCRIPT = `${EMBED_SERVICE}/static/embed.js`
 export const BSKY_DOWNLOAD_URL = 'https://bsky.app/download'
-export const STARTER_PACK_MAX_SIZE = 150
+export const STARTER_PACK_DEFAULT_SIZE = 150
+export const STARTER_PACK_MAX_SIZE = 500
 export const CARD_ASPECT_RATIO = 1200 / 630
 
 // HACK

--- a/src/lib/generate-starterpack.test.ts
+++ b/src/lib/generate-starterpack.test.ts
@@ -21,7 +21,7 @@ describe('createStarterPackList', () => {
       call,
       create,
     } as unknown as Client
-    const profiles = Array.from({length: 101}, (_, i) => ({
+    const profiles = Array.from({length: 401}, (_, i) => ({
       did: `did:plc:${i}`,
     })) as bsky.profile.AnyProfileView[]
 
@@ -35,6 +35,6 @@ describe('createStarterPackList', () => {
     const inputs = (call.mock.calls as unknown[][]).map(
       ([, input]) => input as com.atproto.repo.applyWrites.$InputBody,
     )
-    expect(inputs.map(input => input.writes.length)).toEqual([50, 50, 1])
+    expect(inputs.map(input => input.writes.length)).toEqual([200, 200, 1])
   })
 })

--- a/src/lib/generate-starterpack.test.ts
+++ b/src/lib/generate-starterpack.test.ts
@@ -1,0 +1,40 @@
+import {type Client} from '@atproto/lex'
+
+import {createStarterPackList} from '#/lib/generate-starterpack'
+import {type com} from '#/lexicons'
+import type * as bsky from '#/types/bsky'
+
+jest.mock('#/state/session', () => ({
+  useAppviewClient: jest.fn(),
+  usePdsClient: jest.fn(),
+}))
+
+describe('createStarterPackList', () => {
+  it('batches list item writes', async () => {
+    const create = jest.fn().mockResolvedValue({
+      uri: 'at://did:plc:test/app.bsky.graph.list/test',
+      cid: 'cid',
+    })
+    const call = jest.fn().mockResolvedValue({})
+    const client = {
+      assertDid: 'did:plc:test',
+      call,
+      create,
+    } as unknown as Client
+    const profiles = Array.from({length: 101}, (_, i) => ({
+      did: `did:plc:${i}`,
+    })) as bsky.profile.AnyProfileView[]
+
+    await createStarterPackList({
+      name: 'Test Starter Pack',
+      profiles,
+      client,
+    })
+
+    expect(call).toHaveBeenCalledTimes(3)
+    const inputs = (call.mock.calls as unknown[][]).map(
+      ([, input]) => input as com.atproto.repo.applyWrites.$InputBody,
+    )
+    expect(inputs.map(input => input.writes.length)).toEqual([50, 50, 1])
+  })
+})

--- a/src/lib/generate-starterpack.ts
+++ b/src/lib/generate-starterpack.ts
@@ -1,9 +1,9 @@
+import {chunkArray} from '@atproto/common-web'
 import {type Client} from '@atproto/lex'
 import {type AtUriString, toDatetimeString} from '@atproto/syntax'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {useMutation} from '@tanstack/react-query'
-import chunk from 'lodash.chunk'
 
 import {until} from '#/lib/async/until'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
@@ -37,7 +37,7 @@ export const createStarterPackList = async ({
     purpose: 'app.bsky.graph.defs#referencelist',
   })
   if (!list) throw new Error('List creation failed')
-  for (const profilesChunk of chunk(profiles, 50)) {
+  for (const profilesChunk of chunkArray(profiles, 200)) {
     await client.call(com.atproto.repo.applyWrites, {
       repo: client.assertDid,
       writes: profilesChunk.map(p =>

--- a/src/lib/generate-starterpack.ts
+++ b/src/lib/generate-starterpack.ts
@@ -3,6 +3,7 @@ import {type AtUriString, toDatetimeString} from '@atproto/syntax'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {useMutation} from '@tanstack/react-query'
+import chunk from 'lodash.chunk'
 
 import {until} from '#/lib/async/until'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
@@ -36,10 +37,14 @@ export const createStarterPackList = async ({
     purpose: 'app.bsky.graph.defs#referencelist',
   })
   if (!list) throw new Error('List creation failed')
-  await client.call(com.atproto.repo.applyWrites, {
-    repo: client.assertDid,
-    writes: profiles.map(p => createListItem({did: p.did, listUri: list.uri})),
-  })
+  for (const profilesChunk of chunk(profiles, 50)) {
+    await client.call(com.atproto.repo.applyWrites, {
+      repo: client.assertDid,
+      writes: profilesChunk.map(p =>
+        createListItem({did: p.did, listUri: list.uri}),
+      ),
+    })
+  }
 
   return list
 }

--- a/src/screens/StarterPack/Wizard/State.tsx
+++ b/src/screens/StarterPack/Wizard/State.tsx
@@ -73,7 +73,7 @@ function reducer(state: State, action: Action): State {
       updatedState = {...state, description: action.description}
       break
     case 'AddProfile':
-      if (state.profiles.length > state.profileLimit) {
+      if (state.profiles.length >= state.profileLimit) {
         Toast.show(
           msg`You may only add up to ${plural(state.profileLimit, {
             other: `${state.profileLimit} profiles`,

--- a/src/screens/StarterPack/Wizard/State.tsx
+++ b/src/screens/StarterPack/Wizard/State.tsx
@@ -1,7 +1,7 @@
 import {createContext, useContext, useReducer} from 'react'
 import {msg, plural} from '@lingui/core/macro'
 
-import {STARTER_PACK_MAX_SIZE} from '#/lib/constants'
+import {STARTER_PACK_DEFAULT_SIZE, STARTER_PACK_MAX_SIZE} from '#/lib/constants'
 import * as Toast from '#/components/Toast'
 import {useAnalytics} from '#/analytics'
 import {app} from '#/lexicons'
@@ -129,10 +129,11 @@ export function Provider({
   children: React.ReactNode
 }) {
   const ax = useAnalytics()
-  const {limit: profileLimit} = ax.features.getValue(
+  const {limit: configuredProfileLimit} = ax.features.getValue(
     ax.features.StarterPacksConfig,
-    {limit: STARTER_PACK_MAX_SIZE},
+    {limit: STARTER_PACK_DEFAULT_SIZE},
   )
+  const profileLimit = Math.min(configuredProfileLimit, STARTER_PACK_MAX_SIZE)
 
   const createInitialState = (): State => {
     const targetDid = targetProfile?.did

--- a/src/screens/StarterPack/Wizard/State.tsx
+++ b/src/screens/StarterPack/Wizard/State.tsx
@@ -3,6 +3,7 @@ import {msg, plural} from '@lingui/core/macro'
 
 import {STARTER_PACK_MAX_SIZE} from '#/lib/constants'
 import * as Toast from '#/components/Toast'
+import {useAnalytics} from '#/analytics'
 import {app} from '#/lexicons'
 import * as bsky from '#/types/bsky'
 
@@ -28,6 +29,7 @@ interface State {
   name?: string
   description?: string
   profiles: bsky.profile.AnyProfileView[]
+  profileLimit: number
   feeds: app.bsky.feed.defs.GeneratorView[]
   processing: boolean
   error?: string
@@ -71,10 +73,10 @@ function reducer(state: State, action: Action): State {
       updatedState = {...state, description: action.description}
       break
     case 'AddProfile':
-      if (state.profiles.length > STARTER_PACK_MAX_SIZE) {
+      if (state.profiles.length > state.profileLimit) {
         Toast.show(
-          msg`You may only add up to ${plural(STARTER_PACK_MAX_SIZE, {
-            other: `${STARTER_PACK_MAX_SIZE} profiles`,
+          msg`You may only add up to ${plural(state.profileLimit, {
+            other: `${state.profileLimit} profiles`,
           })}`.message ?? '',
           {
             type: 'info',
@@ -126,6 +128,12 @@ export function Provider({
   targetProfile: bsky.profile.AnyProfileView
   children: React.ReactNode
 }) {
+  const ax = useAnalytics()
+  const {limit: profileLimit} = ax.features.getValue(
+    ax.features.StarterPacksConfig,
+    {limit: STARTER_PACK_MAX_SIZE},
+  )
+
   const createInitialState = (): State => {
     const targetDid = targetProfile?.did
 
@@ -140,6 +148,7 @@ export function Provider({
         description: starterPack.record.description,
         profiles:
           listItems?.filter(i => !i.subjectOptedOut).map(i => i.subject) ?? [],
+        profileLimit,
         feeds: starterPack.feeds ?? [],
         processing: false,
         transitionDirection: 'Forward',
@@ -151,6 +160,7 @@ export function Provider({
       canNext: true,
       currentStep: 'Details',
       profiles: [targetProfile],
+      profileLimit,
       feeds: [],
       processing: false,
       transitionDirection: 'Forward',

--- a/src/screens/StarterPack/Wizard/index.tsx
+++ b/src/screens/StarterPack/Wizard/index.tsx
@@ -9,7 +9,6 @@ import {Plural, Trans, useLingui} from '@lingui/react/macro'
 import {useNavigation} from '@react-navigation/native'
 import {type NativeStackScreenProps} from '@react-navigation/native-stack'
 
-import {STARTER_PACK_MAX_SIZE} from '#/lib/constants'
 import {createSanitizedDisplayName} from '#/lib/moderation/create-sanitized-display-name'
 import {
   type CommonNavigatorParams,
@@ -442,7 +441,7 @@ function Footer({
         <View style={[a.absolute, {right: 14, top: 31}]}>
           <Text style={[a.font_semi_bold]}>
             {items.length}/
-            {state.currentStep === 'Profiles' ? STARTER_PACK_MAX_SIZE : 3}
+            {state.currentStep === 'Profiles' ? state.profileLimit : 3}
           </Text>
         </View>
       )}

--- a/src/state/queries/__tests__/list-members.test.ts
+++ b/src/state/queries/__tests__/list-members.test.ts
@@ -1,0 +1,52 @@
+import {type Client} from '@atproto/lex'
+
+import {type app} from '#/lexicons'
+import {getAllListMembers} from '../list-members'
+
+jest.mock('#/state/queries', () => ({
+  STALE: {MINUTES: {ONE: 60_000}},
+}))
+
+jest.mock('#/state/session', () => ({
+  useAppviewClient: jest.fn(),
+}))
+
+describe('getAllListMembers', () => {
+  it('fetches every page', async () => {
+    const call = jest.fn()
+    for (let i = 0; i < 7; i++) {
+      call.mockResolvedValueOnce({
+        items: [{uri: `at://did:plc:test/app.bsky.graph.listitem/${i}`}],
+        cursor: i < 6 ? String(i + 1) : undefined,
+      })
+    }
+    const client = {call} as unknown as Client
+
+    const items = await getAllListMembers(
+      client,
+      'at://did:plc:test/app.bsky.graph.list/test',
+    )
+
+    expect(items).toHaveLength(7)
+    expect(call).toHaveBeenCalledTimes(7)
+    const params = (call.mock.calls as unknown[][]).map(
+      ([, params]) => params as app.bsky.graph.getList.$Params,
+    )
+    expect(params.map(callParams => callParams.limit)).toEqual(
+      Array(7).fill(100),
+    )
+  })
+
+  it('rejects a repeated cursor', async () => {
+    const call = jest
+      .fn()
+      .mockResolvedValueOnce({items: [], cursor: 'repeated'})
+      .mockResolvedValueOnce({items: [], cursor: 'repeated'})
+    const client = {call} as unknown as Client
+
+    await expect(
+      getAllListMembers(client, 'at://did:plc:test/app.bsky.graph.list/test'),
+    ).rejects.toThrow('Repeated cursor while fetching list members')
+    expect(call).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/state/queries/__tests__/list-members.test.ts
+++ b/src/state/queries/__tests__/list-members.test.ts
@@ -49,4 +49,25 @@ describe('getAllListMembers', () => {
     ).rejects.toThrow('Repeated cursor while fetching list members')
     expect(call).toHaveBeenCalledTimes(2)
   })
+
+  it('stops after 500 members', async () => {
+    const call = jest.fn()
+    for (let page = 0; page < 6; page++) {
+      call.mockResolvedValueOnce({
+        items: Array.from({length: 100}, (_, item) => ({
+          uri: `at://did:plc:test/app.bsky.graph.listitem/${page}-${item}`,
+        })),
+        cursor: String(page + 1),
+      })
+    }
+    const client = {call} as unknown as Client
+
+    const items = await getAllListMembers(
+      client,
+      'at://did:plc:test/app.bsky.graph.list/test',
+    )
+
+    expect(items).toHaveLength(500)
+    expect(call).toHaveBeenCalledTimes(5)
+  })
 })

--- a/src/state/queries/list-members.ts
+++ b/src/state/queries/list-members.ts
@@ -58,22 +58,24 @@ export function useAllListMembersQuery(uri?: string) {
 }
 
 export async function getAllListMembers(client: Client, uri: string) {
-  let hasMore = true
   let cursor: string | undefined
   const listItems: app.bsky.graph.defs.ListItemView[] = []
-  // We want to cap this at 6 pages, just for anything weird happening with the api
-  let i = 0
-  while (hasMore && i < 6) {
+  const seenCursors = new Set<string>()
+
+  do {
     const res = await client.call(app.bsky.graph.getList, {
       list: uri as AtUriString,
-      limit: 50,
+      limit: 100,
       cursor,
     })
     listItems.push(...res.items)
-    hasMore = Boolean(res.cursor)
     cursor = res.cursor
-    i++
-  }
+    if (cursor && seenCursors.has(cursor)) {
+      throw new Error('Repeated cursor while fetching list members')
+    }
+    if (cursor) seenCursors.add(cursor)
+  } while (cursor)
+
   return listItems
 }
 

--- a/src/state/queries/list-members.ts
+++ b/src/state/queries/list-members.ts
@@ -8,6 +8,7 @@ import {
   useQuery,
 } from '@tanstack/react-query'
 
+import {STARTER_PACK_MAX_SIZE} from '#/lib/constants'
 import {STALE} from '#/state/queries'
 import {useAppviewClient} from '#/state/session'
 import {app} from '#/lexicons'
@@ -63,18 +64,23 @@ export async function getAllListMembers(client: Client, uri: string) {
   const seenCursors = new Set<string>()
 
   do {
+    const remaining = STARTER_PACK_MAX_SIZE - listItems.length
     const res = await client.call(app.bsky.graph.getList, {
       list: uri as AtUriString,
-      limit: 100,
+      limit: Math.min(100, remaining),
       cursor,
     })
-    listItems.push(...res.items)
+    listItems.push(...res.items.slice(0, remaining))
     cursor = res.cursor
-    if (cursor && seenCursors.has(cursor)) {
+    if (
+      cursor &&
+      listItems.length < STARTER_PACK_MAX_SIZE &&
+      seenCursors.has(cursor)
+    ) {
       throw new Error('Repeated cursor while fetching list members')
     }
     if (cursor) seenCursors.add(cursor)
-  } while (cursor)
+  } while (cursor && listItems.length < STARTER_PACK_MAX_SIZE)
 
   return listItems
 }


### PR DESCRIPTION
## Summary

- add the starter_packs:config GrowthBook value with the existing 150-profile default and a hard ceiling of 500
- use the configured limit for validation, disabled states, and the wizard counter
- batch starter pack list-item writes in groups of 200
- fetch up to 500 list members for editing, follow-all, onboarding, and list conversion, with repeated-cursor protection

## Test plan

- configure a starter pack limit of 500, create a pack at that size, and confirm the full member set is preserved
- confirm a 501st profile cannot be added
- confirm Follow all processes the complete starter pack