### PR TITLE
keep the ios splash above app content

### DIFF
--- a/src/Splash.tsx
+++ b/src/Splash.tsx
@@ -58,7 +58,7 @@ export function Splash(props: React.PropsWithChildren<Props>) {
   const intro = useSharedValue(0)
   const outroLogo = useSharedValue(0)
   const outroApp = useSharedValue(0)
-  const outroAppOpacity = useSharedValue(0)
+  const outroSplashOpacity = useSharedValue(0)
   const [isAnimationComplete, setIsAnimationComplete] = useState(false)
   const [isImageLoaded, setIsImageLoaded] = useState(false)
   const [isLayoutReady, setIsLayoutReady] = useState(false)
@@ -81,7 +81,7 @@ export function Splash(props: React.PropsWithChildren<Props>) {
 
     const introOpacity = interpolate(intro.get(), [0, 1], [0, 1], 'clamp')
     const outroOpacity = interpolate(
-      outroAppOpacity.get(),
+      outroSplashOpacity.get(),
       [0, 0.1, 0.2, 1],
       [1, 1, 0, 0],
       'clamp',
@@ -101,6 +101,21 @@ export function Splash(props: React.PropsWithChildren<Props>) {
     }
   })
 
+  const splashAnimation = useAnimatedStyle(() => {
+    return {
+      opacity: interpolate(
+        outroSplashOpacity.get(),
+        [0, 0.1, 0.2, 1],
+        [1, 1, 0, 0],
+        'clamp',
+      ),
+    }
+  })
+
+  /**
+   * Keep the app opaque so iOS blur/glass effects can initialize while the
+   * splash hides it.
+   */
   const appAnimation = useAnimatedStyle(() => {
     return {
       transform: [
@@ -108,12 +123,6 @@ export function Splash(props: React.PropsWithChildren<Props>) {
           scale: interpolate(outroApp.get(), [0, 1], [1.1, 1], 'clamp'),
         },
       ],
-      opacity: interpolate(
-        outroAppOpacity.get(),
-        [0, 0.1, 0.2, 1],
-        [0.02, 0.02, 1, 1], // first two values cant be 0 for the iOS blur/glass effects to work, the values obtained by trial and error
-        'clamp',
-      ),
     }
   })
 
@@ -147,7 +156,7 @@ export function Splash(props: React.PropsWithChildren<Props>) {
                     easing: Easing.inOut(Easing.cubic),
                   }),
                 )
-                outroAppOpacity.set(
+                outroSplashOpacity.set(
                   withTiming(1, {
                     duration: 1200,
                     easing: Easing.in(Easing.cubic),
@@ -159,7 +168,7 @@ export function Splash(props: React.PropsWithChildren<Props>) {
         })
         .catch(() => {})
     }
-  }, [onFinish, intro, outroLogo, outroApp, outroAppOpacity, isReady])
+  }, [onFinish, intro, outroLogo, outroApp, outroSplashOpacity, isReady])
 
   useEffect(() => {
     AccessibilityInfo.isReduceMotionEnabled().then(setReduceMotion)
@@ -170,8 +179,21 @@ export function Splash(props: React.PropsWithChildren<Props>) {
 
   return (
     <View style={{flex: 1}} onLayout={onLayout}>
+      {isReady && (
+        <Animated.View style={[{flex: 1}, appAnimation]}>
+          {props.children}
+        </Animated.View>
+      )}
+
       {!isAnimationComplete && (
-        <View style={[a.absolute, a.inset_0]}>
+        <Animated.View
+          style={[
+            a.absolute,
+            a.inset_0,
+            // The splash PNGs contain partially transparent pixels.
+            {backgroundColor: isDarkMode ? '#002861' : '#006AFF'},
+            splashAnimation,
+          ]}>
           <Image
             accessibilityIgnoresInvertColors
             onLoadEnd={onLoadEnd}
@@ -194,31 +216,23 @@ export function Splash(props: React.PropsWithChildren<Props>) {
             ]}>
             <Logotype fill="#fff" width={90} />
           </Animated.View>
-        </View>
+        </Animated.View>
       )}
 
-      {isReady && (
-        <>
-          <Animated.View style={[{flex: 1}, appAnimation]}>
-            {props.children}
-          </Animated.View>
-
-          {!isAnimationComplete && (
-            <Animated.View
-              style={[
-                a.absolute,
-                a.inset_0,
-                logoAnimation,
-                {
-                  flex: 1,
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                },
-              ]}>
-              <Logo fill={logoBg} />
-            </Animated.View>
-          )}
-        </>
+      {isReady && !isAnimationComplete && (
+        <Animated.View
+          style={[
+            a.absolute,
+            a.inset_0,
+            logoAnimation,
+            {
+              flex: 1,
+              justifyContent: 'center',
+              alignItems: 'center',
+            },
+          ]}>
+          <Logo fill={logoBg} />
+        </Animated.View>
       )}
     </View>
   )


### PR DESCRIPTION
On iOS, content that loads quickly can show through the splash because the app is drawn above its background at 2% opacity. Keep the app fully opaque underneath the splash and fade the splash background out at the existing reveal timing, preserving the butterfly and app scale animations. A solid backing color covers the splash PNGs' slightly transparent pixels.

Keeping the app opaque preserves the intent of the iOS blur/glass initialization workaround without exposing content before the reveal.

Manual checks (pending):

- [ ] Cold-launch iOS with a cached feed in light and dark mode. Confirm content stays hidden until the reveal and the butterfly transition looks right.
- [ ] Confirm blur/glass surfaces render correctly after launch.
- [ ] Repeat with Reduce Motion enabled and confirm the splash completes normally.
