### PR TITLE
Respect device 24-hour clock preference

### DIFF
--- a/__mocks__/expo-localization.js
+++ b/__mocks__/expo-localization.js
@@ -1,1 +1,2 @@
+export const getCalendars = jest.fn().mockReturnValue([{uses24hourClock: null}])
 export const getLocales = jest.fn().mockResolvedValue([])

--- a/jest/jestSetup.js
+++ b/jest/jestSetup.js
@@ -144,5 +144,6 @@ jest.mock('expo-modules-core', () => ({
 }))
 
 jest.mock('expo-localization', () => ({
+  getCalendars: jest.fn(() => [{uses24hourClock: null}]),
   getLocales: () => [],
 }))

--- a/src/ageAssurance/components/NoAccessScreen.tsx
+++ b/src/ageAssurance/components/NoAccessScreen.tsx
@@ -4,6 +4,7 @@ import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {Trans, useLingui} from '@lingui/react/macro'
 
 import {dateDiff, useGetTimeAgo} from '#/lib/hooks/useTimeAgo'
+import {formatDateTime} from '#/lib/strings/time'
 import {useIsBirthdateUpdateAllowed} from '#/state/birthdate'
 import {useSessionApi} from '#/state/session'
 import {DeactivateAccountDialog} from '#/screens/Settings/components/DeactivateAccountDialog'
@@ -435,7 +436,7 @@ function AccessSection() {
               ) : lastInitiatedAt && timeAgo && diff ? (
                 <Text
                   style={[a.text_sm, a.italic, t.atoms.text_contrast_medium]}
-                  title={i18n.date(lastInitiatedAt, {
+                  title={formatDateTime(i18n, lastInitiatedAt, {
                     dateStyle: 'medium',
                     timeStyle: 'medium',
                   })}>

--- a/src/components/ageAssurance/AgeAssuranceAccountCard.tsx
+++ b/src/components/ageAssurance/AgeAssuranceAccountCard.tsx
@@ -2,6 +2,7 @@ import {View} from 'react-native'
 import {Trans, useLingui} from '@lingui/react/macro'
 
 import {dateDiff, useGetTimeAgo} from '#/lib/hooks/useTimeAgo'
+import {formatDateTime} from '#/lib/strings/time'
 import {atoms as a, useBreakpoints, useTheme, type ViewStyleProp} from '#/alf'
 import {Admonition} from '#/components/Admonition'
 import {AgeAssuranceAppealDialog} from '#/components/ageAssurance/AgeAssuranceAppealDialog'
@@ -169,7 +170,7 @@ function Inner({style}: ViewStyleProp & {}) {
                 ) : lastInitiatedAt && timeAgo && diff ? (
                   <Text
                     style={[a.text_sm, a.italic, t.atoms.text_contrast_medium]}
-                    title={i18n.date(lastInitiatedAt, {
+                    title={formatDateTime(i18n, lastInitiatedAt, {
                       dateStyle: 'medium',
                       timeStyle: 'medium',
                     })}>

--- a/src/components/dms/DateDivider.tsx
+++ b/src/components/dms/DateDivider.tsx
@@ -3,6 +3,7 @@ import {View} from 'react-native'
 import {Trans, useLingui} from '@lingui/react/macro'
 import {subDays} from 'date-fns'
 
+import {formatDateTime} from '#/lib/strings/time'
 import {atoms as a, useTheme} from '#/alf'
 import {Text} from '#/components/Typography'
 import {localDateString} from './util'
@@ -12,7 +13,7 @@ let DateDivider = ({date: dateStr}: {date: string}): React.ReactNode => {
   const {t: l, i18n} = useLingui()
 
   let date: string
-  const time = i18n.date(new Date(dateStr), {
+  const time = formatDateTime(i18n, new Date(dateStr), {
     hour: 'numeric',
     minute: 'numeric',
   })

--- a/src/components/dms/MessageContextMenu.tsx
+++ b/src/components/dms/MessageContextMenu.tsx
@@ -10,6 +10,7 @@ import {useLingui} from '@lingui/react/macro'
 import {EMOJI_REACTION_LIMIT} from '#/lib/constants'
 import {useGoogleTranslate} from '#/lib/hooks/useGoogleTranslate'
 import {richTextToString} from '#/lib/strings/rich-text-helpers'
+import {formatDateTime} from '#/lib/strings/time'
 import {useMaybeProfileShadow} from '#/state/cache/profile-shadow'
 import {useConvoActive} from '#/state/messages/convo'
 import {useLanguagePrefs} from '#/state/preferences'
@@ -170,7 +171,7 @@ export let MessageContextMenu = ({
 
       <ContextMenu.Outer
         align={isFromSelf ? 'right' : 'left'}
-        label={l`Sent at ${i18n.date(new Date(message.sentAt), {
+        label={l`Sent at ${formatDateTime(i18n, new Date(message.sentAt), {
           timeStyle: 'short',
         })}`}
         style={[isFromSelf && isGroupChatEnabled ? null : a.ml_sm]}

--- a/src/features/liveNow/components/EditLiveDialog.tsx
+++ b/src/features/liveNow/components/EditLiveDialog.tsx
@@ -7,6 +7,7 @@ import {differenceInMinutes} from 'date-fns'
 
 import {useDebouncedValue} from '#/lib/hooks/useDebouncedValue'
 import {cleanError} from '#/lib/strings/errors'
+import {formatDateTime} from '#/lib/strings/time'
 import {definitelyUrl} from '#/lib/strings/url-helpers'
 import {useTickEveryMinute} from '#/state/shell'
 import {atoms as a, platform, useTheme, web} from '#/alf'
@@ -126,10 +127,9 @@ function DialogInner({
               {typeof record?.durationMinutes === 'number' ? (
                 <Trans>
                   Expires in {displayDuration(i18n, minutesUntilExpiry)} at{' '}
-                  {i18n.date(expiryDateTime, {
+                  {formatDateTime(i18n, expiryDateTime, {
                     hour: 'numeric',
                     minute: '2-digit',
-                    hour12: true,
                   })}
                 </Trans>
               ) : (

--- a/src/features/liveNow/components/GoLiveDialog.tsx
+++ b/src/features/liveNow/components/GoLiveDialog.tsx
@@ -6,6 +6,7 @@ import {Trans} from '@lingui/react/macro'
 
 import {useDebouncedValue} from '#/lib/hooks/useDebouncedValue'
 import {cleanError} from '#/lib/strings/errors'
+import {formatDateTime} from '#/lib/strings/time'
 import {definitelyUrl} from '#/lib/strings/url-helpers'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useTickEveryMinute} from '#/state/shell'
@@ -72,7 +73,10 @@ function DialogInner({profile}: {profile: bsky.profile.AnyProfileView}) {
 
       const date = new Date()
       date.setMinutes(date.getMinutes() + offset)
-      return i18n.date(date, {hour: 'numeric', minute: '2-digit', hour12: true})
+      return formatDateTime(i18n, date, {
+        hour: 'numeric',
+        minute: '2-digit',
+      })
     },
     [tick, i18n],
   )

--- a/src/lib/strings/__tests__/time.test.ts
+++ b/src/lib/strings/__tests__/time.test.ts
@@ -1,0 +1,43 @@
+import {getCalendars} from 'expo-localization'
+import {setupI18n} from '@lingui/core'
+
+import {formatDateTime} from '../time'
+
+const i18n = setupI18n()
+i18n.loadAndActivate({locale: 'en-US', messages: {}})
+const date = new Date('2026-05-29T14:54:00Z')
+const options: Intl.DateTimeFormatOptions = {
+  hour: 'numeric',
+  minute: '2-digit',
+  timeZone: 'UTC',
+}
+
+describe('formatDateTime', () => {
+  const getCalendarsMock = jest.mocked(getCalendars)
+
+  it('uses 24-hour time when the device does', () => {
+    getCalendarsMock.mockReturnValue([
+      {uses24hourClock: true} as ReturnType<typeof getCalendars>[number],
+    ])
+
+    expect(formatDateTime(i18n, date, options)).toBe('14:54')
+  })
+
+  it('uses 12-hour time when the device does', () => {
+    getCalendarsMock.mockReturnValue([
+      {uses24hourClock: false} as ReturnType<typeof getCalendars>[number],
+    ])
+
+    const formatted = formatDateTime(i18n, date, options)
+    expect(formatted).toContain('2:54')
+    expect(formatted).toContain('PM')
+  })
+
+  it('falls back to the locale when the device preference is unavailable', () => {
+    getCalendarsMock.mockReturnValue([
+      {uses24hourClock: null} as ReturnType<typeof getCalendars>[number],
+    ])
+
+    expect(formatDateTime(i18n, date, options)).toContain('PM')
+  })
+})

--- a/src/lib/strings/time.ts
+++ b/src/lib/strings/time.ts
@@ -1,5 +1,19 @@
+import {getCalendars} from 'expo-localization'
 import {type I18n} from '@lingui/core'
 import {msg} from '@lingui/core/macro'
+
+export function formatDateTime(
+  i18n: I18n,
+  date: number | string | Date,
+  options: Intl.DateTimeFormatOptions,
+) {
+  const uses24hourClock = getCalendars()[0].uses24hourClock
+
+  return i18n.date(date, {
+    ...options,
+    ...(uses24hourClock === null ? {} : {hour12: !uses24hourClock}),
+  })
+}
 
 export function niceDate(
   i18n: I18n,
@@ -14,15 +28,14 @@ export function niceDate(
     return i18n._(
       msg({
         context: 'date and time formatted like this: [time] · [date]',
-        message: `${i18n.date(d, {timeStyle: ts})} · ${i18n.date(d, {dateStyle: 'medium'})}`,
+        message: `${formatDateTime(i18n, d, {timeStyle: ts})} · ${i18n.date(d, {dateStyle: 'medium'})}`,
       }),
     )
   }
 
-  return i18n.date(d, {
-    dateStyle,
-    timeStyle: ts,
-  })
+  return ts
+    ? formatDateTime(i18n, d, {dateStyle, timeStyle: ts})
+    : i18n.date(d, {dateStyle})
 }
 
 export function getAge(birthDate: Date): number {

--- a/src/screens/Messages/components/InviteLinkDialog.tsx
+++ b/src/screens/Messages/components/InviteLinkDialog.tsx
@@ -7,6 +7,7 @@ import {Plural, Trans, useLingui} from '@lingui/react/macro'
 import {useOpenComposer} from '#/lib/hooks/useOpenComposer'
 import {createSanitizedDisplayName} from '#/lib/moderation/create-sanitized-display-name'
 import {shareUrl} from '#/lib/sharing'
+import {formatDateTime} from '#/lib/strings/time'
 import {useCreateJoinLink} from '#/state/queries/messages/create-join-link'
 import {useDisableJoinLink} from '#/state/queries/messages/disable-join-link'
 import {useEditJoinLink} from '#/state/queries/messages/edit-join-link'
@@ -351,7 +352,7 @@ export function InviteLinkDialog({
               <Text style={[a.mt_xs, a.text_xs, t.atoms.text_contrast_medium]}>
                 <Trans>
                   Created{' '}
-                  {i18n.date(createdAt, {
+                  {formatDateTime(i18n, createdAt, {
                     dateStyle: 'long',
                     timeStyle: 'short',
                   })}

--- a/src/screens/ModerationInbox/components/Timeline.tsx
+++ b/src/screens/ModerationInbox/components/Timeline.tsx
@@ -1,6 +1,7 @@
 import {View} from 'react-native'
 import {useLingui} from '@lingui/react/macro'
 
+import {formatDateTime} from '#/lib/strings/time'
 import {ContentBlock} from './ContentBlock'
 import {TimelineItem} from './TimelineItem'
 
@@ -16,7 +17,7 @@ export function Timeline({items}: {items: {title: string; date?: Date}[]}) {
             title={title}
             date={
               date
-                ? i18n.date(date, {
+                ? formatDateTime(i18n, date, {
                     month: 'short',
                     day: 'numeric',
                     year: 'numeric',

--- a/src/screens/Settings/AppPasswords.tsx
+++ b/src/screens/Settings/AppPasswords.tsx
@@ -13,6 +13,7 @@ import {type NativeStackScreenProps} from '@react-navigation/native-stack'
 
 import {type CommonNavigatorParams} from '#/lib/routes/types'
 import {cleanError} from '#/lib/strings/errors'
+import {formatDateTime} from '#/lib/strings/time'
 import {
   useAppPasswordDeleteMutation,
   useAppPasswordsQuery,
@@ -173,7 +174,7 @@ function AppPasswordCard({
           <Text style={[t.atoms.text_contrast_medium]}>
             <Trans>
               Created{' '}
-              {i18n.date(appPassword.createdAt, {
+              {formatDateTime(i18n, appPassword.createdAt, {
                 year: 'numeric',
                 month: 'numeric',
                 day: 'numeric',


### PR DESCRIPTION
[APP-3066](https://linear.app/blueskyweb/issue/APP-3066/respect-device-24-hour-clock-preference-in-app) fixes clock-bearing timestamps that followed the app language’s default hour cycle instead of the device setting. Date formatting now keeps the app language for wording and date order while applying Expo Localization’s device 12/24-hour preference across posts, DMs, live-status times, and other timestamp surfaces.

## Test plan

- On iOS with the app language set to English (US), enable 24-Hour Time and confirm a post timestamp and DM date divider render a time such as `14:54` without AM/PM.
- Disable 24-Hour Time and confirm the same surfaces render a time such as `2:54 PM`.
